### PR TITLE
feat: Day 3 — deterministic converter and finalize/convert CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,9 +51,13 @@ uv run cli fetch --pages <ID1>,<ID2>,...     # Fetch specific pages by ID
 uv run cli notion-ping                        # Validate Notion token
 uv run cli validate-output <file> <schema>   # Validate agent output (discovery|proposer)
 
-# Agent pipeline (bash script orchestration)
-bash scripts/discover.sh samples/             # Run full pipeline
-bash scripts/discover.sh samples/ --from 2    # Resume from step 2
+# Conversion (Python CLI)
+uv run cli finalize output/proposals.json     # proposals.json → rules.json
+uv run cli convert --rules output/rules.json --input samples/  # XHTML → Notion blocks
+
+# Agent pipeline (bash script orchestration) — steps 1-2 agents, 3-4 deterministic
+bash scripts/discover.sh samples/             # Run full pipeline (4 steps)
+bash scripts/discover.sh samples/ --from 3    # Resume from step 3 (finalize + convert)
 
 # Development
 uv run pytest                                 # Run tests

--- a/scripts/discover.sh
+++ b/scripts/discover.sh
@@ -55,26 +55,22 @@ run_step 2 "rule-proposer" \
 
 Read ${OUTPUT_DIR}/patterns.json and propose transformation rules. Write to ${OUTPUT_DIR}/proposals.json"
 
-# Step 3: Rule Critic (deferred — agent not yet implemented)
-if [[ -f ".claude/agents/rule-critic.md" ]]; then
-    run_step 3 "rule-critic" \
-        ".claude/agents/rule-critic.md" \
-        "$(cat .claude/agents/rule-critic.md)
-
-Read ${OUTPUT_DIR}/proposals.json, validate against XHTML samples in ${SAMPLES_DIR}. Write to ${OUTPUT_DIR}/critiques.json"
-else
-    echo "==> Step 3: rule-critic (skipped, agent not implemented)"
+# Step 3: Finalize rules (2-agent shortcut: proposals → rules.json)
+# When critic/arbitrator agents are added, this step will be replaced by steps 3+4.
+if [[ "$FROM_STEP" -le 3 ]]; then
+    echo "==> Step 3: finalize (proposals → rules.json)"
+    uv run cli finalize "${OUTPUT_DIR}/proposals.json" --out "${OUTPUT_DIR}/rules.json"
+    echo "    Done: ${OUTPUT_DIR}/rules.json"
 fi
 
-# Step 4: Rule Arbitrator (deferred — agent not yet implemented)
-if [[ -f ".claude/agents/rule-arbitrator.md" ]]; then
-    run_step 4 "rule-arbitrator" \
-        ".claude/agents/rule-arbitrator.md" \
-        "$(cat .claude/agents/rule-arbitrator.md)
-
-Read ${OUTPUT_DIR}/critiques.json, resolve conflicts. Write final rules to ${OUTPUT_DIR}/rules.json"
-else
-    echo "==> Step 4: rule-arbitrator (skipped, agent not implemented)"
+# Step 4: Convert XHTML → Notion blocks
+if [[ "$FROM_STEP" -le 4 ]]; then
+    echo "==> Step 4: convert (XHTML → Notion blocks)"
+    uv run cli convert \
+        --rules "${OUTPUT_DIR}/rules.json" \
+        --input "${SAMPLES_DIR}" \
+        --output "${OUTPUT_DIR}/converted"
+    echo "    Done: ${OUTPUT_DIR}/converted/"
 fi
 
 echo ""

--- a/src/confluence_to_notion/agents/schemas.py
+++ b/src/confluence_to_notion/agents/schemas.py
@@ -65,3 +65,45 @@ class ProposerOutput(BaseModel):
         default_factory=list,
         description="Proposed mapping rules",
     )
+
+
+# --- Final Ruleset (converter input contract) ---
+
+
+class FinalRule(BaseModel):
+    """A confirmed transformation rule ready for the deterministic converter."""
+
+    rule_id: str
+    source_pattern_id: str
+    source_description: str
+    notion_block_type: str
+    mapping_description: str
+    example_input: str
+    example_output: dict[str, Any]
+    confidence: Literal["high", "medium", "low"]
+    enabled: bool = Field(default=True, description="Whether this rule is active")
+
+    @classmethod
+    def from_proposed(cls, proposed: ProposedRule, *, enabled: bool = True) -> "FinalRule":
+        """Promote a ProposedRule to a FinalRule."""
+        return cls(**proposed.model_dump(), enabled=enabled)
+
+
+class FinalRuleset(BaseModel):
+    """The complete set of rules fed into the deterministic converter → output/rules.json."""
+
+    source: str = Field(description="Path to the proposals file this was derived from")
+    rules: list[FinalRule] = Field(default_factory=list)
+
+    @property
+    def enabled_rules(self) -> list[FinalRule]:
+        """Return only active rules."""
+        return [r for r in self.rules if r.enabled]
+
+    @classmethod
+    def from_proposer_output(cls, output: ProposerOutput) -> "FinalRuleset":
+        """Convert ProposerOutput directly to a FinalRuleset (2-agent shortcut)."""
+        return cls(
+            source=output.source_patterns_file,
+            rules=[FinalRule.from_proposed(r) for r in output.rules],
+        )

--- a/src/confluence_to_notion/cli.py
+++ b/src/confluence_to_notion/cli.py
@@ -1,6 +1,7 @@
 """CLI entry points for confluence-to-notion."""
 
 import asyncio
+import json
 from pathlib import Path
 
 import httpx
