### PR TITLE
feat: Day 5 polish — rate limit, CI, error handling, metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Lint (ruff)
+        run: uv run ruff check src/ tests/
+
+      - name: Type check (mypy)
+        run: uv run mypy src/
+
+      - name: Test (pytest)
+        run: uv run pytest --tb=short
+
+  eval:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check for agent prompt changes
+        id: prompt-check
+        run: |
+          if git diff HEAD~1 --name-only -- '.claude/agents/' | grep -q .; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install uv
+        if: steps.prompt-check.outputs.changed == 'true'
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        if: steps.prompt-check.outputs.changed == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        if: steps.prompt-check.outputs.changed == 'true'
+        run: uv sync --dev
+
+      - name: Validate agent output schemas
+        if: steps.prompt-check.outputs.changed == 'true'
+        run: |
+          echo "Agent prompts changed — running schema validation"
+          uv run cli validate-output tests/fixtures/eval/expected_patterns.json discovery
+          uv run cli validate-output tests/fixtures/eval/expected_proposals.json proposer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Check for agent prompt changes
         id: prompt-check
         run: |
-          if git diff HEAD~1 --name-only -- '.claude/agents/' | grep -q .; then
+          if git diff ${{ github.event.pull_request.base.sha }}...HEAD --name-only -- '.claude/agents/' | grep -q .; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ Derived rules are applied by a deterministic converter to migrate wiki pages whi
 - **CRITICAL**: Before any agent prompt change, run `scripts/run-eval.sh`
 - Conventional commits: `feat|fix|docs|refactor|test|chore`
 - Squash merge only
+- PR 생성 시 관련 이슈를 `Closes #N` 키워드로 본문에 연결 (머지 시 자동 클로즈)
 
 ## Additional Rules
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,20 @@ version = "0.1.0"
 description = "Auto-discover Confluence → Notion transformation rules using a multi-agent pipeline"
 license = "MIT"
 requires-python = ">=3.11"
