### PR TITLE
feat: add /discover slash command

### DIFF
--- a/.claude/commands/discover.md
+++ b/.claude/commands/discover.md
@@ -1,0 +1,23 @@
+Run the discovery pipeline to extract Confluence → Notion transformation rules.
+
+Usage: /discover <samples-dir> [--from N]
+
+## What this does
+
+Executes `scripts/discover.sh` which runs a 4-step pipeline:
+
+1. **Pattern Discovery** (agent) — analyze XHTML samples → `output/patterns.json`
+2. **Rule Proposer** (agent) — propose mapping rules → `output/proposals.json`
+3. **Finalize** (cli) — proposals → `output/rules.json`
+4. **Convert** (cli) — apply rules to XHTML → `output/converted/`
+
+## Steps
+
+1. Parse the samples directory from `$ARGUMENTS`. Default to `samples/` if empty.
+2. Run: `bash scripts/discover.sh $ARGUMENTS`
+3. Stream the output so the user can follow progress.
+4. When complete, report:
+   - Number of patterns discovered
+   - Number of rules generated
+   - Number of pages converted
+   - Any errors or warnings


### PR DESCRIPTION
## Summary
- Add `/discover` slash command for Claude Code to trigger the discovery pipeline (`scripts/discover.sh`)
- Pairs with the existing `/develop` command added in #12

## Test plan
- [ ] `/discover samples/` triggers the pipeline
- [ ] `/discover samples/ --from 3` resumes from step 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)