### PR TITLE
fix: address scout-pipeline review feedback

### DIFF
--- a/.claude/agents/discover/scout-routine.md
+++ b/.claude/agents/discover/scout-routine.md
@@ -43,18 +43,13 @@ You are a scout routine agent triggered on a schedule. Your job is to run the fu
 
 ## Scheduling as a Claude Code Trigger
 
-To register this routine as a recurring scheduled trigger, use Claude Code's CronCreate:
+To register this as a recurring trigger, use Claude Code's CronCreate with this agent's
+prompt file — the agent handles running the script and reporting results:
 
 ```
 CronCreate:
   schedule: "0 9 * * 1"          # Every Monday at 9:00 AM UTC
-  prompt: |
-    Run the scout routine agent.
-    bash scripts/scout-pipeline.sh
-    Then read output/sources.json and report a summary of:
-    - total sources, accessible count, fetched count
-    - any new sources discovered or fetched in this run
-    - any errors from the pipeline
+  prompt: <contents of .claude/agents/discover/scout-routine.md>
 ```
 
 Adjust the cron schedule as needed. Common schedules:

--- a/scripts/scout-pipeline.sh
+++ b/scripts/scout-pipeline.sh
@@ -4,13 +4,16 @@
 # Chains:
 #   1. Run confluence-scout agent → output/sources.json
 #   2. Parse sources.json for new accessible sources (fetched_at == null)
-#   3. Fetch pages from each new source into samples/<space_key>/
-#   4. Update fetched_at in sources.json
-#   5. Run discover.sh for each newly fetched source
+#   Per new source:
+#     3. Fetch pages into samples/<space_key>/
+#     4. Run discover.sh
+#     5. Stamp fetched_at (only after both 3+4 succeed; failures retry next run)
 #
 # Usage:
 #   bash scripts/scout-pipeline.sh
 #   bash scripts/scout-pipeline.sh --dry-run   # preview without executing
+#
+# Note: --dry-run with no existing sources.json exits after Step 1 (nothing to preview).
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -26,6 +29,12 @@ while [[ $# -gt 0 ]]; do
         *) echo "Unknown option: $1"; exit 1 ;;
     esac
 done
+
+# Require jq for JSON processing in Steps 2-5
+if ! command -v jq &>/dev/null; then
+    echo "ERROR: jq is required but not installed. Install it with: brew install jq"
+    exit 1
+fi
 
 mkdir -p "$OUTPUT_DIR"
 
@@ -68,9 +77,13 @@ echo "$NEW_SOURCES" | while IFS='|' read -r url key; do
     echo "      - ${key} @ ${url}"
 done
 
-# --- Steps 3-5: For each new source: fetch, update timestamp, discover ---
+# --- Steps 3-5: For each new source: fetch, discover, stamp fetched_at ---
+# fetched_at is set only after discover succeeds, so failed sources are retried next run.
+# One source failing does not block subsequent sources.
 echo ""
-echo "$NEW_SOURCES" | while IFS='|' read -r wiki_url space_key; do
+FAILED_SOURCES=""
+
+while IFS='|' read -r wiki_url space_key; do
     SAMPLES_SUBDIR="${PROJECT_DIR}/samples/${space_key}"
 
     # Step 3: Fetch pages
@@ -79,15 +92,34 @@ echo "$NEW_SOURCES" | while IFS='|' read -r wiki_url space_key; do
         echo "    [dry-run] Would run: CONFLUENCE_BASE_URL=${wiki_url} uv run cli fetch --space ${space_key} --limit 50 --out-dir ${SAMPLES_SUBDIR}"
     else
         mkdir -p "$SAMPLES_SUBDIR"
-        CONFLUENCE_BASE_URL="${wiki_url}" uv run cli fetch \
+        if ! CONFLUENCE_BASE_URL="${wiki_url}" uv run cli fetch \
             --space "$space_key" \
             --limit 50 \
-            --out-dir "$SAMPLES_SUBDIR"
+            --out-dir "$SAMPLES_SUBDIR"; then
+            echo "    FAILED: fetch for ${space_key} — skipping"
+            FAILED_SOURCES="${FAILED_SOURCES}${space_key} (fetch), "
+            echo ""
+            continue
+        fi
         echo "    Done: ${SAMPLES_SUBDIR}/"
     fi
 
-    # Step 4: Update fetched_at timestamp in sources.json
-    echo "==> Step 4: Update fetched_at for ${space_key}"
+    # Step 4: Run discovery pipeline
+    echo "==> Step 4: Run discover.sh for ${space_key}"
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echo "    [dry-run] Would run: bash scripts/discover.sh ${SAMPLES_SUBDIR}"
+    else
+        if ! bash "${SCRIPT_DIR}/discover.sh" "$SAMPLES_SUBDIR"; then
+            echo "    FAILED: discover for ${space_key} — skipping"
+            FAILED_SOURCES="${FAILED_SOURCES}${space_key} (discover), "
+            echo ""
+            continue
+        fi
+        echo "    Done: discovery pipeline for ${space_key}"
+    fi
+
+    # Step 5: Stamp fetched_at (only after fetch + discover both succeed)
+    echo "==> Step 5: Update fetched_at for ${space_key}"
     TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
     if [[ "$DRY_RUN" == "true" ]]; then
         echo "    [dry-run] Would set fetched_at=${TIMESTAMP} for ${space_key}"
@@ -99,16 +131,13 @@ echo "$NEW_SOURCES" | while IFS='|' read -r wiki_url space_key; do
         echo "    Done: fetched_at=${TIMESTAMP}"
     fi
 
-    # Step 5: Run discovery pipeline
-    echo "==> Step 5: Run discover.sh for ${space_key}"
-    if [[ "$DRY_RUN" == "true" ]]; then
-        echo "    [dry-run] Would run: bash scripts/discover.sh ${SAMPLES_SUBDIR}"
-    else
-        bash "${SCRIPT_DIR}/discover.sh" "$SAMPLES_SUBDIR"
-        echo "    Done: discovery pipeline for ${space_key}"
-    fi
-
     echo ""
-done
+done <<< "$NEW_SOURCES"
 
-echo "==> Scout pipeline complete."
+# Report results
+if [[ -n "$FAILED_SOURCES" ]]; then
+    echo "==> Scout pipeline complete with failures: ${FAILED_SOURCES%, }"
+    exit 1
+else
+    echo "==> Scout pipeline complete."
+fi


### PR DESCRIPTION
## Summary

PR #16 코드 리뷰 피드백 반영:

- **jq 사전 검사**: 스크립트 초반에 `command -v jq` 체크 추가 (없으면 에러 메시지와 함께 종료)
- **fetched_at 타이밍**: fetch+discover 둘 다 성공 후에만 스탬프 → 실패한 소스는 다음 실행에서 재시도
- **부분 실패 처리**: 한 소스 실패 시 나머지 계속 처리, 끝에 실패 목록 리포트
- **dry-run 문서**: sources.json 없을 때 동작 명시
- **scout-routine.md**: CronCreate에서 스크립트 직접 호출 제거, 에이전트 프롬프트 참조로 통일

## Test plan

- [x] `bash -n scripts/scout-pipeline.sh` syntax check
- [x] 130 tests passing
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)