+authors = [
+    { name = "minseon", email = "let.sunny.day@gmail.com" },
+]
+keywords = ["confluence", "notion", "migration", "wiki", "converter"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Office/Business",
+    "Topic :: Text Processing :: Markup",
+    "Typing :: Typed",
+]
 dependencies = [
     "httpx>=0.27.0",
     "notion-client>=2.2.0",
@@ -22,6 +36,10 @@ dev = [
     "ruff>=0.8.0",
     "mypy>=1.13.0",
 ]
+
+[project.urls]
+Repository = "https://github.com/let-sunny/confluence-to-notion"
+Issues = "https://github.com/let-sunny/confluence-to-notion/issues"
 
 [project.scripts]
 cli = "confluence_to_notion.cli:app"

--- a/scripts/discover.sh
+++ b/scripts/discover.sh
@@ -25,6 +25,16 @@ done
 
 mkdir -p "$OUTPUT_DIR"
 
+check_output() {
+    local file="$1"
+    local step_name="$2"
+    if [[ ! -f "$file" ]]; then
+        echo "[ERROR] Step '$step_name' did not produce expected output: $file"
+        echo "        Check the log: ${OUTPUT_DIR}/${step_name}.log"
+        exit 1
+    fi
+}
+
 run_step() {
     local step_num="$1"
     local step_name="$2"
@@ -37,9 +47,13 @@ run_step() {
     fi
 
     echo "==> Step $step_num: $step_name"
-    claude -p "$prompt" \
+    if ! claude -p "$prompt" \
         --allowedTools "Read,Write,Bash,Glob,Grep,Edit" \
-        2>&1 | tee "$OUTPUT_DIR/${step_name}.log"
+        2>&1 | tee "$OUTPUT_DIR/${step_name}.log"; then
+        echo "[ERROR] Step $step_num ($step_name) failed."
+        echo "        Log: ${OUTPUT_DIR}/${step_name}.log"
+        exit 1
+    fi
 
     echo "    Done: $OUTPUT_DIR/"
 }
@@ -66,6 +80,10 @@ run_step 1 "pattern-discovery" \
 
 Analyze the XHTML files in ${SAMPLES_DIR} and write discovered patterns to ${OUTPUT_DIR}/patterns.json"
 
+if [[ "$FROM_STEP" -le 1 ]]; then
+    check_output "${OUTPUT_DIR}/patterns.json" "pattern-discovery"
+fi
+
 # Step 2: Rule Proposer
 run_step 2 "rule-proposer" \
     ".claude/agents/discover/rule-proposer.md" \
@@ -73,21 +91,35 @@ run_step 2 "rule-proposer" \
 
 Read ${OUTPUT_DIR}/patterns.json and propose transformation rules. Write to ${OUTPUT_DIR}/proposals.json"
 
+if [[ "$FROM_STEP" -le 2 ]]; then
+    check_output "${OUTPUT_DIR}/proposals.json" "rule-proposer"
+fi
+
 # Step 3: Finalize rules (2-agent shortcut: proposals → rules.json)
 # When critic/arbitrator agents are added, this step will be replaced by steps 3+4.
 if [[ "$FROM_STEP" -le 3 ]]; then
     echo "==> Step 3: finalize (proposals → rules.json)"
-    uv run cli finalize "${OUTPUT_DIR}/proposals.json" --out "${OUTPUT_DIR}/rules.json"
+    if ! uv run cli finalize "${OUTPUT_DIR}/proposals.json" --out "${OUTPUT_DIR}/rules.json"; then
+        echo "[ERROR] Step 3 (finalize) failed."
+        echo "        Input: ${OUTPUT_DIR}/proposals.json"
+        exit 1
+    fi
+    check_output "${OUTPUT_DIR}/rules.json" "finalize"
     echo "    Done: ${OUTPUT_DIR}/rules.json"
 fi
 
 # Step 4: Convert XHTML → Notion blocks
 if [[ "$FROM_STEP" -le 4 ]]; then
     echo "==> Step 4: convert (XHTML → Notion blocks)"
-    uv run cli convert \
+    if ! uv run cli convert \
         --rules "${OUTPUT_DIR}/rules.json" \
         --input "${SAMPLES_DIR}" \
-        --output "${OUTPUT_DIR}/converted"
+        --output "${OUTPUT_DIR}/converted"; then
+        echo "[ERROR] Step 4 (convert) failed."
+        echo "        Rules: ${OUTPUT_DIR}/rules.json"
+        echo "        Input: ${SAMPLES_DIR}"
+        exit 1
+    fi
     echo "    Done: ${OUTPUT_DIR}/converted/"
 fi
 

--- a/scripts/discover.sh
+++ b/scripts/discover.sh
@@ -38,8 +38,7 @@ check_output() {
 run_step() {
     local step_num="$1"
     local step_name="$2"
-    local agent_file="$3"
-    local prompt="$4"
+    local prompt="$3"
 
     if [[ "$step_num" -lt "$FROM_STEP" ]]; then
         echo "==> Step $step_num: $step_name (skipped, --from $FROM_STEP)"
@@ -75,7 +74,6 @@ fi
 
 # Step 1: Pattern Discovery
 run_step 1 "pattern-discovery" \
-    ".claude/agents/discover/pattern-discovery.md" \
     "$(cat .claude/agents/discover/pattern-discovery.md)
 
 Analyze the XHTML files in ${SAMPLES_DIR} and write discovered patterns to ${OUTPUT_DIR}/patterns.json"
@@ -86,7 +84,6 @@ fi
 
 # Step 2: Rule Proposer
 run_step 2 "rule-proposer" \
-    ".claude/agents/discover/rule-proposer.md" \
     "$(cat .claude/agents/discover/rule-proposer.md)
 
 Read ${OUTPUT_DIR}/patterns.json and propose transformation rules. Write to ${OUTPUT_DIR}/proposals.json"

--- a/src/confluence_to_notion/notion/client.py
+++ b/src/confluence_to_notion/notion/client.py
@@ -1,6 +1,8 @@
 """Async wrapper over the official notion-client SDK."""
 
+import asyncio
 import logging
+import random
 from typing import Any
 
 from notion_client import APIResponseError, AsyncClient
@@ -9,6 +11,9 @@ from confluence_to_notion.config import Settings
 from confluence_to_notion.notion.schemas import NotionPageResult
 
 logger = logging.getLogger(__name__)
+
+MAX_RETRIES = 5
+BASE_DELAY = 1.0  # seconds
 
 
 class NotionClientWrapper:
@@ -36,10 +41,31 @@ class NotionClientWrapper:
     async def create_page(
         self, parent_id: str, title: str, blocks: list[dict[str, Any]]
     ) -> NotionPageResult:
-        """Create a page under the given parent and return a NotionPageResult."""
-        resp: Any = await self._client.pages.create(
-            parent={"page_id": parent_id},
-            properties={"title": [{"text": {"content": title}}]},
-            children=blocks,
-        )
-        return NotionPageResult(page_id=resp["id"])
+        """Create a page under the given parent and return a NotionPageResult.
+
+        Retries up to MAX_RETRIES times on 429 (rate limit) with exponential backoff.
+        """
+        last_error: APIResponseError | None = None
+        for attempt in range(MAX_RETRIES + 1):
+            try:
+                resp: Any = await self._client.pages.create(
+                    parent={"page_id": parent_id},
+                    properties={"title": [{"text": {"content": title}}]},
+                    children=blocks,
+                )
+                return NotionPageResult(page_id=resp["id"])
+            except APIResponseError as e:
+                if e.status != 429 or attempt == MAX_RETRIES:
+                    raise
+                last_error = e
+                delay = BASE_DELAY * (2**attempt) + random.uniform(0, 1)
+                logger.warning(
+                    "Notion rate limited (429), retry %d/%d in %.1fs",
+                    attempt + 1,
+                    MAX_RETRIES,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+
+        assert last_error is not None  # unreachable, satisfies mypy
+        raise last_error

--- a/tests/unit/test_notion_client.py
+++ b/tests/unit/test_notion_client.py
@@ -89,3 +89,93 @@ async def test_create_page_missing_id(notion_client: NotionClientWrapper) -> Non
             title="Test",
             blocks=[],
         )
+
+
+# --- Rate limit retry tests ---
+
+
+async def test_create_page_retries_on_429(notion_client: NotionClientWrapper) -> None:
+    """429 rate limit triggers retry, succeeds on second attempt."""
+    rate_limit_error = _make_api_error(429, "Rate limited")
+    rate_limit_error.status = 429
+    success_response: dict[str, Any] = {"id": "page-after-retry", "object": "page"}
+    mock_create = AsyncMock(side_effect=[rate_limit_error, success_response])
+    with (
+        patch.object(notion_client._client.pages, "create", mock_create),
+        patch("confluence_to_notion.notion.client.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        result = await notion_client.create_page(
+            parent_id="parent-123",
+            title="Retry Test",
+            blocks=[],
+        )
+    assert result.page_id == "page-after-retry"
+    assert mock_create.call_count == 2
+
+
+async def test_create_page_raises_after_max_retries(
+    notion_client: NotionClientWrapper,
+) -> None:
+    """Raises APIResponseError after exhausting all retries on persistent 429."""
+    rate_limit_error = _make_api_error(429, "Rate limited")
+    rate_limit_error.status = 429
+    mock_create = AsyncMock(side_effect=rate_limit_error)
+    with (
+        patch.object(notion_client._client.pages, "create", mock_create),
+        patch("confluence_to_notion.notion.client.asyncio.sleep", new_callable=AsyncMock),
+        pytest.raises(APIResponseError),
+    ):
+        await notion_client.create_page(
+            parent_id="parent-123",
+            title="Max Retry Test",
+            blocks=[],
+        )
+    # 1 initial + 5 retries = 6 calls
+    assert mock_create.call_count == 6
+
+
+async def test_create_page_no_retry_on_other_errors(
+    notion_client: NotionClientWrapper,
+) -> None:
+    """Non-429 API errors are raised immediately without retry."""
+    auth_error = _make_api_error(401, "Unauthorized")
+    auth_error.status = 401
+    mock_create = AsyncMock(side_effect=auth_error)
+    with (
+        patch.object(notion_client._client.pages, "create", mock_create),
+        pytest.raises(APIResponseError),
+    ):
+        await notion_client.create_page(
+            parent_id="parent-123",
+            title="No Retry Test",
+            blocks=[],
+        )
+    assert mock_create.call_count == 1
+
+
+async def test_create_page_retry_uses_backoff(
+    notion_client: NotionClientWrapper,
+) -> None:
+    """Verify exponential backoff delays increase between retries."""
+    rate_limit_error = _make_api_error(429, "Rate limited")
+    rate_limit_error.status = 429
+    success_response: dict[str, Any] = {"id": "page-id", "object": "page"}
+    mock_create = AsyncMock(
+        side_effect=[rate_limit_error, rate_limit_error, rate_limit_error, success_response]
+    )
+    mock_sleep = AsyncMock()
+    with (
+        patch.object(notion_client._client.pages, "create", mock_create),
+        patch("confluence_to_notion.notion.client.asyncio.sleep", mock_sleep),
+    ):
+        await notion_client.create_page(
+            parent_id="parent-123",
+            title="Backoff Test",
+            blocks=[],
+        )
+    assert mock_sleep.call_count == 3
+    delays = [call.args[0] for call in mock_sleep.call_args_list]
+    # Each delay should be larger than the previous (exponential backoff + jitter)
+    # Base delays: 1, 2, 4 — with jitter they should still be increasing
+    for i in range(1, len(delays)):
+        assert delays[i] > delays[i - 1] * 0.5, f"Delay {i} not increasing: {delays}"


### PR DESCRIPTION
## Summary

#6 을 4개 서브이슈로 분할하여 구현한 PR입니다.

- **#28** Notion API 429 rate limit retry with exponential backoff (5회, 지터 포함)
- **#29** GitHub Actions CI 워크플로우 (ruff + mypy + pytest on PR, 프롬프트 변경 시 eval)
- **#30** discover.sh 에러 핸들링 강화 (실패 메시지 + 로그 경로 + output 검증)
- **#31** pyproject.toml 메타데이터 추가 (authors, urls, classifiers, keywords)
- CLAUDE.md에 PR-이슈 연결 규칙 추가

Closes #28
Closes #29
Closes #30
Closes #31

## Test plan

- [x] `uv run pytest` — 170 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run mypy src/` — clean
- [ ] CI 워크플로우 실행 확인 (이 PR에서 자동 트리거)

https://claude.ai/code/session_01T7KrHYzDWHFK2F7mgco4Ln