### PR TITLE
chore: add CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,100 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+language: en
+
+reviews:
+  profile: "assertive"
+
+  path_filters:
+    - "!samples/**"
+    - "!output/**"
+    - "!uv.lock"
+    - "!**/__pycache__/**"
+    - "!**/*.pyc"
+    - "!**/*.egg-info/**"
+
+  suggested_labels: false
+  auto_apply_labels: false
+
+  auto_review:
+    enabled: true
+    drafts: false
+    labels: []
+
+  tools:
+    ruff:
+      enabled: true
+    mypy:
+      enabled: true
+
+  path_instructions:
+    - path: "src/**/*.py"
+      instructions: |
+        Python 3.11+ with strict mypy. Enforce:
+        - Full type hints on all public functions
+        - Pydantic v2 models (model_config style, not Config inner class)
+        - Async-first for all I/O (httpx.AsyncClient, not requests)
+        - No print() calls — use rich console/logger
+        - pathlib.Path over os.path
+
+    - path: "src/confluence_to_notion/agents/schemas.py"
+      instructions: |
+        Pydantic schemas define the file-based contract between Claude Code subagents.
+        Changes here affect both pattern-discovery and rule-proposer agents.
+        - Verify backward compatibility or confirm both agent prompts are updated
+        - Fields with min_length/gt constraints are intentional — do not relax without justification
+        - Check that JSON roundtrip (model_dump_json → model_validate_json) still works
+
+    - path: "src/confluence_to_notion/confluence/**"
+      instructions: |
+        Confluence REST API client using httpx.AsyncClient.
+        - All I/O must be async
+        - Unit tests must mock HTTP with respx — no real API calls
+        - Auth is optional (public wikis like cwiki.apache.org work without credentials)
+
+    - path: "src/confluence_to_notion/notion/**"
+      instructions: |
+        Notion API client wrapping the official notion-client SDK.
+        - All I/O must be async
+        - Unit tests must mock external calls — no real API calls
+        - Notion token format: must start with 'ntn_' or 'secret_'
+
+    - path: ".claude/agents/**"
+      instructions: |
+        Claude Code subagent prompt definitions. Each agent runs as an independent `claude -p` session.
+        - Agents communicate via files only (no shared context)
+        - Output must conform to Pydantic schemas in src/confluence_to_notion/agents/schemas.py
+        - Prompt changes require running scripts/run-eval.sh before merging
+        - Check that input/output file paths match what scripts/discover.sh expects
+
+    - path: "scripts/**"
+      instructions: |
+        Bash orchestration scripts. Pipeline flow must be deterministic and visible in code.
+        - `claude -p` calls should be sequential, one step per agent
+        - Failed steps must be individually re-runnable (--from flag)
+        - Never embed LLM judgment in flow control
+
+    - path: "tests/**/*.py"
+      instructions: |
+        pytest + pytest-asyncio tests. Enforce:
+        - All external I/O (Confluence, Notion, Anthropic) mocked in unit tests
+        - Use respx for httpx mocking
+        - Integration tests in tests/integration/, skipped by default (-m integration)
+        - Fixtures shared across tests go in tests/conftest.py
+
+    - path: "docs/adr/**"
+      instructions: |
+        Architecture Decision Records. If a code change contradicts an existing ADR,
+        flag it and require either updating the ADR or revising the code.
+
+    - path: "**/*.py"
+      instructions: |
+        If a code change contradicts documentation in CLAUDE.md or .claude/rules/*.md,
+        flag it and suggest updating the relevant docs to stay in sync.
+
+  pre_merge_checks:
+    docstrings:
+      mode: "off"
+
+chat:
+  auto_reply: true


### PR DESCRIPTION
## Summary
- Add `.coderabbit.yaml` with project-specific review rules
- Assertive profile, English reviews, docstring check off
- Path-specific instructions for schemas, agents, scripts, tests, ADRs
- Excludes `samples/`, `output/`, `uv.lock`, `__pycache__/` from review

## Test plan
- [ ] CodeRabbit activates on next PR and follows configured rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)