### PR TITLE
test: E2E 통합 테스트 — fetch → discover → convert → migrate

### DIFF
--- a/output/dev/dev-implementer.log
+++ b/output/dev/dev-implementer.log
@@ -1,0 +1,1 @@
+Committed and pushed to `claude/pick-dev-tasks-V3yab`.

--- a/output/dev/dev-planner.log
+++ b/output/dev/dev-planner.log
@@ -1,0 +1,1 @@
+Committed and pushed `output/dev/plan.json` to `claude/pick-dev-tasks-V3yab`.

--- a/output/dev/dev-reviewer.log
+++ b/output/dev/dev-reviewer.log
@@ -1,0 +1,1 @@
+Committed and pushed `output/dev/review.json` and the three pipeline logs to `claude/pick-dev-tasks-V3yab`.

--- a/output/dev/implement-log.json
+++ b/output/dev/implement-log.json
@@ -1,0 +1,45 @@
+{
+  "plan_file": "output/dev/plan.json",
+  "decisions": [
+    {
+      "task_id": "task:1",
+      "description": "Used pytest_configure hook in tests/conftest.py to register the 'integration' marker, and created three fixture files under tests/fixtures/integration/.",
+      "reason": "pytest_configure is the standard idiomatic way to register custom markers so pytest does not warn about unknown markers at runtime. Placing fixtures in tests/fixtures/integration/ mirrors the existing fixtures/migrate/ pattern already in the codebase.",
+      "alternatives": [
+        "Register marker in pytest.ini / pyproject.toml [tool.pytest.ini_options] markers list — rejected because the plan explicitly says to use the pytest_configure hook in conftest.py.",
+        "Add addopts = -m 'not integration' to pyproject.toml to skip integration tests by default — not done because pyproject.toml was not in the affected_files list and the test runner supports explicit -m integration filtering."
+      ]
+    },
+    {
+      "task_id": "task:1",
+      "description": "rules.json is a minimal but schema-valid FinalRuleset with three rules covering headings, paragraphs, and list items.",
+      "reason": "The FinalRule model requires rule_id, source_pattern_id, source_description, notion_block_type, mapping_description, example_input, example_output, and confidence. Three rules were included so that page1.xhtml and page2.xhtml each produce a diverse set of block types (headings, paragraphs, bulleted and numbered list items) that can be individually asserted in tests.",
+      "alternatives": [
+        "Empty rules list (source + rules: []) — rejected because with no rules the converter still produces heading/paragraph/list blocks via built-in tag handling, so the tests would pass, but the fixture would not accurately represent a real discover pipeline output.",
+        "Full rule set with macro rules — not needed; the fixture pages have no Confluence macros."
+      ]
+    },
+    {
+      "task_id": "task:2",
+      "description": "Split tests into two classes: TestConvertPage (direct convert_page calls) and TestMigrateDryRun (CLI invocation with mocked NotionClientWrapper). Helper functions _setup_settings, _setup_notion_client, _copy_fixtures, _copy_rules eliminate repetition across the four CLI tests.",
+      "reason": "Separating convert_page tests from CLI tests keeps each test focused on one layer. The helpers keep the test methods short and declarative. This mirrors the existing unit/test_cli_migrate.py pattern.",
+      "alternatives": [
+        "Single monolithic test that does all five steps in sequence — rejected because individual test methods are easier to diagnose on failure.",
+        "Parametrize migrate tests over both fixture pages — rejected; the plan specifically calls for asserting one page's title ('Integration Test Page 1'), so separate tests are clearer."
+      ]
+    },
+    {
+      "task_id": "task:2",
+      "description": "Used unittest.mock.patch on 'confluence_to_notion.cli.NotionClientWrapper' and 'confluence_to_notion.cli._load_settings' rather than patching at the source module.",
+      "reason": "The migrate CLI imports NotionClientWrapper at the top of cli.py and calls it as a local name. Patching at the call site (cli module) is the correct mock target, consistent with the existing test_cli_migrate.py tests.",
+      "alternatives": [
+        "Patch 'confluence_to_notion.notion.client.NotionClientWrapper' — incorrect target; cli.py holds its own reference after the import."
+      ]
+    }
+  ],
+  "known_risks": [
+    "The integration tests do NOT test the actual fetch (Confluence HTTP) or discover (claude -p) pipeline stages — those remain untested end-to-end because they require live credentials. The tests simulate those stages by using pre-written fixture files.",
+    "The integration marker is not excluded from the default pytest run (no addopts in pyproject.toml). Running 'uv run pytest' without -m will include integration tests. This is acceptable because all mocks are in place and no external services are needed; the tests complete in under 1 second.",
+    "Fixture XHTML files use plain HTML tags (h1, p, ul, ol, li) — not Confluence-namespaced XHTML. The converter handles these correctly via its _local_tag() stripping logic, but the fixtures do not exercise Confluence-specific macros (toc, info, code, etc.)."
+  ]
+}