@@ -162,8 +163,93 @@ def validate_output(
 
 
 @app.command()
+def finalize(
+    proposals_file: Path = typer.Argument(
+        Path("output/proposals.json"), help="Path to proposals.json"
+    ),
+    out: Path = typer.Option(Path("output/rules.json"), help="Output rules.json path"),
+) -> None:
+    """Convert proposals.json → rules.json (2-agent shortcut).
+
+    Promotes all proposed rules to final rules with enabled=True.
+    When critic/arbitrator agents are added, this step will be replaced.
+    """
+    from confluence_to_notion.agents.schemas import FinalRuleset, ProposerOutput
+
+    if not proposals_file.exists():
+        console.print(f"[red]File not found: {proposals_file}[/red]")
+        raise typer.Exit(code=1)
+
+    raw = proposals_file.read_text()
+    try:
+        proposer = ProposerOutput.model_validate_json(raw)
+    except ValidationError as e:
+        console.print(f"[red]Invalid proposals file: {e.error_count()} errors[/red]")
+        raise typer.Exit(code=1) from None
+
+    ruleset = FinalRuleset.from_proposer_output(proposer)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(ruleset.model_dump_json(indent=2) + "\n")
+    console.print(
+        f"[green]Finalized {len(ruleset.rules)} rules → {out}[/green]"
+    )
+
+
+@app.command()
+def convert(
+    rules_file: Path = typer.Option(
+        Path("output/rules.json"), "--rules", help="Path to rules.json"
+    ),
+    input_dir: Path = typer.Option(
+        Path("samples"), "--input", help="Directory of XHTML files"
+    ),
+    output_dir: Path = typer.Option(
+        Path("output/converted"), "--output", help="Output directory for converted JSON"
+    ),
+) -> None:
+    """Convert XHTML pages to Notion blocks using finalized rules.
+
+    Examples:
+        cli convert --rules output/rules.json --input samples/ --output output/converted/
+    """
+    from confluence_to_notion.agents.schemas import FinalRuleset
+    from confluence_to_notion.converter.converter import convert_page
+
+    if not rules_file.exists():
+        console.print(f"[red]Rules file not found: {rules_file}[/red]")
+        raise typer.Exit(code=1)
+    if not input_dir.exists():
+        console.print(f"[red]Input directory not found: {input_dir}[/red]")
+        raise typer.Exit(code=1)
+
+    try:
+        ruleset = FinalRuleset.model_validate_json(rules_file.read_text())
+    except ValidationError as e:
+        console.print(f"[red]Invalid rules file: {e.error_count()} errors[/red]")
+        raise typer.Exit(code=1) from None
+
+    xhtml_files = sorted(input_dir.glob("*.xhtml"))
+    if not xhtml_files:
+        console.print(f"[yellow]No .xhtml files found in {input_dir}[/yellow]")
+        raise typer.Exit(code=1)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    converted = 0
+
+    for xhtml_path in xhtml_files:
+        xhtml = xhtml_path.read_text()
+        blocks = convert_page(xhtml, ruleset)
+        out_file = output_dir / f"{xhtml_path.stem}.json"
+        out_file.write_text(json.dumps(blocks, indent=2, ensure_ascii=False) + "\n")
+        converted += 1
+        console.print(f"  {xhtml_path.name} → {out_file.name} ({len(blocks)} blocks)")
+
+    console.print(f"[green]Converted {converted} pages → {output_dir}[/green]")
+
+
+@app.command()
 def migrate() -> None:
-    """Run migration pipeline. (Day 3)"""
+    """Upload converted pages to Notion. (Day 4)"""
     console.print("[yellow]Not implemented yet[/yellow]")
     raise typer.Exit(code=1)
 

--- a/src/confluence_to_notion/converter/converter.py
+++ b/src/confluence_to_notion/converter/converter.py
@@ -1,0 +1,569 @@
+"""Deterministic XHTML → Notion block converter.
+
+Applies FinalRuleset rules to Confluence XHTML, producing Notion API block dicts.
+No LLM calls — pure Python transformation logic.
+"""
+
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ET
+from typing import Any
+
+from confluence_to_notion.agents.schemas import FinalRuleset
+
+# Confluence XHTML namespace prefixes
+_NS = {
+    "ac": "http://www.atlassian.com/schema/confluence/4/ac/",
+    "ri": "http://www.atlassian.com/schema/confluence/4/ri/",
+}
+
+_XHTML_WRAPPER = (
+    '<root xmlns:ac="http://www.atlassian.com/schema/confluence/4/ac/"'
+    ' xmlns:ri="http://www.atlassian.com/schema/confluence/4/ri/"'
+    ">{}</root>"
+)
+
+# Panel macro → (emoji, color)
+_PANEL_STYLES: dict[str, tuple[str, str]] = {
+    "info": ("\u2139\ufe0f", "blue_background"),
+    "note": ("\U0001f4dd", "gray_background"),
+    "warning": ("\u26a0\ufe0f", "yellow_background"),
+    "tip": ("\U0001f4a1", "green_background"),
+}
+
+_HEADING_MAP: dict[str, str] = {
+    "h1": "heading_1",
+    "h2": "heading_2",
+    "h3": "heading_3",
+    "h4": "heading_3",
+    "h5": "heading_3",
+    "h6": "heading_3",
+}
+
+
+def convert_page(xhtml: str, ruleset: FinalRuleset) -> list[dict[str, Any]]:
+    """Convert a Confluence XHTML page to a list of Notion blocks."""
+    xhtml = xhtml.strip()
+    if not xhtml:
+        return []
+
+    enabled_ids = {r.rule_id for r in ruleset.enabled_rules}
+    xml_str = _XHTML_WRAPPER.format(xhtml)
+    root = ET.fromstring(xml_str)
+
+    return _convert_children(root, enabled_ids, block_type=None)
+
+
+def _convert_children(
+    parent: ET.Element,
+    enabled_ids: set[str],
+    block_type: str | None,
+) -> list[dict[str, Any]]:
+    """Convert child elements of a parent node to Notion blocks."""
+    blocks: list[dict[str, Any]] = []
+
+    # Handle bare text before first child
+    if parent.text and parent.text.strip():
+        blocks.append(_paragraph([_text_seg(parent.text.strip())]))
+
+    for child in parent:
+        child_blocks = _convert_element(child, enabled_ids)
+        blocks.extend(child_blocks)
+
+        # Handle tail text after elements
+        if child.tail and child.tail.strip():
+            blocks.append(_paragraph([_text_seg(child.tail.strip())]))
+
+    return blocks
+
+
+def _convert_element(
+    elem: ET.Element,
+    enabled_ids: set[str],
+) -> list[dict[str, Any]]:
+    """Convert a single element to Notion block(s)."""
+    tag = _local_tag(elem)
+
+    # --- Headings ---
+    if tag in _HEADING_MAP:
+        rt = _extract_rich_text(elem, enabled_ids)
+        if not rt:
+            return []
+        heading_type = _HEADING_MAP[tag]
+        return [{heading_type: {"rich_text": rt}, "type": heading_type}]
+
+    # --- Paragraphs ---
+    if tag == "p":
+        # Promote block-level macros wrapped in <p> (common in Confluence XHTML)
+        promoted = _try_promote_block_macro(elem, enabled_ids)
+        if promoted is not None:
+            return promoted
+        rt = _extract_rich_text(elem, enabled_ids)
+        if not rt:
+            return []
+        return [_paragraph(rt)]
+
+    # --- Lists ---
+    if tag in ("ul", "ol"):
+        return _convert_list(elem, tag, enabled_ids)
+
+    # --- Preformatted ---
+    if tag == "pre":
+        return _convert_pre(elem)
+
+    # --- Confluence structured macro ---
+    if tag == "structured-macro":
+        return _convert_macro(elem, enabled_ids)
+
+    # --- Confluence image ---
+    if tag == "image":
+        return _convert_ac_image(elem, enabled_ids)
+
+    # --- Styled span (heading substitute) ---
+    if tag == "span":
+        return _convert_span(elem)
+
+    # --- Fallback: recurse into children ---
+    return _convert_children(elem, enabled_ids, block_type=None)
+
+
+# --- Rich text extraction ---
+
+
+def _extract_rich_text(
+    elem: ET.Element,
+    enabled_ids: set[str],
+) -> list[dict[str, Any]]:
+    """Extract Notion rich_text segments from an inline element."""
+    segments: list[dict[str, Any]] = []
+
+    if elem.text:
+        segments.append(_text_seg(elem.text))
+
+    for child in elem:
+        tag = _local_tag(child)
+
+        if tag == "code":
+            text = _get_all_text(child)
+            if text:
+                segments.append(_text_seg(text, code=True))
+
+        elif tag in ("strong", "b"):
+            text = _get_all_text(child)
+            if text:
+                segments.append(_text_seg(text, bold=True))
+
+        elif tag in ("em", "i"):
+            text = _get_all_text(child)
+            if text:
+                segments.append(_text_seg(text, italic=True))
+
+        elif tag == "a":
+            text = _get_all_text(child) or child.get("href", "")
+            href = child.get("href", "")
+            segments.append(_text_seg(text, link=href))
+
+        elif tag == "link":
+            # ac:link — Confluence internal page link
+            segments.extend(_extract_ac_link_rich_text(child))
+
+        elif tag == "br":
+            pass  # skip line breaks in inline context
+
+        elif tag == "span":
+            # Plain span: just extract text
+            text = _get_all_text(child)
+            if text:
+                segments.append(_text_seg(text))
+
+        elif tag == "structured-macro":
+            # Inline macro (e.g., JIRA reference within a paragraph)
+            inline_segs = _extract_inline_macro(child, enabled_ids)
+            segments.extend(inline_segs)
+
+        elif tag == "image":
+            pass  # Images handled at block level
+
+        else:
+            # Unknown inline element: extract text
+            text = _get_all_text(child)
+            if text:
+                segments.append(_text_seg(text))
+
+        if child.tail:
+            segments.append(_text_seg(child.tail))
+
+    return segments
+
+
+def _extract_ac_link_rich_text(elem: ET.Element) -> list[dict[str, Any]]:
+    """Extract rich_text from an ac:link element."""
+    page_title = ""
+    display_text = ""
+
+    for child in elem:
+        child_tag = _local_tag(child)
+        if child_tag == "page":
+            page_title = child.get(f"{{{_NS['ri']}}}content-title", "") or child.get(
+                "ri:content-title", ""
+            )
+        elif child_tag == "plain-text-link-body":
+            display_text = _get_all_text(child)
+
+    text = display_text or page_title or "link"
+    url = f"https://notion.so/placeholder/{page_title}" if page_title else "#"
+    return [_text_seg(text, link=url)]
+
+
+def _extract_inline_macro(
+    elem: ET.Element,
+    enabled_ids: set[str],
+) -> list[dict[str, Any]]:
+    """Extract rich_text segments from an inline macro (e.g., JIRA)."""
+    macro_name = _get_macro_name(elem)
+
+    if macro_name == "jira" and "rule:macro:jira" in enabled_ids:
+        return _jira_rich_text(elem)
+
+    # Unknown inline macro: extract any text
+    text = _get_all_text(elem)
+    return [_text_seg(text)] if text else []
+
+
+# --- Block converters ---
+
+
+_BLOCK_MACROS = {"toc", "info", "note", "warning", "tip", "code", "noformat", "expand"}
+
+
+def _try_promote_block_macro(
+    p_elem: ET.Element,
+    enabled_ids: set[str],
+) -> list[dict[str, Any]] | None:
+    """If a <p> contains only a single block-level macro, promote it."""
+    has_text = bool(p_elem.text and p_elem.text.strip())
+    children = list(p_elem)
+
+    if has_text or len(children) != 1:
+        return None
+
+    child = children[0]
+    if _local_tag(child) != "structured-macro":
+        return None
+
+    has_tail = bool(child.tail and child.tail.strip())
+    if has_tail:
+        return None
+
+    macro_name = _get_macro_name(child)
+    if macro_name in _BLOCK_MACROS:
+        return _convert_macro(child, enabled_ids)
+
+    return None
+
+
+def _convert_macro(
+    elem: ET.Element,
+    enabled_ids: set[str],
+) -> list[dict[str, Any]]:
+    """Convert an ac:structured-macro to Notion block(s)."""
+    macro_name = _get_macro_name(elem)
+
+    # TOC
+    if macro_name == "toc" and "rule:macro:toc" in enabled_ids:
+        return [{"type": "table_of_contents", "table_of_contents": {"color": "default"}}]
+
+    # JIRA
+    if macro_name == "jira" and "rule:macro:jira" in enabled_ids:
+        return [_paragraph(_jira_rich_text(elem))]
+
+    # Info/Note/Warning/Tip panels
+    if macro_name in _PANEL_STYLES and f"rule:macro:{macro_name}" in enabled_ids:
+        return _convert_panel_macro(elem, macro_name, enabled_ids)
+    # Also handle panels without explicit rules (built-in behavior for info-family macros)
+    if macro_name in _PANEL_STYLES:
+        return _convert_panel_macro(elem, macro_name, enabled_ids)
+
+    # Fallback: render as paragraph with the macro's text content
+    text = _get_all_text(elem).strip()
+    if text:
+        return [_paragraph([_text_seg(f"[{macro_name}] {text}")])]
+    return [_paragraph([_text_seg(f"[{macro_name}]")])]
+
+
+def _convert_panel_macro(
+    elem: ET.Element,
+    macro_name: str,
+    enabled_ids: set[str],
+) -> list[dict[str, Any]]:
+    """Convert info/note/warning/tip macro to a Notion callout block."""
+    emoji, color = _PANEL_STYLES[macro_name]
+    rich_text: list[dict[str, Any]] = []
+
+    for child in elem:
+        if _local_tag(child) == "rich-text-body":
+            # Extract text from inner elements (typically <p> tags)
+            for inner in child:
+                inner_tag = _local_tag(inner)
+                if inner_tag == "p":
+                    rt = _extract_rich_text(inner, enabled_ids)
+                    rich_text.extend(rt)
+                else:
+                    text = _get_all_text(inner)
+                    if text:
+                        rich_text.append(_text_seg(text))
+
+    return [
+        {
+            "type": "callout",
+            "callout": {
+                "icon": {"type": "emoji", "emoji": emoji},
+                "color": color,
+                "rich_text": rich_text,
+            },
+        }
+    ]
+
+
+def _jira_rich_text(elem: ET.Element) -> list[dict[str, Any]]:
+    """Extract JIRA issue key and URL as rich_text segments."""
+    params = _get_macro_params(elem)
+    key = params.get("key", "UNKNOWN")
+    url = f"https://issues.apache.org/jira/browse/{key}"
+    return [_text_seg(key, link=url)]
+
+
+def _convert_ac_image(
+    elem: ET.Element,
+    enabled_ids: set[str],
+) -> list[dict[str, Any]]:
+    """Convert an ac:image element to a Notion image block."""
+    if "rule:element:ac-image" not in enabled_ids:
+        return [_paragraph([_text_seg("[image]")])]
+
+    filename = ""
+    for child in elem:
+        if _local_tag(child) == "attachment":
+            filename = child.get(f"{{{_NS['ri']}}}filename", "") or child.get(
+                "ri:filename", ""
+            )
+
+    url = f"https://placeholder.confluence/attachments/{filename}" if filename else "#"
+    return [
+        {
+            "type": "image",
+            "image": {
+                "type": "external",
+                "external": {"url": url},
+            },
+        }
+    ]
+
+
+def _convert_pre(elem: ET.Element) -> list[dict[str, Any]]:
+    """Convert a <pre> element to a Notion code block."""
+    parts: list[str] = []
+    if elem.text:
+        parts.append(elem.text)
+    for child in elem:
+        tag = _local_tag(child)
+        if tag == "br":
+            parts.append("\n")
+        else:
+            text = _get_all_text(child)
+            if text:
+                parts.append(text)
+        if child.tail:
+            parts.append(child.tail)
+
+    content = "".join(parts).strip()
+    return [
+        {
+            "type": "code",
+            "code": {
+                "language": "plain text",
+                "rich_text": [_text_seg(content)],
+            },
+        }
+    ]
+
+
+def _convert_list(
+    elem: ET.Element,
+    list_tag: str,
+    enabled_ids: set[str],
+) -> list[dict[str, Any]]:
+    """Convert a <ul> or <ol> to Notion list items."""
+    block_type = "bulleted_list_item" if list_tag == "ul" else "numbered_list_item"
+    items: list[dict[str, Any]] = []
+
+    for child in elem:
+        if _local_tag(child) != "li":
+            continue
+
+        rt = _extract_rich_text_from_li(child, enabled_ids)
+        children = _extract_nested_list(child, enabled_ids)
+
+        block: dict[str, Any] = {
+            "type": block_type,
+            block_type: {"rich_text": rt},
+        }
+        if children:
+            block[block_type]["children"] = children
+        items.append(block)
+
+    return items
+
+
+def _extract_rich_text_from_li(
+    li: ET.Element,
+    enabled_ids: set[str],
+) -> list[dict[str, Any]]:
+    """Extract rich_text from a <li>, ignoring nested lists."""
+    segments: list[dict[str, Any]] = []
+
+    if li.text:
+        segments.append(_text_seg(li.text))
+
+    for child in li:
+        tag = _local_tag(child)
+        if tag in ("ul", "ol"):
+            continue  # nested list handled separately
+
+        if tag == "p":
+            rt = _extract_rich_text(child, enabled_ids)
+            segments.extend(rt)
+        elif tag == "code":
+            segments.append(_text_seg(_get_all_text(child), code=True))
+        elif tag in ("strong", "b"):
+            segments.append(_text_seg(_get_all_text(child), bold=True))
+        elif tag in ("em", "i"):
+            segments.append(_text_seg(_get_all_text(child), italic=True))
+        elif tag == "a":
+            text = _get_all_text(child) or child.get("href", "")
+            segments.append(_text_seg(text, link=child.get("href", "")))
+        elif tag == "link":
+            segments.extend(_extract_ac_link_rich_text(child))
+        elif tag == "structured-macro":
+            segments.extend(_extract_inline_macro(child, enabled_ids))
+        else:
+            text = _get_all_text(child)
+            if text:
+                segments.append(_text_seg(text))
+
+        if child.tail:
+            segments.append(_text_seg(child.tail))
+
+    return segments
+
+
+def _extract_nested_list(
+    li: ET.Element,
+    enabled_ids: set[str],
+) -> list[dict[str, Any]]:
+    """Extract nested <ul>/<ol> from a <li> element."""
+    children: list[dict[str, Any]] = []
+    for child in li:
+        tag = _local_tag(child)
+        if tag in ("ul", "ol"):
+            children.extend(_convert_list(child, tag, enabled_ids))
+    return children
+
+
+def _convert_span(elem: ET.Element) -> list[dict[str, Any]]:
+    """Convert a styled <span> to heading or paragraph."""
+    style = elem.get("style", "")
+    text = _get_all_text(elem).strip()
+    if not text:
+        return []
+
+    is_bold = "font-weight: bold" in style or "font-weight:bold" in style
+    font_size = _parse_font_size(style)
+
+    if is_bold and font_size:
+        if font_size >= 20:
+            heading_type = "heading_1"
+        elif font_size >= 14:
+            heading_type = "heading_2"
+        else:
+            heading_type = "heading_3"
+        return [{"type": heading_type, heading_type: {"rich_text": [_text_seg(text)]}}]
+
+    return [_paragraph([_text_seg(text)])]
+
+
+# --- Utility functions ---
+
+
+def _local_tag(elem: ET.Element) -> str:
+    """Strip namespace from element tag, returning the local name."""
+    tag = elem.tag
+    if "}" in tag:
+        return tag.split("}", 1)[1]
+    return tag
+
+
+def _get_all_text(elem: ET.Element) -> str:
+    """Get all text content from an element and its descendants."""
+    return "".join(elem.itertext())
+
+
+def _get_macro_name(elem: ET.Element) -> str:
+    """Get the macro name from an ac:structured-macro element."""
+    return elem.get(f"{{{_NS['ac']}}}name", "") or elem.get("ac:name", "")
+
+
+def _get_macro_params(elem: ET.Element) -> dict[str, str]:
+    """Extract parameter name→value map from macro child elements."""
+    params: dict[str, str] = {}
+    for child in elem:
+        if _local_tag(child) == "parameter":
+            name = child.get(f"{{{_NS['ac']}}}name", "") or child.get("ac:name", "")
+            value = _get_all_text(child).strip()
+            if name:
+                params[name] = value
+    return params
+
+
+def _parse_font_size(style: str) -> float | None:
+    """Extract font-size in px from an inline style string."""
+    match = re.search(r"font-size:\s*([\d.]+)px", style)
+    return float(match.group(1)) if match else None
+
+
+def _text_seg(
+    content: str,
+    *,
+    bold: bool = False,
+    italic: bool = False,
+    code: bool = False,
+    link: str = "",
+) -> dict[str, Any]:
+    """Build a Notion rich_text segment."""
+    seg: dict[str, Any] = {
+        "type": "text",
+        "text": {"content": content},
+    }
+    if link:
+        seg["text"]["link"] = {"url": link}
+
+    annotations: dict[str, bool] = {}
+    if bold:
+        annotations["bold"] = True
+    if italic:
+        annotations["italic"] = True
+    if code:
+        annotations["code"] = True
+    if annotations:
+        seg["annotations"] = annotations
+
+    return seg
+
+
+def _paragraph(rich_text: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build a Notion paragraph block."""
+    return {
+        "type": "paragraph",
+        "paragraph": {"rich_text": rich_text},
+    }

--- a/tests/unit/test_agent_schemas.py
+++ b/tests/unit/test_agent_schemas.py
@@ -7,6 +7,8 @@ from pydantic import ValidationError
 from confluence_to_notion.agents.schemas import (
     DiscoveryOutput,
     DiscoveryPattern,
+    FinalRule,
+    FinalRuleset,
     ProposedRule,
     ProposerOutput,
 )
@@ -215,3 +217,78 @@ class TestProposerOutput:
         json_str = output.model_dump_json(indent=2)
         parsed = ProposerOutput.model_validate_json(json_str)
         assert parsed == output
+
+
+# --- FinalRule / FinalRuleset ---
+
+
+def _make_proposed_rule(**overrides: object) -> ProposedRule:
+    defaults = dict(
+        rule_id="rule:macro:toc",
+        source_pattern_id="macro:toc",
+        source_description="TOC macro",
+        notion_block_type="table_of_contents",
+        mapping_description="Map TOC",
+        example_input="<x/>",
+        example_output={"type": "table_of_contents"},
+        confidence="high",
+    )
+    return ProposedRule(**{**defaults, **overrides})  # type: ignore[arg-type]
+
+
+class TestFinalRule:
+    def test_from_proposed_rule(self) -> None:
+        proposed = _make_proposed_rule()
+        rule = FinalRule.from_proposed(proposed)
+        assert rule.rule_id == proposed.rule_id
+        assert rule.notion_block_type == proposed.notion_block_type
+        assert rule.enabled is True
+
+    def test_disabled_rule(self) -> None:
+        proposed = _make_proposed_rule()
+        rule = FinalRule.from_proposed(proposed, enabled=False)
+        assert rule.enabled is False
+
+    def test_preserves_all_fields(self) -> None:
+        proposed = _make_proposed_rule(confidence="low")
+        rule = FinalRule.from_proposed(proposed)
+        assert rule.confidence == "low"
+        assert rule.source_pattern_id == proposed.source_pattern_id
+        assert rule.mapping_description == proposed.mapping_description
+        assert rule.example_input == proposed.example_input
+        assert rule.example_output == proposed.example_output
+
+
+class TestFinalRuleset:
+    def test_from_proposer_output(self) -> None:
+        proposer = ProposerOutput(
+            source_patterns_file="output/patterns.json",
+            rules=[_make_proposed_rule(), _make_proposed_rule(rule_id="rule:macro:jira")],
+        )
+        ruleset = FinalRuleset.from_proposer_output(proposer)
+        assert len(ruleset.rules) == 2
+        assert ruleset.source == "output/patterns.json"
+        assert all(r.enabled for r in ruleset.rules)
+
+    def test_empty_rules_allowed(self) -> None:
+        ruleset = FinalRuleset(source="output/patterns.json", rules=[])
+        assert len(ruleset.rules) == 0
+
+    def test_enabled_rules_property(self) -> None:
+        r1 = FinalRule.from_proposed(_make_proposed_rule())
+        r2 = FinalRule.from_proposed(
+            _make_proposed_rule(rule_id="rule:macro:jira"), enabled=False
+        )
+        ruleset = FinalRuleset(source="f.json", rules=[r1, r2])
+        assert len(ruleset.enabled_rules) == 1
+        assert ruleset.enabled_rules[0].rule_id == "rule:macro:toc"
+
+    def test_json_roundtrip(self) -> None:
+        proposer = ProposerOutput(
+            source_patterns_file="output/patterns.json",
+            rules=[_make_proposed_rule()],
+        )
+        ruleset = FinalRuleset.from_proposer_output(proposer)
+        json_str = ruleset.model_dump_json(indent=2)
+        parsed = FinalRuleset.model_validate_json(json_str)
+        assert parsed == ruleset

--- a/tests/unit/test_converter.py
+++ b/tests/unit/test_converter.py
@@ -1,0 +1,353 @@
+"""Unit tests for the deterministic XHTML → Notion block converter."""
+
+from typing import Any
+
+import pytest
+
+from confluence_to_notion.agents.schemas import FinalRule, FinalRuleset, ProposedRule
+from confluence_to_notion.converter.converter import convert_page
+
+# --- Helpers ---
+
+
+def _ruleset(rules: list[dict[str, Any]] | None = None) -> FinalRuleset:
+    """Build a FinalRuleset from shorthand dicts, or return default test ruleset."""
+    if rules is None:
+        rules = []
+    final_rules = [
+        FinalRule.from_proposed(ProposedRule(**r))  # type: ignore[arg-type]
+        for r in rules
+    ]
+    return FinalRuleset(source="test", rules=final_rules)
+
+
+def _default_ruleset() -> FinalRuleset:
+    """A ruleset containing all 8 rules from the actual proposals.json."""
+    return _ruleset(
+        [
+            {
+                "rule_id": "rule:macro:toc",
+                "source_pattern_id": "macro:toc",
+                "source_description": "TOC",
+                "notion_block_type": "table_of_contents",
+                "mapping_description": "Map TOC",
+                "example_input": "<x/>",
+                "example_output": {"type": "table_of_contents"},
+                "confidence": "high",
+            },
+            {
+                "rule_id": "rule:macro:jira",
+                "source_pattern_id": "macro:jira",
+                "source_description": "JIRA ref",
+                "notion_block_type": "paragraph",
+                "mapping_description": "Map JIRA",
+                "example_input": "<x/>",
+                "example_output": {"type": "paragraph"},
+                "confidence": "medium",
+            },
+            {
+                "rule_id": "rule:macro:info",
+                "source_pattern_id": "macro:info",
+                "source_description": "Info panel",
+                "notion_block_type": "callout",
+                "mapping_description": "Map info",
+                "example_input": "<x/>",
+                "example_output": {"type": "callout"},
+                "confidence": "high",
+            },
+            {
+                "rule_id": "rule:element:ac-image",
+                "source_pattern_id": "element:ac-image",
+                "source_description": "Image",
+                "notion_block_type": "image",
+                "mapping_description": "Map image",
+                "example_input": "<x/>",
+                "example_output": {"type": "image"},
+                "confidence": "medium",
+            },
+            {
+                "rule_id": "rule:formatting:pre",
+                "source_pattern_id": "formatting:pre",
+                "source_description": "Preformatted",
+                "notion_block_type": "code",
+                "mapping_description": "Map pre",
+                "example_input": "<x/>",
+                "example_output": {"type": "code"},
+                "confidence": "high",
+            },
+        ]
+    )
+
+
+# --- Standard HTML ---
+
+
+class TestHeadings:
+    def test_h1(self) -> None:
+        blocks = convert_page("<h1>Title</h1>", _default_ruleset())
+        assert blocks == [
+            {
+                "type": "heading_1",
+                "heading_1": {
+                    "rich_text": [{"type": "text", "text": {"content": "Title"}}],
+                },
+            }
+        ]
+
+    def test_h2(self) -> None:
+        blocks = convert_page("<h2>Section</h2>", _default_ruleset())
+        assert blocks[0]["type"] == "heading_2"
+
+    def test_h3(self) -> None:
+        blocks = convert_page("<h3>Subsection</h3>", _default_ruleset())
+        assert blocks[0]["type"] == "heading_3"
+
+    def test_h4_h5_h6_fallback_to_h3(self) -> None:
+        """Notion only supports h1-h3; h4+ should map to h3."""
+        blocks = convert_page("<h4>Deep heading</h4>", _default_ruleset())
+        assert blocks[0]["type"] == "heading_3"
+
+
+class TestParagraphs:
+    def test_simple_paragraph(self) -> None:
+        blocks = convert_page("<p>Hello world</p>", _default_ruleset())
+        assert blocks == [
+            {
+                "type": "paragraph",
+                "paragraph": {
+                    "rich_text": [{"type": "text", "text": {"content": "Hello world"}}],
+                },
+            }
+        ]
+
+    def test_empty_paragraph_skipped(self) -> None:
+        blocks = convert_page("<p></p>", _default_ruleset())
+        assert blocks == []
+
+    def test_br_only_paragraph_skipped(self) -> None:
+        blocks = convert_page("<p><br /></p>", _default_ruleset())
+        assert blocks == []
+
+    def test_paragraph_with_inline_code(self) -> None:
+        blocks = convert_page("<p>Run <code>gradle</code> now</p>", _default_ruleset())
+        rich_text = blocks[0]["paragraph"]["rich_text"]
+        assert len(rich_text) == 3
+        assert rich_text[0] == {"type": "text", "text": {"content": "Run "}}
+        assert rich_text[1]["annotations"]["code"] is True
+        assert rich_text[1]["text"]["content"] == "gradle"
+        assert rich_text[2] == {"type": "text", "text": {"content": " now"}}
+
+    def test_paragraph_with_bold(self) -> None:
+        blocks = convert_page("<p>This is <strong>bold</strong> text</p>", _default_ruleset())
+        rich_text = blocks[0]["paragraph"]["rich_text"]
+        assert rich_text[1]["annotations"]["bold"] is True
+
+    def test_paragraph_with_italic(self) -> None:
+        blocks = convert_page("<p>This is <em>italic</em> text</p>", _default_ruleset())
+        rich_text = blocks[0]["paragraph"]["rich_text"]
+        assert rich_text[1]["annotations"]["italic"] is True
+
+    def test_paragraph_with_link(self) -> None:
+        blocks = convert_page(
+            '<p>See <a href="https://example.com">here</a></p>',
+            _default_ruleset(),
+        )
+        rich_text = blocks[0]["paragraph"]["rich_text"]
+        assert rich_text[1]["text"]["link"] == {"url": "https://example.com"}
+
+
+class TestLists:
+    def test_unordered_list(self) -> None:
+        blocks = convert_page("<ul><li>one</li><li>two</li></ul>", _default_ruleset())
+        assert len(blocks) == 2
+        assert blocks[0]["type"] == "bulleted_list_item"
+        assert blocks[0]["bulleted_list_item"]["rich_text"][0]["text"]["content"] == "one"
+
+    def test_ordered_list(self) -> None:
+        blocks = convert_page("<ol><li>first</li><li>second</li></ol>", _default_ruleset())
+        assert len(blocks) == 2
+        assert blocks[0]["type"] == "numbered_list_item"
+
+    def test_nested_list(self) -> None:
+        xhtml = "<ul><li>parent<ul><li>child</li></ul></li></ul>"
+        blocks = convert_page(xhtml, _default_ruleset())
+        assert blocks[0]["type"] == "bulleted_list_item"
+        children = blocks[0].get("bulleted_list_item", {}).get("children", [])
+        assert len(children) == 1
+        assert children[0]["type"] == "bulleted_list_item"
+
+
+# --- Confluence Macros ---
+
+
+class TestMacroToc:
+    def test_toc_macro(self) -> None:
+        xhtml = (
+            '<ac:structured-macro ac:name="toc" ac:schema-version="1">'
+            '<ac:parameter ac:name="maxLevel">3</ac:parameter>'
+            "</ac:structured-macro>"
+        )
+        blocks = convert_page(xhtml, _default_ruleset())
+        assert blocks == [
+            {
+                "type": "table_of_contents",
+                "table_of_contents": {"color": "default"},
+            }
+        ]
+
+    def test_toc_macro_wrapped_in_paragraph(self) -> None:
+        """Confluence often wraps block macros in <p>; converter should promote them."""
+        xhtml = (
+            "<p>"
+            '<ac:structured-macro ac:name="toc" ac:schema-version="1">'
+            '<ac:parameter ac:name="maxLevel">3</ac:parameter>'
+            "</ac:structured-macro>"
+            "</p>"
+        )
+        blocks = convert_page(xhtml, _default_ruleset())
+        assert len(blocks) == 1
+        assert blocks[0]["type"] == "table_of_contents"
+
+
+class TestMacroJira:
+    def test_jira_macro(self) -> None:
+        xhtml = (
+            '<ac:structured-macro ac:name="jira" ac:schema-version="1">'
+            '<ac:parameter ac:name="server">ASF JIRA</ac:parameter>'
+            '<ac:parameter ac:name="key">KAFKA-4617</ac:parameter>'
+            "</ac:structured-macro>"
+        )
+        blocks = convert_page(xhtml, _default_ruleset())
+        rt = blocks[0]["paragraph"]["rich_text"]
+        assert rt[0]["text"]["content"] == "KAFKA-4617"
+        assert "jira/browse/KAFKA-4617" in rt[0]["text"]["link"]["url"]
+
+
+class TestMacroInfo:
+    def test_info_macro(self) -> None:
+        xhtml = (
+            '<ac:structured-macro ac:name="info">'
+            "<ac:rich-text-body><p>Important note</p></ac:rich-text-body>"
+            "</ac:structured-macro>"
+        )
+        blocks = convert_page(xhtml, _default_ruleset())
+        assert blocks[0]["type"] == "callout"
+        callout = blocks[0]["callout"]
+        assert callout["icon"] == {"type": "emoji", "emoji": "\u2139\ufe0f"}
+        assert callout["color"] == "blue_background"
+        assert callout["rich_text"][0]["text"]["content"] == "Important note"
+
+    @pytest.mark.parametrize(
+        ("macro_name", "emoji", "color"),
+        [
+            ("note", "\U0001f4dd", "gray_background"),
+            ("warning", "\u26a0\ufe0f", "yellow_background"),
+            ("tip", "\U0001f4a1", "green_background"),
+        ],
+    )
+    def test_panel_variants(self, macro_name: str, emoji: str, color: str) -> None:
+        xhtml = (
+            f'<ac:structured-macro ac:name="{macro_name}">'
+            "<ac:rich-text-body><p>Text</p></ac:rich-text-body>"
+            "</ac:structured-macro>"
+        )
+        blocks = convert_page(xhtml, _default_ruleset())
+        assert blocks[0]["callout"]["icon"]["emoji"] == emoji
+        assert blocks[0]["callout"]["color"] == color
+
+
+# --- Confluence Elements ---
+
+
+class TestAcLink:
+    def test_ac_link_in_paragraph(self) -> None:
+        xhtml = (
+            "<p>See "
+            '<ac:link><ri:page ri:content-title="Setup Guide" /></ac:link>'
+            " for details</p>"
+        )
+        blocks = convert_page(xhtml, _default_ruleset())
+        rt = blocks[0]["paragraph"]["rich_text"]
+        link_seg = next(s for s in rt if s["text"].get("link"))
+        assert link_seg["text"]["content"] == "Setup Guide"
+
+    def test_ac_link_with_custom_text(self) -> None:
+        xhtml = (
+            "<p>"
+            "<ac:link><ri:page ri:content-title=\"Compression\" />"
+            "<ac:plain-text-link-body><![CDATA[Kafka compression]]>"
+            "</ac:plain-text-link-body></ac:link>"
+            "</p>"
+        )
+        blocks = convert_page(xhtml, _default_ruleset())
+        rt = blocks[0]["paragraph"]["rich_text"]
+        link_seg = next(s for s in rt if s["text"].get("link"))
+        assert link_seg["text"]["content"] == "Kafka compression"
+
+
+class TestAcImage:
+    def test_image(self) -> None:
+        xhtml = '<ac:image ac:height="250"><ri:attachment ri:filename="pic.jpg" /></ac:image>'
+        blocks = convert_page(xhtml, _default_ruleset())
+        assert blocks[0]["type"] == "image"
+        assert blocks[0]["image"]["type"] == "external"
+        assert "pic.jpg" in blocks[0]["image"]["external"]["url"]
+
+
+# --- Formatting ---
+
+
+class TestPreformatted:
+    def test_pre_block(self) -> None:
+        xhtml = "<pre>line1<br />line2</pre>"
+        blocks = convert_page(xhtml, _default_ruleset())
+        assert blocks[0]["type"] == "code"
+        content = blocks[0]["code"]["rich_text"][0]["text"]["content"]
+        assert content == "line1\nline2"
+        assert blocks[0]["code"]["language"] == "plain text"
+
+
+class TestStyledSpan:
+    def test_bold_large_span_as_heading(self) -> None:
+        xhtml = '<span style="font-size: 16.0px;font-weight: bold;">Section Title</span>'
+        blocks = convert_page(xhtml, _default_ruleset())
+        assert blocks[0]["type"] == "heading_2"
+
+    def test_non_bold_span_as_paragraph(self) -> None:
+        xhtml = '<span style="font-size: 16.0px;">Not a heading</span>'
+        blocks = convert_page(xhtml, _default_ruleset())
+        assert blocks[0]["type"] == "paragraph"
+
+
+# --- Edge cases ---
+
+
+class TestEdgeCases:
+    def test_empty_input(self) -> None:
+        blocks = convert_page("", _default_ruleset())
+        assert blocks == []
+
+    def test_plain_text_only(self) -> None:
+        blocks = convert_page("just text", _default_ruleset())
+        assert blocks[0]["type"] == "paragraph"
+        assert blocks[0]["paragraph"]["rich_text"][0]["text"]["content"] == "just text"
+
+    def test_unknown_macro_as_paragraph(self) -> None:
+        xhtml = (
+            '<ac:structured-macro ac:name="unknown-thing">'
+            '<ac:parameter ac:name="x">val</ac:parameter>'
+            "</ac:structured-macro>"
+        )
+        blocks = convert_page(xhtml, _default_ruleset())
+        assert len(blocks) == 1
+        assert blocks[0]["type"] == "paragraph"
+
+    def test_disabled_rule_not_applied(self) -> None:
+        """When the toc rule is disabled, toc macro becomes a fallback paragraph."""
+        ruleset = _default_ruleset()
+        for r in ruleset.rules:
+            if r.rule_id == "rule:macro:toc":
+                r.enabled = False
+        xhtml = '<ac:structured-macro ac:name="toc" ac:schema-version="1" />'
+        blocks = convert_page(xhtml, ruleset)
+        assert blocks[0]["type"] == "paragraph"


### PR DESCRIPTION
## Summary
- **FinalRule/FinalRuleset schemas**: 2-agent shortcut that promotes `ProposerOutput` directly to final ruleset (`enabled` flag for future critic/arbitrator integration)
- **Deterministic converter** (`src/converter/converter.py`): Pure Python XHTML → Notion block transformation — handles 8 discovered rule types (toc, jira, info/note/warning/tip, ac-link, ac-image, pre, code, styled-span) plus standard HTML (headings, paragraphs, lists, inline formatting)
- **CLI commands**: `cli finalize` (proposals → rules.json) and `cli convert` (XHTML + rules → Notion block JSON)
- **Pipeline steps 3-4**: `discover.sh` now runs finalize + convert as deterministic Python steps (no LLM calls)

Closes #4

## Test plan
- [x] 31 converter unit tests covering each rule type, edge cases, and disabled rules
- [x] FinalRule/FinalRuleset schema tests with JSON roundtrip
- [x] All 86 tests pass
- [x] ruff / mypy strict pass
- [x] End-to-end: `bash scripts/discover.sh samples/ --from 3` converts all 5 sample pages (137 blocks total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)