--- a/output/dev/plan.json
+++ b/output/dev/plan.json
@@ -1,0 +1,34 @@
+{
+  "issue_number": 20,
+  "issue_title": "test: E2E 통합 테스트 — fetch → discover → convert → migrate",
+  "split": false,
+  "remaining_description": null,
+  "tasks": [
+    {
+      "task_id": "task:1",
+      "title": "Register integration marker and create fixture data",
+      "description": "Register the 'integration' pytest marker in tests/conftest.py via pytest_configure hook. Create two fixture XHTML pages (page1.xhtml, page2.xhtml) under tests/fixtures/integration/ covering headings, paragraphs, and lists. Create tests/fixtures/integration/rules.json as a minimal FinalRuleset (matching src/confluence_to_notion/agents/schemas.py FinalRuleset) to simulate discover pipeline output.",
+      "affected_files": [
+        "tests/conftest.py",
+        "tests/fixtures/integration/page1.xhtml",
+        "tests/fixtures/integration/page2.xhtml",
+        "tests/fixtures/integration/rules.json"
+      ],
+      "depends_on": [],
+      "test_files": []
+    },
+    {
+      "task_id": "task:2",
+      "title": "Write E2E integration tests: convert → migrate dry-run",
+      "description": "Create tests/integration/__init__.py and tests/integration/test_e2e_pipeline.py. Tests must be marked @pytest.mark.integration and require no external APIs. Test flow: (1) load fixture XHTML pages from tests/fixtures/integration/ (simulating fetch output); (2) load fixture rules.json into FinalRuleset (simulating discover output); (3) call convert_page() directly to produce Notion blocks; (4) mock NotionClientWrapper.create_page as a dry-run and invoke the migrate CLI command; (5) assert blocks are non-empty with correct Notion block structure, and that create_page was called once per page with correct parent_id and title. Run with: uv run pytest -m integration",
+      "affected_files": [
+        "tests/integration/__init__.py",
+        "tests/integration/test_e2e_pipeline.py"
+      ],
+      "depends_on": ["task:1"],
+      "test_files": [
+        "tests/integration/test_e2e_pipeline.py"
+      ]
+    }
+  ]
+}

--- a/output/dev/review.json
+++ b/output/dev/review.json
@@ -1,0 +1,23 @@
+{
+  "plan_file": "output/dev/plan.json",
+  "files_reviewed": [
+    "tests/conftest.py",
+    "tests/fixtures/integration/page1.xhtml",
+    "tests/fixtures/integration/page2.xhtml",
+    "tests/fixtures/integration/rules.json",
+    "tests/integration/__init__.py",
+    "tests/integration/test_e2e_pipeline.py"
+  ],
+  "issues": [
+    {
+      "severity": "warning",
+      "file": "tests/integration/test_e2e_pipeline.py",
+      "line": null,
+      "description": "Integration tests are not excluded from the default pytest run. testing.md states: 'Integration tests live in tests/integration/, skipped by default, run with -m integration'. No addopts filter is set in pyproject.toml, so 'uv run pytest' includes all 9 integration tests.",
+      "suggestion": "Add 'addopts = \"-m not integration\"' (or 'filterwarnings' + 'addopts') under [tool.pytest.ini_options] in pyproject.toml so that 'uv run pytest' skips integration tests by default and they require an explicit '-m integration' flag.",
+      "intent_conflict": true,
+      "implement_intent": "The integration marker is not excluded from the default pytest run because all mocks are in place, no external services are needed, and the tests complete in under 1 second — so there is no practical cost to including them in the default run."
+    }
+  ],
+  "approved": true
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,8 @@ plugins = ["pydantic.mypy"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+addopts = "-m 'not integration'"
+markers = ["integration: E2E integration tests (require explicit -m integration)"]
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,14 @@ import pytest
 from confluence_to_notion.config import Settings
 
 
+def pytest_configure(config: pytest.Config) -> None:
+    """Register custom pytest markers."""
+    config.addinivalue_line(
+        "markers",
+        "integration: mark test as an integration test (run with: pytest -m integration)",
+    )
+
+
 @pytest.fixture
 def settings() -> Settings:
     """Create test settings with dummy values (authenticated Confluence)."""

--- a/tests/fixtures/integration/page1.xhtml
+++ b/tests/fixtures/integration/page1.xhtml
@@ -1,0 +1,9 @@
+<h1>Integration Test Page 1</h1>
+<p>This is the first paragraph of page 1.</p>
+<h2>Bullet List Section</h2>
+<ul>
+  <li>First bullet item</li>
+  <li>Second bullet item</li>
+  <li>Third bullet item</li>
+</ul>
+<p>Another paragraph with <strong>bold text</strong> and <em>italic text</em>.</p>

--- a/tests/fixtures/integration/page2.xhtml
+++ b/tests/fixtures/integration/page2.xhtml
@@ -1,0 +1,9 @@
+<h1>Integration Test Page 2</h1>
+<p>Introduction paragraph for page 2.</p>
+<h2>Numbered List Section</h2>
+<ol>
+  <li>First numbered item</li>
+  <li>Second numbered item</li>
+  <li>Third numbered item</li>
+</ol>
+<p>Closing paragraph for page 2.</p>

--- a/tests/fixtures/integration/rules.json
+++ b/tests/fixtures/integration/rules.json
@@ -1,0 +1,47 @@
+{
+  "source": "tests/fixtures/integration/rules.json",
+  "rules": [
+    {
+      "rule_id": "rule:element:heading",
+      "source_pattern_id": "element:heading",
+      "source_description": "HTML heading tags h1-h6 map to Notion heading blocks",
+      "notion_block_type": "heading_1",
+      "mapping_description": "Map h1 to heading_1, h2 to heading_2, h3 to heading_3",
+      "example_input": "<h1>Title</h1>",
+      "example_output": {
+        "type": "heading_1",
+        "heading_1": {"rich_text": [{"type": "text", "text": {"content": "Title"}}]}
+      },
+      "confidence": "high",
+      "enabled": true
+    },
+    {
+      "rule_id": "rule:element:paragraph",
+      "source_pattern_id": "element:paragraph",
+      "source_description": "HTML paragraph tags map to Notion paragraph blocks",
+      "notion_block_type": "paragraph",
+      "mapping_description": "Map <p> tags to Notion paragraph blocks",
+      "example_input": "<p>Hello world</p>",
+      "example_output": {
+        "type": "paragraph",
+        "paragraph": {"rich_text": [{"type": "text", "text": {"content": "Hello world"}}]}
+      },
+      "confidence": "high",
+      "enabled": true
+    },
+    {
+      "rule_id": "rule:element:list",
+      "source_pattern_id": "element:list",
+      "source_description": "HTML ul/ol list elements map to Notion bulleted/numbered list items",
+      "notion_block_type": "bulleted_list_item",
+      "mapping_description": "Map <ul><li> to bulleted_list_item and <ol><li> to numbered_list_item",
+      "example_input": "<ul><li>Item</li></ul>",
+      "example_output": {
+        "type": "bulleted_list_item",
+        "bulleted_list_item": {"rich_text": [{"type": "text", "text": {"content": "Item"}}]}
+      },
+      "confidence": "high",
+      "enabled": true
+    }
+  ]
+}

--- a/tests/integration/test_e2e_pipeline.py
+++ b/tests/integration/test_e2e_pipeline.py
@@ -1,0 +1,218 @@
+"""E2E integration tests: fetch → discover → convert → migrate dry-run.
+
+No external APIs are called. The tests use:
+- Fixture XHTML pages under tests/fixtures/integration/ (simulating fetch output)
+- Fixture rules.json (simulating discover pipeline output)
+- Mocked NotionClientWrapper.create_page (dry-run, no real Notion writes)
+
+Run with:
+    uv run pytest -m integration
+"""
+
+import shutil
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from confluence_to_notion.agents.schemas import FinalRuleset
+from confluence_to_notion.cli import app
+from confluence_to_notion.converter.converter import convert_page
+from confluence_to_notion.notion.schemas import NotionPageResult
+
+FIXTURE_DIR = Path(__file__).parent.parent / "fixtures" / "integration"
+
+runner = CliRunner()
+
+
+@pytest.mark.integration
+class TestConvertPage:
+    """Step 3: call convert_page() directly to produce Notion blocks."""
+
+    def test_page1_produces_nonempty_blocks(self) -> None:
+        xhtml = (FIXTURE_DIR / "page1.xhtml").read_text()
+        ruleset = FinalRuleset.model_validate_json((FIXTURE_DIR / "rules.json").read_text())
+
+        blocks = convert_page(xhtml, ruleset)
+
+        assert len(blocks) > 0
+
+    def test_page1_blocks_have_valid_notion_structure(self) -> None:
+        xhtml = (FIXTURE_DIR / "page1.xhtml").read_text()
+        ruleset = FinalRuleset.model_validate_json((FIXTURE_DIR / "rules.json").read_text())
+
+        blocks = convert_page(xhtml, ruleset)
+
+        for block in blocks:
+            assert "type" in block, f"Block missing 'type': {block}"
+            block_type = block["type"]
+            assert block_type in block, f"Block missing content key '{block_type}': {block}"
+
+    def test_page1_contains_heading_and_list_blocks(self) -> None:
+        xhtml = (FIXTURE_DIR / "page1.xhtml").read_text()
+        ruleset = FinalRuleset.model_validate_json((FIXTURE_DIR / "rules.json").read_text())
+
+        blocks = convert_page(xhtml, ruleset)
+
+        block_types = {b["type"] for b in blocks}
+        assert any(t.startswith("heading") for t in block_types), "Expected at least one heading"
+        assert "bulleted_list_item" in block_types, "Expected bulleted list items from page1.xhtml"
+
+    def test_page2_produces_nonempty_blocks(self) -> None:
+        xhtml = (FIXTURE_DIR / "page2.xhtml").read_text()
+        ruleset = FinalRuleset.model_validate_json((FIXTURE_DIR / "rules.json").read_text())
+
+        blocks = convert_page(xhtml, ruleset)
+
+        assert len(blocks) > 0
+
+    def test_page2_contains_numbered_list_items(self) -> None:
+        xhtml = (FIXTURE_DIR / "page2.xhtml").read_text()
+        ruleset = FinalRuleset.model_validate_json((FIXTURE_DIR / "rules.json").read_text())
+
+        blocks = convert_page(xhtml, ruleset)
+
+        list_items = [b for b in blocks if b["type"] == "numbered_list_item"]
+        assert list_items, "Expected numbered list items in page2.xhtml"
+
+
+@pytest.mark.integration
+class TestMigrateDryRun:
+    """Steps 4-5: mock NotionClientWrapper.create_page and invoke the migrate CLI."""
+
+    @patch("confluence_to_notion.cli.NotionClientWrapper")
+    @patch("confluence_to_notion.cli._load_settings")
+    def test_create_page_called_once_per_xhtml(
+        self,
+        mock_load_settings: Any,
+        mock_notion_cls: Any,
+        tmp_path: Path,
+    ) -> None:
+        """create_page is called exactly once for each XHTML file in the input dir."""
+        parent_id = "test-parent-page-id"
+        _setup_settings(mock_load_settings, parent_id)
+        mock_client = _setup_notion_client(mock_notion_cls)
+
+        input_dir = _copy_fixtures(tmp_path, "page1.xhtml", "page2.xhtml")
+        rules_file = _copy_rules(tmp_path)
+
+        args = [
+            "migrate", "--rules", str(rules_file), "--input", str(input_dir), "--target", parent_id
+        ]
+        result = runner.invoke(app, args)
+
+        assert result.exit_code == 0, result.output
+        assert mock_client.create_page.call_count == 2
+
+    @patch("confluence_to_notion.cli.NotionClientWrapper")
+    @patch("confluence_to_notion.cli._load_settings")
+    def test_create_page_uses_correct_parent_id(
+        self,
+        mock_load_settings: Any,
+        mock_notion_cls: Any,
+        tmp_path: Path,
+    ) -> None:
+        """Each create_page call receives the parent_id from --target."""
+        parent_id = "expected-parent-page-id"
+        _setup_settings(mock_load_settings, parent_id)
+        mock_client = _setup_notion_client(mock_notion_cls)
+
+        input_dir = _copy_fixtures(tmp_path, "page1.xhtml")
+        rules_file = _copy_rules(tmp_path)
+
+        args = [
+            "migrate", "--rules", str(rules_file), "--input", str(input_dir), "--target", parent_id
+        ]
+        result = runner.invoke(app, args)
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = mock_client.create_page.call_args.kwargs
+        assert call_kwargs["parent_id"] == parent_id
+
+    @patch("confluence_to_notion.cli.NotionClientWrapper")
+    @patch("confluence_to_notion.cli._load_settings")
+    def test_create_page_receives_nonempty_valid_blocks(
+        self,
+        mock_load_settings: Any,
+        mock_notion_cls: Any,
+        tmp_path: Path,
+    ) -> None:
+        """Blocks passed to create_page are non-empty and have valid Notion structure."""
+        parent_id = "test-parent-id"
+        _setup_settings(mock_load_settings, parent_id)
+        mock_client = _setup_notion_client(mock_notion_cls)
+
+        input_dir = _copy_fixtures(tmp_path, "page1.xhtml")
+        rules_file = _copy_rules(tmp_path)
+
+        args = [
+            "migrate", "--rules", str(rules_file), "--input", str(input_dir), "--target", parent_id
+        ]
+        result = runner.invoke(app, args)
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = mock_client.create_page.call_args.kwargs
+        blocks: list[dict[str, Any]] = call_kwargs["blocks"]
+        assert blocks, "Blocks passed to create_page must be non-empty"
+        for block in blocks:
+            assert "type" in block, f"Block missing 'type': {block}"
+            block_type = block["type"]
+            assert block_type in block, f"Block missing content key '{block_type}': {block}"
+
+    @patch("confluence_to_notion.cli.NotionClientWrapper")
+    @patch("confluence_to_notion.cli._load_settings")
+    def test_create_page_title_extracted_from_h1(
+        self,
+        mock_load_settings: Any,
+        mock_notion_cls: Any,
+        tmp_path: Path,
+    ) -> None:
+        """Title passed to create_page is extracted from the first <h1> of page1.xhtml."""
+        parent_id = "test-parent-id"
+        _setup_settings(mock_load_settings, parent_id)
+        mock_client = _setup_notion_client(mock_notion_cls)
+
+        input_dir = _copy_fixtures(tmp_path, "page1.xhtml")
+        rules_file = _copy_rules(tmp_path)
+
+        args = [
+            "migrate", "--rules", str(rules_file), "--input", str(input_dir), "--target", parent_id
+        ]
+        result = runner.invoke(app, args)
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = mock_client.create_page.call_args.kwargs
+        assert call_kwargs["title"] == "Integration Test Page 1"
+
+
+# --- Helpers ---
+
+
+def _setup_settings(mock_load_settings: Any, parent_id: str) -> Any:
+    settings = mock_load_settings.return_value
+    settings.notion_root_page_id = parent_id
+    settings.require_notion.return_value = None
+    settings.notion_api_token = "ntn_fake"
+    return settings
+
+
+def _setup_notion_client(mock_notion_cls: Any) -> Any:
+    mock_client = mock_notion_cls.return_value
+    mock_client.create_page = AsyncMock(return_value=NotionPageResult(page_id="created-id"))
+    return mock_client
+
+
+def _copy_fixtures(tmp_path: Path, *filenames: str) -> Path:
+    input_dir = tmp_path / "input"
+    input_dir.mkdir(exist_ok=True)
+    for fname in filenames:
+        shutil.copy(FIXTURE_DIR / fname, input_dir / fname)
+    return input_dir
+
+
+def _copy_rules(tmp_path: Path) -> Path:
+    rules_file = tmp_path / "rules.json"
+    shutil.copy(FIXTURE_DIR / "rules.json", rules_file)
+    return rules_file


### PR DESCRIPTION
## Summary

- fixture 기반 E2E 통합 테스트 추가 (2개 XHTML 페이지 + 최소 rules.json)
- `convert_page()` 직접 호출 + `cli migrate` dry-run 파이프라인 검증
- integration marker 등록 및 `addopts` 설정으로 기본 pytest에서 제외
- 외부 API 의존 없이 CI에서 실행 가능

Closes #20

## Pipeline

Generated by `scripts/develop.sh 20` — Plan, Implement, Test, Review, Fix, Verify, PR.

## Artifacts

- Plan: `output/dev/plan.json`
- Review: `output/dev/review.json`

## Test plan

- [x] `uv run ruff check src/ tests/` passes
- [x] `uv run mypy src/` passes
- [x] `uv run pytest` passes (166 unit, 9 integration deselected)
- [x] `uv run pytest -m integration` passes (9 tests)
- [ ] Manual review of changes against issue requirements

https://claude.ai/code/session_01GHKEhW1CcLDLCHCEdwQmbP