### PR TITLE
feat: resolution store + resolver framework for hybrid pipeline

### DIFF
--- a/src/confluence_to_notion/cli.py
+++ b/src/confluence_to_notion/cli.py
@@ -252,11 +252,15 @@ def convert(
 
     for xhtml_path in xhtml_files:
         xhtml = xhtml_path.read_text()
-        blocks = convert_page(xhtml, ruleset)
+        result = convert_page(xhtml, ruleset, page_id=xhtml_path.stem)
         out_file = output_dir / f"{xhtml_path.stem}.json"
-        out_file.write_text(json.dumps(blocks, indent=2, ensure_ascii=False) + "\n")
+        out_file.write_text(
+            json.dumps(result.blocks, indent=2, ensure_ascii=False) + "\n"
+        )
         converted += 1
-        console.print(f"  {xhtml_path.name} → {out_file.name} ({len(blocks)} blocks)")
+        console.print(
+            f"  {xhtml_path.name} → {out_file.name} ({len(result.blocks)} blocks)"
+        )
 
     console.print(f"[green]Converted {converted} pages → {output_dir}[/green]")
 
@@ -329,11 +333,11 @@ def migrate(
             for xhtml_path in xhtml_files:
                 try:
                     xhtml = xhtml_path.read_text()
-                    blocks = convert_page(xhtml, ruleset)
-                    title = _extract_title(blocks, fallback=xhtml_path.stem)
+                    result = convert_page(xhtml, ruleset, page_id=xhtml_path.stem)
+                    title = _extract_title(result.blocks, fallback=xhtml_path.stem)
 
                     await client.create_page(
-                        parent_id=parent_id, title=title, blocks=blocks
+                        parent_id=parent_id, title=title, blocks=result.blocks
                     )
                     succeeded += 1
                     console.print(f"  [green]{xhtml_path.name}[/green] → {title}")

--- a/src/confluence_to_notion/converter/converter.py
+++ b/src/confluence_to_notion/converter/converter.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 import logging
 import re
 import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
 from typing import Any
 
 from confluence_to_notion.agents.schemas import FinalRuleset
+from confluence_to_notion.converter.schemas import ConversionResult, UnresolvedItem
 
 logger = logging.getLogger(__name__)
 
@@ -48,17 +50,43 @@ _HEADING_MAP: dict[str, str] = {
 }
 
 
-def convert_page(xhtml: str, ruleset: FinalRuleset) -> list[dict[str, Any]]:
-    """Convert a Confluence XHTML page to a list of Notion blocks."""
+@dataclass
+class _ConversionContext:
+    """Internal state threaded through all conversion functions."""
+
+    enabled_ids: set[str]
+    page_id: str
+    unresolved: list[UnresolvedItem] = field(default_factory=list)
+
+
+def convert_page(
+    xhtml: str,
+    ruleset: FinalRuleset,
+    *,
+    page_id: str = "",
+) -> ConversionResult:
+    """Convert a Confluence XHTML page to a list of Notion blocks.
+
+    Args:
+        xhtml: Confluence XHTML storage body.
+        ruleset: Rules controlling which macros/elements to convert.
+        page_id: Confluence page ID (used to tag unresolved items).
+
+    Returns:
+        ConversionResult with blocks and any unresolved items.
+    """
     xhtml = xhtml.strip()
     if not xhtml:
-        return []
+        return ConversionResult()
 
-    enabled_ids = {r.rule_id for r in ruleset.enabled_rules}
+    ctx = _ConversionContext(
+        enabled_ids={r.rule_id for r in ruleset.enabled_rules},
+        page_id=page_id,
+    )
     xml_str = _XHTML_WRAPPER.format(xhtml)
     root = ET.fromstring(xml_str)
 
-    blocks = _convert_children(root, enabled_ids, block_type=None)
+    blocks = _convert_children(root, ctx, block_type=None)
 
     input_size = len(xhtml.encode())
     if len(blocks) > LARGE_PAGE_BLOCK_THRESHOLD or input_size > LARGE_PAGE_SIZE_THRESHOLD:
@@ -68,12 +96,12 @@ def convert_page(xhtml: str, ruleset: FinalRuleset) -> list[dict[str, Any]]:
             input_size / 1024,
         )
 
-    return blocks
+    return ConversionResult(blocks=blocks, unresolved=ctx.unresolved)
 
 
 def _convert_children(
     parent: ET.Element,
-    enabled_ids: set[str],
+    ctx: _ConversionContext,
     block_type: str | None,
 ) -> list[dict[str, Any]]:
     """Convert child elements of a parent node to Notion blocks."""
@@ -84,7 +112,7 @@ def _convert_children(
         blocks.append(_paragraph([_text_seg(parent.text.strip())]))
 
     for child in parent:
-        child_blocks = _convert_element(child, enabled_ids)
+        child_blocks = _convert_element(child, ctx)
         blocks.extend(child_blocks)
 
         # Handle tail text after elements
@@ -96,14 +124,14 @@ def _convert_children(
 
 def _convert_element(
     elem: ET.Element,
-    enabled_ids: set[str],
+    ctx: _ConversionContext,
 ) -> list[dict[str, Any]]:
     """Convert a single element to Notion block(s)."""
     tag = _local_tag(elem)
 
     # --- Headings ---
     if tag in _HEADING_MAP:
-        rt = _extract_rich_text(elem, enabled_ids)
+        rt = _extract_rich_text(elem, ctx)
         if not rt:
             return []
         heading_type = _HEADING_MAP[tag]
@@ -112,17 +140,17 @@ def _convert_element(
     # --- Paragraphs ---
     if tag == "p":
         # Promote block-level macros wrapped in <p> (common in Confluence XHTML)
-        promoted = _try_promote_block_macro(elem, enabled_ids)
+        promoted = _try_promote_block_macro(elem, ctx)
         if promoted is not None:
             return promoted
-        rt = _extract_rich_text(elem, enabled_ids)
+        rt = _extract_rich_text(elem, ctx)
         if not rt:
             return []
         return [_paragraph(rt)]
 
     # --- Lists ---
     if tag in ("ul", "ol"):
-        return _convert_list(elem, tag, enabled_ids)
+        return _convert_list(elem, tag, ctx)
 
     # --- Preformatted ---
     if tag == "pre":
@@ -130,18 +158,18 @@ def _convert_element(
 
     # --- Confluence structured macro ---
     if tag == "structured-macro":
-        return _convert_macro(elem, enabled_ids)
+        return _convert_macro(elem, ctx)
 
     # --- Confluence image ---
     if tag == "image":
-        return _convert_ac_image(elem, enabled_ids)
+        return _convert_ac_image(elem, ctx)
 
     # --- Styled span (heading substitute) ---
     if tag == "span":
         return _convert_span(elem)
 
     # --- Fallback: recurse into children ---
-    return _convert_children(elem, enabled_ids, block_type=None)
+    return _convert_children(elem, ctx, block_type=None)
 
 
 # --- Rich text extraction ---
@@ -149,7 +177,7 @@ def _convert_element(
 
 def _extract_rich_text(
     elem: ET.Element,
-    enabled_ids: set[str],
+    ctx: _ConversionContext,
 ) -> list[dict[str, Any]]:
     """Extract Notion rich_text segments from an inline element."""
     segments: list[dict[str, Any]] = []
@@ -182,7 +210,7 @@ def _extract_rich_text(
 
         elif tag == "link":
             # ac:link — Confluence internal page link
-            segments.extend(_extract_ac_link_rich_text(child))
+            segments.extend(_extract_ac_link_rich_text(child, ctx))
 
         elif tag == "br":
             pass  # skip line breaks in inline context
@@ -195,7 +223,7 @@ def _extract_rich_text(
 
         elif tag == "structured-macro":
             # Inline macro (e.g., JIRA reference within a paragraph)
-            inline_segs = _extract_inline_macro(child, enabled_ids)
+            inline_segs = _extract_inline_macro(child, ctx)
             segments.extend(inline_segs)
 
         elif tag == "image":
@@ -213,7 +241,10 @@ def _extract_rich_text(
     return segments
 
 
-def _extract_ac_link_rich_text(elem: ET.Element) -> list[dict[str, Any]]:
+def _extract_ac_link_rich_text(
+    elem: ET.Element,
+    ctx: _ConversionContext,
+) -> list[dict[str, Any]]:
     """Extract rich_text from an ac:link element."""
     page_title = ""
     display_text = ""
@@ -229,17 +260,27 @@ def _extract_ac_link_rich_text(elem: ET.Element) -> list[dict[str, Any]]:
 
     text = display_text or page_title or "link"
     url = f"https://notion.so/placeholder/{page_title}" if page_title else "#"
+
+    if page_title:
+        ctx.unresolved.append(
+            UnresolvedItem(
+                kind="page_link",
+                identifier=page_title,
+                source_page_id=ctx.page_id,
+            )
+        )
+
     return [_text_seg(text, link=url)]
 
 
 def _extract_inline_macro(
     elem: ET.Element,
-    enabled_ids: set[str],
+    ctx: _ConversionContext,
 ) -> list[dict[str, Any]]:
     """Extract rich_text segments from an inline macro (e.g., JIRA)."""
     macro_name = _get_macro_name(elem)
 
-    if macro_name == "jira" and "rule:macro:jira" in enabled_ids:
+    if macro_name == "jira" and "rule:macro:jira" in ctx.enabled_ids:
         return _jira_rich_text(elem)
 
     # Unknown inline macro: extract any text
@@ -255,7 +296,7 @@ _BLOCK_MACROS = {"toc", "info", "note", "warning", "tip", "code", "noformat", "e
 
 def _try_promote_block_macro(
     p_elem: ET.Element,
-    enabled_ids: set[str],
+    ctx: _ConversionContext,
 ) -> list[dict[str, Any]] | None:
     """If a <p> contains only a single block-level macro, promote it."""
     has_text = bool(p_elem.text and p_elem.text.strip())
@@ -274,42 +315,50 @@ def _try_promote_block_macro(
 
     macro_name = _get_macro_name(child)
     if macro_name in _BLOCK_MACROS:
-        return _convert_macro(child, enabled_ids)
+        return _convert_macro(child, ctx)
 
     return None
 
 
 def _convert_macro(
     elem: ET.Element,
-    enabled_ids: set[str],
+    ctx: _ConversionContext,
 ) -> list[dict[str, Any]]:
     """Convert an ac:structured-macro to Notion block(s)."""
     macro_name = _get_macro_name(elem)
 
     # TOC
-    if macro_name == "toc" and "rule:macro:toc" in enabled_ids:
+    if macro_name == "toc" and "rule:macro:toc" in ctx.enabled_ids:
         return [{"type": "table_of_contents", "table_of_contents": {"color": "default"}}]
 
     # JIRA
-    if macro_name == "jira" and "rule:macro:jira" in enabled_ids:
+    if macro_name == "jira" and "rule:macro:jira" in ctx.enabled_ids:
         return [_paragraph(_jira_rich_text(elem))]
 
     # Code / noformat
-    if macro_name in ("code", "noformat") and "rule:macro:code" in enabled_ids:
+    if macro_name in ("code", "noformat") and "rule:macro:code" in ctx.enabled_ids:
         return _convert_code_macro(elem)
 
     # Expand (toggle)
-    if macro_name == "expand" and "rule:macro:expand" in enabled_ids:
-        return _convert_expand_macro(elem, enabled_ids)
+    if macro_name == "expand" and "rule:macro:expand" in ctx.enabled_ids:
+        return _convert_expand_macro(elem, ctx)
 
     # Info/Note/Warning/Tip panels
-    if macro_name in _PANEL_STYLES and f"rule:macro:{macro_name}" in enabled_ids:
-        return _convert_panel_macro(elem, macro_name, enabled_ids)
+    if macro_name in _PANEL_STYLES and f"rule:macro:{macro_name}" in ctx.enabled_ids:
+        return _convert_panel_macro(elem, macro_name, ctx)
     # Also handle panels without explicit rules (built-in behavior for info-family macros)
     if macro_name in _PANEL_STYLES:
-        return _convert_panel_macro(elem, macro_name, enabled_ids)
+        return _convert_panel_macro(elem, macro_name, ctx)
 
     # Fallback: render as paragraph with the macro's text content
+    ctx.unresolved.append(
+        UnresolvedItem(
+            kind="macro",
+            identifier=macro_name,
+            source_page_id=ctx.page_id,
+            context_xhtml=ET.tostring(elem, encoding="unicode"),
+        )
+    )
     text = _get_all_text(elem).strip()
     if text:
         return [_paragraph([_text_seg(f"[{macro_name}] {text}")])]
@@ -319,7 +368,7 @@ def _convert_macro(
 def _convert_panel_macro(
     elem: ET.Element,
     macro_name: str,
-    enabled_ids: set[str],
+    ctx: _ConversionContext,
 ) -> list[dict[str, Any]]:
     """Convert info/note/warning/tip macro to a Notion callout block."""
     emoji, color = _PANEL_STYLES[macro_name]
@@ -333,12 +382,12 @@ def _convert_panel_macro(
                 inner_tag = _local_tag(inner)
                 if inner_tag == "p" and not first_p_done:
                     # First <p> becomes the callout's rich_text
-                    rt = _extract_rich_text(inner, enabled_ids)
+                    rt = _extract_rich_text(inner, ctx)
                     rich_text.extend(rt)
                     first_p_done = True
                 else:
                     # Subsequent elements become nested children
-                    child_blocks = _convert_element(inner, enabled_ids)
+                    child_blocks = _convert_element(inner, ctx)
                     children.extend(child_blocks)
 
     callout: dict[str, Any] = {
@@ -375,7 +424,7 @@ def _convert_code_macro(elem: ET.Element) -> list[dict[str, Any]]:
 
 def _convert_expand_macro(
     elem: ET.Element,
-    enabled_ids: set[str],
+    ctx: _ConversionContext,
 ) -> list[dict[str, Any]]:
     """Convert expand macro to a Notion toggle block."""
     params = _get_macro_params(elem)
@@ -385,7 +434,7 @@ def _convert_expand_macro(
     for child in elem:
         if _local_tag(child) == "rich-text-body":
             for inner in child:
-                child_blocks = _convert_element(inner, enabled_ids)
+                child_blocks = _convert_element(inner, ctx)
                 children.extend(child_blocks)
 
     toggle: dict[str, Any] = {
@@ -407,10 +456,10 @@ def _jira_rich_text(elem: ET.Element) -> list[dict[str, Any]]:
 
 def _convert_ac_image(
     elem: ET.Element,
-    enabled_ids: set[str],
+    ctx: _ConversionContext,
 ) -> list[dict[str, Any]]:
     """Convert an ac:image element to a Notion image block."""
-    if "rule:element:ac-image" not in enabled_ids:
+    if "rule:element:ac-image" not in ctx.enabled_ids:
         return [_paragraph([_text_seg("[image]")])]
 
     filename = ""
@@ -463,7 +512,7 @@ def _convert_pre(elem: ET.Element) -> list[dict[str, Any]]:
 def _convert_list(
     elem: ET.Element,
     list_tag: str,
-    enabled_ids: set[str],
+    ctx: _ConversionContext,
 ) -> list[dict[str, Any]]:
     """Convert a <ul> or <ol> to Notion list items."""
     block_type = "bulleted_list_item" if list_tag == "ul" else "numbered_list_item"
@@ -473,8 +522,8 @@ def _convert_list(
         if _local_tag(child) != "li":
             continue
 
-        rt = _extract_rich_text_from_li(child, enabled_ids)
-        children = _extract_nested_list(child, enabled_ids)
+        rt = _extract_rich_text_from_li(child, ctx)
+        children = _extract_nested_list(child, ctx)
 
         block: dict[str, Any] = {
             "type": block_type,
@@ -489,7 +538,7 @@ def _convert_list(
 
 def _extract_rich_text_from_li(
     li: ET.Element,
-    enabled_ids: set[str],
+    ctx: _ConversionContext,
 ) -> list[dict[str, Any]]:
     """Extract rich_text from a <li>, ignoring nested lists."""
     segments: list[dict[str, Any]] = []
@@ -503,7 +552,7 @@ def _extract_rich_text_from_li(
             continue  # nested list handled separately
 
         if tag == "p":
-            rt = _extract_rich_text(child, enabled_ids)
+            rt = _extract_rich_text(child, ctx)
             segments.extend(rt)
         elif tag == "code":
             segments.append(_text_seg(_get_all_text(child), code=True))
@@ -515,9 +564,9 @@ def _extract_rich_text_from_li(
             text = _get_all_text(child) or child.get("href", "")
             segments.append(_text_seg(text, link=child.get("href", "")))
         elif tag == "link":
-            segments.extend(_extract_ac_link_rich_text(child))
+            segments.extend(_extract_ac_link_rich_text(child, ctx))
         elif tag == "structured-macro":
-            segments.extend(_extract_inline_macro(child, enabled_ids))
+            segments.extend(_extract_inline_macro(child, ctx))
         else:
             text = _get_all_text(child)
             if text:
@@ -531,14 +580,14 @@ def _extract_rich_text_from_li(
 
 def _extract_nested_list(
     li: ET.Element,
-    enabled_ids: set[str],
+    ctx: _ConversionContext,
 ) -> list[dict[str, Any]]:
     """Extract nested <ul>/<ol> from a <li> element."""
     children: list[dict[str, Any]] = []
     for child in li:
         tag = _local_tag(child)
         if tag in ("ul", "ol"):
-            children.extend(_convert_list(child, tag, enabled_ids))
+            children.extend(_convert_list(child, tag, ctx))
     return children
 
 

--- a/src/confluence_to_notion/converter/converter.py
+++ b/src/confluence_to_notion/converter/converter.py
@@ -6,6 +6,7 @@ No LLM calls — pure Python transformation logic.
 
 from __future__ import annotations
 
+import copy
 import logging
 import re
 import xml.etree.ElementTree as ET
@@ -13,6 +14,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from confluence_to_notion.agents.schemas import FinalRuleset
+from confluence_to_notion.converter.resolution import ResolutionStore
 from confluence_to_notion.converter.schemas import ConversionResult, UnresolvedItem
 
 logger = logging.getLogger(__name__)
@@ -56,6 +58,7 @@ class _ConversionContext:
 
     enabled_ids: set[str]
     page_id: str
+    store: ResolutionStore | None = None
     unresolved: list[UnresolvedItem] = field(default_factory=list)
 
 
@@ -64,6 +67,7 @@ def convert_page(
     ruleset: FinalRuleset,
     *,
     page_id: str = "",
+    store: ResolutionStore | None = None,
 ) -> ConversionResult:
     """Convert a Confluence XHTML page to a list of Notion blocks.
 
@@ -71,6 +75,8 @@ def convert_page(
         xhtml: Confluence XHTML storage body.
         ruleset: Rules controlling which macros/elements to convert.
         page_id: Confluence page ID (used to tag unresolved items).
+        store: Resolution store — if provided, resolved entries are used
+            instead of placeholders for unknown macros and page links.
 
     Returns:
         ConversionResult with blocks and any unresolved items.
@@ -82,6 +88,7 @@ def convert_page(
     ctx = _ConversionContext(
         enabled_ids={r.rule_id for r in ruleset.enabled_rules},
         page_id=page_id,
+        store=store,
     )
     xml_str = _XHTML_WRAPPER.format(xhtml)
     root = ET.fromstring(xml_str)
@@ -259,8 +266,14 @@ def _extract_ac_link_rich_text(
             display_text = _get_all_text(child)
 
     text = display_text or page_title or "link"
-    url = f"https://notion.so/placeholder/{page_title}" if page_title else "#"
 
+    if page_title and ctx.store:
+        entry = ctx.store.lookup(f"page_link:{page_title}")
+        if entry and "notion_page_id" in entry.value:
+            url = f"https://notion.so/{entry.value['notion_page_id']}"
+            return [_text_seg(text, link=url)]
+
+    url = f"https://notion.so/placeholder/{page_title}" if page_title else "#"
     if page_title:
         ctx.unresolved.append(
             UnresolvedItem(
@@ -349,6 +362,13 @@ def _convert_macro(
     # Also handle panels without explicit rules (built-in behavior for info-family macros)
     if macro_name in _PANEL_STYLES:
         return _convert_panel_macro(elem, macro_name, ctx)
+
+    # Check resolution store for pre-resolved blocks
+    if ctx.store:
+        entry = ctx.store.lookup(f"macro:{macro_name}")
+        if entry and "notion_blocks" in entry.value:
+            blocks: list[dict[str, Any]] = copy.deepcopy(entry.value["notion_blocks"])
+            return blocks
 
     # Fallback: render as paragraph with the macro's text content
     ctx.unresolved.append(

--- a/src/confluence_to_notion/converter/resolution.py
+++ b/src/confluence_to_notion/converter/resolution.py
@@ -1,0 +1,66 @@
+"""Resolution store — persists resolved facts across conversion runs."""
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from confluence_to_notion.converter.schemas import ResolutionData, ResolutionEntry
+
+logger = logging.getLogger(__name__)
+
+
+class ResolutionStore:
+    """Load, query, and persist resolution entries.
+
+    Usage:
+        store = ResolutionStore(Path("output/resolution.json"))
+        entry = store.lookup("jira_server:ASF JIRA")
+        if entry is None:
+            store.add("jira_server:ASF JIRA", resolved_by="user_input",
+                       value={"url": "https://issues.apache.org/jira"})
+            store.save()
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self.data = self._load()
+
+    def _load(self) -> ResolutionData:
+        if not self._path.exists():
+            return ResolutionData()
+        try:
+            return ResolutionData.model_validate_json(self._path.read_text(encoding="utf-8"))
+        except (ValueError, OSError):
+            logger.warning("Failed to load %s, starting fresh", self._path)
+            return ResolutionData()
+
+    def lookup(self, key: str) -> ResolutionEntry | None:
+        """Look up a resolution entry by key (e.g. 'macro:toc')."""
+        return self.data.entries.get(key)
+
+    def add(
+        self,
+        key: str,
+        *,
+        resolved_by: str,
+        value: dict[str, Any],
+        confidence: float | None = None,
+    ) -> None:
+        """Add or overwrite a resolution entry."""
+        self.data.entries[key] = ResolutionEntry(
+            resolved_by=resolved_by,
+            value=value,
+            confidence=confidence,
+        )
+
+    def keys(self) -> list[str]:
+        """Return all resolution keys."""
+        return list(self.data.entries.keys())
+
+    def save(self) -> None:
+        """Persist the store to disk."""
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._path.write_text(
+            self.data.model_dump_json(indent=2),
+            encoding="utf-8",
+        )

--- a/src/confluence_to_notion/converter/resolver.py
+++ b/src/confluence_to_notion/converter/resolver.py
@@ -6,8 +6,9 @@ entries are saved to the store automatically.
 """
 
 import logging
-from dataclasses import dataclass, field
 from typing import Protocol, runtime_checkable
+
+from pydantic import BaseModel, Field
 
 from confluence_to_notion.converter.resolution import ResolutionStore
 from confluence_to_notion.converter.schemas import ResolutionEntry, UnresolvedItem
@@ -22,14 +23,13 @@ class ResolveStrategy(Protocol):
     async def try_resolve(self, item: UnresolvedItem) -> ResolutionEntry | None: ...
 
 
-@dataclass
-class ResolveReport:
+class ResolveReport(BaseModel):
     """Result of a resolve pass."""
 
-    resolved_count: int = 0
-    from_store: int = 0
-    newly_resolved: int = 0
-    still_unresolved: list[UnresolvedItem] = field(default_factory=list)
+    resolved_count: int = Field(default=0)
+    from_store: int = Field(default=0)
+    newly_resolved: int = Field(default=0)
+    still_unresolved: list[UnresolvedItem] = Field(default_factory=list)
 
 
 class Resolver:

--- a/src/confluence_to_notion/converter/resolver.py
+++ b/src/confluence_to_notion/converter/resolver.py
@@ -1,0 +1,98 @@
+"""Resolver — processes unresolved items using pluggable strategies.
+
+The resolver deduplicates items, checks the resolution store first,
+then tries each strategy in order until one succeeds. Newly resolved
+entries are saved to the store automatically.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable
+
+from confluence_to_notion.converter.resolution import ResolutionStore
+from confluence_to_notion.converter.schemas import ResolutionEntry, UnresolvedItem
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class ResolveStrategy(Protocol):
+    """Protocol for resolution strategies (AI, API, user input, etc.)."""
+
+    async def try_resolve(self, item: UnresolvedItem) -> ResolutionEntry | None: ...
+
+
+@dataclass
+class ResolveReport:
+    """Result of a resolve pass."""
+
+    resolved_count: int = 0
+    from_store: int = 0
+    newly_resolved: int = 0
+    still_unresolved: list[UnresolvedItem] = field(default_factory=list)
+
+
+class Resolver:
+    """Resolves unresolved items using store lookup + pluggable strategies.
+
+    Usage:
+        store = ResolutionStore(Path("output/resolution.json"))
+        resolver = Resolver(store, strategies=[ai_strategy, user_strategy])
+        report = await resolver.resolve(result.unresolved)
+    """
+
+    def __init__(
+        self,
+        store: ResolutionStore,
+        strategies: list[ResolveStrategy] | None = None,
+    ) -> None:
+        self._store = store
+        self._strategies = strategies or []
+
+    async def resolve(self, items: list[UnresolvedItem]) -> ResolveReport:
+        """Process unresolved items: deduplicate, check store, try strategies."""
+        report = ResolveReport()
+        seen: set[str] = set()
+
+        for item in items:
+            key = f"{item.kind}:{item.identifier}"
+            if key in seen:
+                continue
+            seen.add(key)
+
+            # 1. Check store
+            existing = self._store.lookup(key)
+            if existing is not None:
+                report.resolved_count += 1
+                report.from_store += 1
+                logger.debug("Store hit: %s", key)
+                continue
+
+            # 2. Try strategies in order
+            entry = await self._try_strategies(item)
+            if entry is not None:
+                self._store.add(
+                    key=key,
+                    resolved_by=entry.resolved_by,
+                    value=entry.value,
+                    confidence=entry.confidence,
+                )
+                report.resolved_count += 1
+                report.newly_resolved += 1
+                logger.info("Resolved: %s via %s", key, entry.resolved_by)
+            else:
+                report.still_unresolved.append(item)
+                logger.info("Unresolved: %s", key)
+
+        # Persist newly resolved entries
+        if report.newly_resolved > 0:
+            self._store.save()
+
+        return report
+
+    async def _try_strategies(self, item: UnresolvedItem) -> ResolutionEntry | None:
+        for strategy in self._strategies:
+            entry = await strategy.try_resolve(item)
+            if entry is not None:
+                return entry
+        return None

--- a/src/confluence_to_notion/converter/schemas.py
+++ b/src/confluence_to_notion/converter/schemas.py
@@ -1,0 +1,74 @@
+"""Pydantic models for the resolution store and unresolved items.
+
+The resolution store persists facts discovered during conversion — JIRA server URLs,
+custom macro mappings, page ID lookups — so they're not re-asked on subsequent runs.
+"""
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class ResolutionEntry(BaseModel):
+    """A single resolved fact stored in resolution.json."""
+
+    resolved_by: Literal["user_input", "ai_inference", "api_call", "auto_lookup"] = Field(
+        description="How this entry was resolved",
+    )
+    value: dict[str, Any] = Field(
+        description="The resolved value (structure depends on the entry kind)",
+    )
+    confidence: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Confidence score for AI-inferred entries",
+    )
+    resolved_at: datetime = Field(
+        default_factory=datetime.now,
+        description="When this entry was resolved",
+    )
+
+
+class UnresolvedItem(BaseModel):
+    """An element the converter couldn't handle deterministically.
+
+    Collected during conversion and processed afterwards by the resolver.
+    """
+
+    kind: Literal["macro", "jira_server", "page_link"] = Field(
+        description="Category of the unresolved element",
+    )
+    identifier: str = Field(
+        description="Key identifier (macro name, server name, page title)",
+    )
+    source_page_id: str = Field(
+        description="Confluence page ID where this was encountered",
+    )
+    context_xhtml: str | None = Field(
+        default=None,
+        description="Original XHTML snippet for context",
+    )
+
+
+class ResolutionData(BaseModel):
+    """Root model for resolution.json — keyed map of resolved entries."""
+
+    entries: dict[str, ResolutionEntry] = Field(
+        default_factory=dict,
+        description="Map of 'kind:identifier' → resolved entry",
+    )
+
+
+class ConversionResult(BaseModel):
+    """Result of converting a Confluence page — blocks plus unresolved items."""
+
+    blocks: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="Notion API block dicts",
+    )
+    unresolved: list[UnresolvedItem] = Field(
+        default_factory=list,
+        description="Elements the converter couldn't handle deterministically",
+    )

--- a/tests/integration/test_e2e_pipeline.py
+++ b/tests/integration/test_e2e_pipeline.py
@@ -35,7 +35,7 @@ class TestConvertPage:
         xhtml = (FIXTURE_DIR / "page1.xhtml").read_text()
         ruleset = FinalRuleset.model_validate_json((FIXTURE_DIR / "rules.json").read_text())
 
-        blocks = convert_page(xhtml, ruleset)
+        blocks = convert_page(xhtml, ruleset).blocks
 
         assert len(blocks) > 0
 
@@ -43,7 +43,7 @@ class TestConvertPage:
         xhtml = (FIXTURE_DIR / "page1.xhtml").read_text()
         ruleset = FinalRuleset.model_validate_json((FIXTURE_DIR / "rules.json").read_text())
 
-        blocks = convert_page(xhtml, ruleset)
+        blocks = convert_page(xhtml, ruleset).blocks
 
         for block in blocks:
             assert "type" in block, f"Block missing 'type': {block}"
@@ -54,7 +54,7 @@ class TestConvertPage:
         xhtml = (FIXTURE_DIR / "page1.xhtml").read_text()
         ruleset = FinalRuleset.model_validate_json((FIXTURE_DIR / "rules.json").read_text())
 
-        blocks = convert_page(xhtml, ruleset)
+        blocks = convert_page(xhtml, ruleset).blocks
 
         block_types = {b["type"] for b in blocks}
         assert any(t.startswith("heading") for t in block_types), "Expected at least one heading"
@@ -64,7 +64,7 @@ class TestConvertPage:
         xhtml = (FIXTURE_DIR / "page2.xhtml").read_text()
         ruleset = FinalRuleset.model_validate_json((FIXTURE_DIR / "rules.json").read_text())
 
-        blocks = convert_page(xhtml, ruleset)
+        blocks = convert_page(xhtml, ruleset).blocks
 
         assert len(blocks) > 0
 
@@ -72,7 +72,7 @@ class TestConvertPage:
         xhtml = (FIXTURE_DIR / "page2.xhtml").read_text()
         ruleset = FinalRuleset.model_validate_json((FIXTURE_DIR / "rules.json").read_text())
 
-        blocks = convert_page(xhtml, ruleset)
+        blocks = convert_page(xhtml, ruleset).blocks
 
         list_items = [b for b in blocks if b["type"] == "numbered_list_item"]
         assert list_items, "Expected numbered list items in page2.xhtml"

--- a/tests/unit/test_cli_migrate.py
+++ b/tests/unit/test_cli_migrate.py
@@ -9,6 +9,7 @@ from notion_client import APIResponseError
 from typer.testing import CliRunner
 
 from confluence_to_notion.cli import _extract_title, app
+from confluence_to_notion.converter.schemas import ConversionResult
 from confluence_to_notion.notion.schemas import NotionPageResult
 
 runner = CliRunner()
@@ -27,34 +28,36 @@ def _make_api_error(status: int, message: str) -> APIResponseError:
     )
 
 
-def _fake_blocks() -> list[dict[str, Any]]:
-    """Return minimal Notion blocks with a heading for title extraction."""
-    return [
-        {
-            "type": "heading_1",
-            "heading_1": {
-                "rich_text": [{"type": "text", "text": {"content": "Test Page Title"}}],
+def _fake_result() -> ConversionResult:
+    """Return a ConversionResult with minimal blocks for title extraction."""
+    return ConversionResult(
+        blocks=[
+            {
+                "type": "heading_1",
+                "heading_1": {
+                    "rich_text": [{"type": "text", "text": {"content": "Test Page Title"}}],
+                },
             },
-        },
-        {
-            "type": "paragraph",
-            "paragraph": {
-                "rich_text": [
-                    {
-                        "type": "text",
-                        "text": {"content": "This is a test paragraph for migration."},
-                    },
-                ],
+            {
+                "type": "paragraph",
+                "paragraph": {
+                    "rich_text": [
+                        {
+                            "type": "text",
+                            "text": {"content": "This is a test paragraph for migration."},
+                        },
+                    ],
+                },
             },
-        },
-    ]
+        ]
+    )
 
 
 class TestMigrateHappyPath:
     """Happy path: converts XHTML files and publishes to Notion."""
 
     @patch("confluence_to_notion.cli.NotionClientWrapper")
-    @patch("confluence_to_notion.converter.converter.convert_page", return_value=_fake_blocks())
+    @patch("confluence_to_notion.converter.converter.convert_page", return_value=_fake_result())
     @patch("confluence_to_notion.cli._load_settings")
     def test_migrate_success(
         self,
@@ -101,7 +104,7 @@ class TestMigrateHappyPath:
         assert call_args.kwargs["title"] == "Test Page Title"
 
     @patch("confluence_to_notion.cli.NotionClientWrapper")
-    @patch("confluence_to_notion.converter.converter.convert_page", return_value=_fake_blocks())
+    @patch("confluence_to_notion.converter.converter.convert_page", return_value=_fake_result())
     @patch("confluence_to_notion.cli._load_settings")
     def test_migrate_uses_root_page_id_when_no_target(
         self,
@@ -142,7 +145,7 @@ class TestMigrateErrorHandling:
     """When create_page raises APIResponseError, that page is skipped."""
 
     @patch("confluence_to_notion.cli.NotionClientWrapper")
-    @patch("confluence_to_notion.converter.converter.convert_page", return_value=_fake_blocks())
+    @patch("confluence_to_notion.converter.converter.convert_page", return_value=_fake_result())
     @patch("confluence_to_notion.cli._load_settings")
     def test_api_error_skips_page_continues(
         self,

--- a/tests/unit/test_converter.py
+++ b/tests/unit/test_converter.py
@@ -108,7 +108,7 @@ def _default_ruleset() -> FinalRuleset:
 
 class TestHeadings:
     def test_h1(self) -> None:
-        blocks = convert_page("<h1>Title</h1>", _default_ruleset())
+        blocks = convert_page("<h1>Title</h1>", _default_ruleset()).blocks
         assert blocks == [
             {
                 "type": "heading_1",
@@ -119,22 +119,22 @@ class TestHeadings:
         ]
 
     def test_h2(self) -> None:
-        blocks = convert_page("<h2>Section</h2>", _default_ruleset())
+        blocks = convert_page("<h2>Section</h2>", _default_ruleset()).blocks
         assert blocks[0]["type"] == "heading_2"
 
     def test_h3(self) -> None:
-        blocks = convert_page("<h3>Subsection</h3>", _default_ruleset())
+        blocks = convert_page("<h3>Subsection</h3>", _default_ruleset()).blocks
         assert blocks[0]["type"] == "heading_3"
 
     def test_h4_h5_h6_fallback_to_h3(self) -> None:
         """Notion only supports h1-h3; h4+ should map to h3."""
-        blocks = convert_page("<h4>Deep heading</h4>", _default_ruleset())
+        blocks = convert_page("<h4>Deep heading</h4>", _default_ruleset()).blocks
         assert blocks[0]["type"] == "heading_3"
 
 
 class TestParagraphs:
     def test_simple_paragraph(self) -> None:
-        blocks = convert_page("<p>Hello world</p>", _default_ruleset())
+        blocks = convert_page("<p>Hello world</p>", _default_ruleset()).blocks
         assert blocks == [
             {
                 "type": "paragraph",
@@ -145,15 +145,15 @@ class TestParagraphs:
         ]
 
     def test_empty_paragraph_skipped(self) -> None:
-        blocks = convert_page("<p></p>", _default_ruleset())
+        blocks = convert_page("<p></p>", _default_ruleset()).blocks
         assert blocks == []
 
     def test_br_only_paragraph_skipped(self) -> None:
-        blocks = convert_page("<p><br /></p>", _default_ruleset())
+        blocks = convert_page("<p><br /></p>", _default_ruleset()).blocks
         assert blocks == []
 
     def test_paragraph_with_inline_code(self) -> None:
-        blocks = convert_page("<p>Run <code>gradle</code> now</p>", _default_ruleset())
+        blocks = convert_page("<p>Run <code>gradle</code> now</p>", _default_ruleset()).blocks
         rich_text = blocks[0]["paragraph"]["rich_text"]
         assert len(rich_text) == 3
         assert rich_text[0] == {"type": "text", "text": {"content": "Run "}}
@@ -162,12 +162,13 @@ class TestParagraphs:
         assert rich_text[2] == {"type": "text", "text": {"content": " now"}}
 
     def test_paragraph_with_bold(self) -> None:
-        blocks = convert_page("<p>This is <strong>bold</strong> text</p>", _default_ruleset())
+        xhtml = "<p>This is <strong>bold</strong> text</p>"
+        blocks = convert_page(xhtml, _default_ruleset()).blocks
         rich_text = blocks[0]["paragraph"]["rich_text"]
         assert rich_text[1]["annotations"]["bold"] is True
 
     def test_paragraph_with_italic(self) -> None:
-        blocks = convert_page("<p>This is <em>italic</em> text</p>", _default_ruleset())
+        blocks = convert_page("<p>This is <em>italic</em> text</p>", _default_ruleset()).blocks
         rich_text = blocks[0]["paragraph"]["rich_text"]
         assert rich_text[1]["annotations"]["italic"] is True
 
@@ -175,26 +176,26 @@ class TestParagraphs:
         blocks = convert_page(
             '<p>See <a href="https://example.com">here</a></p>',
             _default_ruleset(),
-        )
+        ).blocks
         rich_text = blocks[0]["paragraph"]["rich_text"]
         assert rich_text[1]["text"]["link"] == {"url": "https://example.com"}
 
 
 class TestLists:
     def test_unordered_list(self) -> None:
-        blocks = convert_page("<ul><li>one</li><li>two</li></ul>", _default_ruleset())
+        blocks = convert_page("<ul><li>one</li><li>two</li></ul>", _default_ruleset()).blocks
         assert len(blocks) == 2
         assert blocks[0]["type"] == "bulleted_list_item"
         assert blocks[0]["bulleted_list_item"]["rich_text"][0]["text"]["content"] == "one"
 
     def test_ordered_list(self) -> None:
-        blocks = convert_page("<ol><li>first</li><li>second</li></ol>", _default_ruleset())
+        blocks = convert_page("<ol><li>first</li><li>second</li></ol>", _default_ruleset()).blocks
         assert len(blocks) == 2
         assert blocks[0]["type"] == "numbered_list_item"
 
     def test_nested_list(self) -> None:
         xhtml = "<ul><li>parent<ul><li>child</li></ul></li></ul>"
-        blocks = convert_page(xhtml, _default_ruleset())
+        blocks = convert_page(xhtml, _default_ruleset()).blocks
         assert blocks[0]["type"] == "bulleted_list_item"
         children = blocks[0].get("bulleted_list_item", {}).get("children", [])
         assert len(children) == 1
@@ -211,7 +212,7 @@ class TestMacroToc:
             '<ac:parameter ac:name="maxLevel">3</ac:parameter>'
             "</ac:structured-macro>"
         )
-        blocks = convert_page(xhtml, _default_ruleset())
+        blocks = convert_page(xhtml, _default_ruleset()).blocks
         assert blocks == [
             {
                 "type": "table_of_contents",
@@ -228,7 +229,7 @@ class TestMacroToc:
             "</ac:structured-macro>"
             "</p>"
         )
-        blocks = convert_page(xhtml, _default_ruleset())
+        blocks = convert_page(xhtml, _default_ruleset()).blocks
         assert len(blocks) == 1
         assert blocks[0]["type"] == "table_of_contents"
 
@@ -241,7 +242,7 @@ class TestMacroJira:
             '<ac:parameter ac:name="key">KAFKA-4617</ac:parameter>'
             "</ac:structured-macro>"
         )
-        blocks = convert_page(xhtml, _default_ruleset())
+        blocks = convert_page(xhtml, _default_ruleset()).blocks
         rt = blocks[0]["paragraph"]["rich_text"]
         assert rt[0]["text"]["content"] == "KAFKA-4617"
         assert "jira/browse/KAFKA-4617" in rt[0]["text"]["link"]["url"]
@@ -254,7 +255,7 @@ class TestMacroInfo:
             "<ac:rich-text-body><p>Important note</p></ac:rich-text-body>"
             "</ac:structured-macro>"
         )
-        blocks = convert_page(xhtml, _default_ruleset())
+        blocks = convert_page(xhtml, _default_ruleset()).blocks
         assert blocks[0]["type"] == "callout"
         callout = blocks[0]["callout"]
         assert callout["icon"] == {"type": "emoji", "emoji": "\u2139\ufe0f"}
@@ -275,7 +276,7 @@ class TestMacroInfo:
             "<ac:rich-text-body><p>Text</p></ac:rich-text-body>"
             "</ac:structured-macro>"
         )
-        blocks = convert_page(xhtml, _default_ruleset())
+        blocks = convert_page(xhtml, _default_ruleset()).blocks
         assert blocks[0]["callout"]["icon"]["emoji"] == emoji
         assert blocks[0]["callout"]["color"] == color
 
@@ -289,7 +290,7 @@ class TestMacroCode:
             "<ac:plain-text-body><![CDATA[print('hello')]]></ac:plain-text-body>"
             "</ac:structured-macro>"
         )
-        blocks = convert_page(xhtml, _default_ruleset())
+        blocks = convert_page(xhtml, _default_ruleset()).blocks
         assert len(blocks) == 1
         assert blocks[0]["type"] == "code"
         assert blocks[0]["code"]["language"] == "python"
@@ -302,7 +303,7 @@ class TestMacroCode:
             "<ac:plain-text-body><![CDATA[some code]]></ac:plain-text-body>"
             "</ac:structured-macro>"
         )
-        blocks = convert_page(xhtml, _default_ruleset())
+        blocks = convert_page(xhtml, _default_ruleset()).blocks
         assert blocks[0]["type"] == "code"
         assert blocks[0]["code"]["language"] == "plain text"
 
@@ -313,7 +314,7 @@ class TestMacroCode:
             "<ac:plain-text-body><![CDATA[raw text]]></ac:plain-text-body>"
             "</ac:structured-macro>"
         )
-        blocks = convert_page(xhtml, _default_ruleset())
+        blocks = convert_page(xhtml, _default_ruleset()).blocks
         assert blocks[0]["type"] == "code"
         assert blocks[0]["code"]["language"] == "plain text"
         assert blocks[0]["code"]["rich_text"][0]["text"]["content"] == "raw text"
@@ -329,7 +330,7 @@ class TestNestedMacros:
     def test_info_with_inline_code_from_sample(self) -> None:
         """Real sample: info macro with <code> inside (from samples/27835336.xhtml)."""
         xhtml = self._load_fixture("info-with-code-from-sample.xhtml")
-        blocks = convert_page(xhtml, _default_ruleset())
+        blocks = convert_page(xhtml, _default_ruleset()).blocks
         assert len(blocks) == 1
         assert blocks[0]["type"] == "callout"
         callout = blocks[0]["callout"]
@@ -341,7 +342,7 @@ class TestNestedMacros:
     def test_expand_with_nested_code(self) -> None:
         """Expand containing a code macro → toggle with code block child."""
         xhtml = self._load_fixture("expand-with-code.xhtml")
-        blocks = convert_page(xhtml, _default_ruleset())
+        blocks = convert_page(xhtml, _default_ruleset()).blocks
         assert len(blocks) == 1
         assert blocks[0]["type"] == "toggle"
         toggle = blocks[0]["toggle"]
@@ -355,7 +356,7 @@ class TestNestedMacros:
     def test_three_level_expand_info_code(self) -> None:
         """Expand > info > code → toggle > callout > code (3-level nesting)."""
         xhtml = self._load_fixture("expand-with-info-and-code.xhtml")
-        blocks = convert_page(xhtml, _default_ruleset())
+        blocks = convert_page(xhtml, _default_ruleset()).blocks
         assert len(blocks) == 1
         assert blocks[0]["type"] == "toggle"
         toggle = blocks[0]["toggle"]
@@ -375,7 +376,7 @@ class TestNestedMacros:
     def test_warning_with_nested_info(self) -> None:
         """Warning panel containing info panel → callout with callout child."""
         xhtml = self._load_fixture("warning-with-info.xhtml")
-        blocks = convert_page(xhtml, _default_ruleset())
+        blocks = convert_page(xhtml, _default_ruleset()).blocks
         assert len(blocks) == 1
         assert blocks[0]["type"] == "callout"
         outer = blocks[0]["callout"]
@@ -393,7 +394,7 @@ class TestNestedMacros:
     def test_note_with_jira_and_code(self) -> None:
         """Note panel with JIRA macro + code block — mixed nesting from real patterns."""
         xhtml = self._load_fixture("panel-with-jira-and-code.xhtml")
-        blocks = convert_page(xhtml, _default_ruleset())
+        blocks = convert_page(xhtml, _default_ruleset()).blocks
         assert len(blocks) == 1
         assert blocks[0]["type"] == "callout"
         callout = blocks[0]["callout"]
@@ -415,7 +416,7 @@ class TestAcLink:
             '<ac:link><ri:page ri:content-title="Setup Guide" /></ac:link>'
             " for details</p>"
         )
-        blocks = convert_page(xhtml, _default_ruleset())
+        blocks = convert_page(xhtml, _default_ruleset()).blocks
         rt = blocks[0]["paragraph"]["rich_text"]
         link_seg = next(s for s in rt if s["text"].get("link"))
         assert link_seg["text"]["content"] == "Setup Guide"
@@ -428,7 +429,7 @@ class TestAcLink:
             "</ac:plain-text-link-body></ac:link>"
             "</p>"
         )
-        blocks = convert_page(xhtml, _default_ruleset())
+        blocks = convert_page(xhtml, _default_ruleset()).blocks
         rt = blocks[0]["paragraph"]["rich_text"]
         link_seg = next(s for s in rt if s["text"].get("link"))
         assert link_seg["text"]["content"] == "Kafka compression"
@@ -437,7 +438,7 @@ class TestAcLink:
 class TestAcImage:
     def test_image(self) -> None:
         xhtml = '<ac:image ac:height="250"><ri:attachment ri:filename="pic.jpg" /></ac:image>'
-        blocks = convert_page(xhtml, _default_ruleset())
+        blocks = convert_page(xhtml, _default_ruleset()).blocks
         assert blocks[0]["type"] == "image"
         assert blocks[0]["image"]["type"] == "external"
         assert "pic.jpg" in blocks[0]["image"]["external"]["url"]
@@ -449,7 +450,7 @@ class TestAcImage:
 class TestPreformatted:
     def test_pre_block(self) -> None:
         xhtml = "<pre>line1<br />line2</pre>"
-        blocks = convert_page(xhtml, _default_ruleset())
+        blocks = convert_page(xhtml, _default_ruleset()).blocks
         assert blocks[0]["type"] == "code"
         content = blocks[0]["code"]["rich_text"][0]["text"]["content"]
         assert content == "line1\nline2"
@@ -459,12 +460,12 @@ class TestPreformatted:
 class TestStyledSpan:
     def test_bold_large_span_as_heading(self) -> None:
         xhtml = '<span style="font-size: 16.0px;font-weight: bold;">Section Title</span>'
-        blocks = convert_page(xhtml, _default_ruleset())
+        blocks = convert_page(xhtml, _default_ruleset()).blocks
         assert blocks[0]["type"] == "heading_2"
 
     def test_non_bold_span_as_paragraph(self) -> None:
         xhtml = '<span style="font-size: 16.0px;">Not a heading</span>'
-        blocks = convert_page(xhtml, _default_ruleset())
+        blocks = convert_page(xhtml, _default_ruleset()).blocks
         assert blocks[0]["type"] == "paragraph"
 
 
@@ -473,11 +474,11 @@ class TestStyledSpan:
 
 class TestEdgeCases:
     def test_empty_input(self) -> None:
-        blocks = convert_page("", _default_ruleset())
+        blocks = convert_page("", _default_ruleset()).blocks
         assert blocks == []
 
     def test_plain_text_only(self) -> None:
-        blocks = convert_page("just text", _default_ruleset())
+        blocks = convert_page("just text", _default_ruleset()).blocks
         assert blocks[0]["type"] == "paragraph"
         assert blocks[0]["paragraph"]["rich_text"][0]["text"]["content"] == "just text"
 
@@ -487,7 +488,7 @@ class TestEdgeCases:
             '<ac:parameter ac:name="x">val</ac:parameter>'
             "</ac:structured-macro>"
         )
-        blocks = convert_page(xhtml, _default_ruleset())
+        blocks = convert_page(xhtml, _default_ruleset()).blocks
         assert len(blocks) == 1
         assert blocks[0]["type"] == "paragraph"
 
@@ -498,7 +499,7 @@ class TestEdgeCases:
             if r.rule_id == "rule:macro:toc":
                 r.enabled = False
         xhtml = '<ac:structured-macro ac:name="toc" ac:schema-version="1" />'
-        blocks = convert_page(xhtml, ruleset)
+        blocks = convert_page(xhtml, ruleset).blocks
         assert blocks[0]["type"] == "paragraph"
 
 
@@ -516,14 +517,14 @@ class TestLargePageConversion:
     def test_large_page_produces_expected_block_count(self) -> None:
         """200+ <p> tags should produce 200+ blocks."""
         xhtml = self._make_large_xhtml(200)
-        blocks = convert_page(xhtml, _default_ruleset())
+        blocks = convert_page(xhtml, _default_ruleset()).blocks
         assert len(blocks) == 200
 
     def test_large_page_emits_warning_log(self, caplog: pytest.LogCaptureFixture) -> None:
         """Converting XHTML producing >100 blocks emits a warning with block count and size."""
         xhtml = self._make_large_xhtml(150)
         with caplog.at_level(logging.WARNING, logger="confluence_to_notion.converter.converter"):
-            blocks = convert_page(xhtml, _default_ruleset())
+            blocks = convert_page(xhtml, _default_ruleset()).blocks
         assert len(blocks) == 150
         warning_records = [
             r for r in caplog.records
@@ -537,7 +538,7 @@ class TestLargePageConversion:
         """XHTML under the threshold does NOT emit a warning."""
         xhtml = self._make_large_xhtml(50)
         with caplog.at_level(logging.WARNING, logger="confluence_to_notion.converter.converter"):
-            blocks = convert_page(xhtml, _default_ruleset())
+            blocks = convert_page(xhtml, _default_ruleset()).blocks
         assert len(blocks) == 50
         warning_records = [
             r for r in caplog.records
@@ -545,3 +546,77 @@ class TestLargePageConversion:
             and r.levelno == logging.WARNING
         ]
         assert len(warning_records) == 0
+
+
+# --- Unresolved item collection ---
+
+
+class TestUnresolvedCollection:
+    """convert_page collects UnresolvedItem for elements it can't handle deterministically."""
+
+    def test_unknown_macro_collected(self) -> None:
+        """Unknown macro produces a placeholder block AND an unresolved item."""
+        xhtml = (
+            '<ac:structured-macro ac:name="custom-board">'
+            "<ac:rich-text-body><p>Board content</p></ac:rich-text-body>"
+            "</ac:structured-macro>"
+        )
+        result = convert_page(xhtml, _default_ruleset(), page_id="pg-1")
+        # Still produces placeholder block
+        assert len(result.blocks) == 1
+        assert result.blocks[0]["type"] == "paragraph"
+        # Collects unresolved item
+        assert len(result.unresolved) == 1
+        item = result.unresolved[0]
+        assert item.kind == "macro"
+        assert item.identifier == "custom-board"
+        assert item.source_page_id == "pg-1"
+
+    def test_known_macro_no_unresolved(self) -> None:
+        """Known macros (toc, info, etc.) produce NO unresolved items."""
+        xhtml = (
+            '<ac:structured-macro ac:name="toc" ac:schema-version="1">'
+            '<ac:parameter ac:name="maxLevel">3</ac:parameter>'
+            "</ac:structured-macro>"
+        )
+        result = convert_page(xhtml, _default_ruleset(), page_id="pg-2")
+        assert len(result.blocks) == 1
+        assert result.blocks[0]["type"] == "table_of_contents"
+        assert result.unresolved == []
+
+    def test_ac_link_collected(self) -> None:
+        """Internal page links are collected as unresolved page_link items."""
+        xhtml = (
+            "<p>See "
+            '<ac:link><ri:page ri:content-title="Setup Guide" /></ac:link>'
+            " for details</p>"
+        )
+        result = convert_page(xhtml, _default_ruleset(), page_id="pg-3")
+        # Still produces block with placeholder link
+        assert len(result.blocks) == 1
+        # Collects page link unresolved
+        page_links = [u for u in result.unresolved if u.kind == "page_link"]
+        assert len(page_links) == 1
+        assert page_links[0].identifier == "Setup Guide"
+        assert page_links[0].source_page_id == "pg-3"
+
+    def test_mixed_known_unknown(self) -> None:
+        """Page with both known and unknown elements only collects unknowns."""
+        xhtml = (
+            "<h1>Title</h1>"
+            '<ac:structured-macro ac:name="toc" />'
+            '<ac:structured-macro ac:name="fancy-widget">'
+            "<ac:rich-text-body><p>Widget</p></ac:rich-text-body>"
+            "</ac:structured-macro>"
+        )
+        result = convert_page(xhtml, _default_ruleset(), page_id="pg-4")
+        assert len(result.blocks) == 3  # heading + toc + placeholder
+        assert len(result.unresolved) == 1
+        assert result.unresolved[0].identifier == "fancy-widget"
+
+    def test_no_page_id_still_works(self) -> None:
+        """Without page_id, unresolved items have empty source_page_id."""
+        xhtml = '<ac:structured-macro ac:name="mystery" />'
+        result = convert_page(xhtml, _default_ruleset())
+        assert len(result.unresolved) == 1
+        assert result.unresolved[0].source_page_id == ""

--- a/tests/unit/test_converter.py
+++ b/tests/unit/test_converter.py
@@ -8,6 +8,7 @@ import pytest
 
 from confluence_to_notion.agents.schemas import FinalRule, FinalRuleset, ProposedRule
 from confluence_to_notion.converter.converter import convert_page
+from confluence_to_notion.converter.resolution import ResolutionStore
 
 FIXTURES_DIR = Path(__file__).parent.parent / "fixtures" / "nested-macros"
 
@@ -620,3 +621,97 @@ class TestUnresolvedCollection:
         result = convert_page(xhtml, _default_ruleset())
         assert len(result.unresolved) == 1
         assert result.unresolved[0].source_page_id == ""
+
+
+# --- Re-conversion with resolution store ---
+
+
+class TestResolvedConversion:
+    """When a ResolutionStore has entries, converter uses them instead of placeholders."""
+
+    def test_resolved_macro_uses_store_blocks(self, tmp_path: Path) -> None:
+        """Macro resolved in store → use stored Notion blocks, no unresolved."""
+        store = ResolutionStore(tmp_path / "res.json")
+        store.add(
+            key="macro:custom-board",
+            resolved_by="ai_inference",
+            value={
+                "notion_blocks": [
+                    {
+                        "type": "callout",
+                        "callout": {
+                            "icon": {"type": "emoji", "emoji": "\U0001f4cb"},
+                            "color": "blue_background",
+                            "rich_text": [
+                                {"type": "text", "text": {"content": "Board content"}}
+                            ],
+                        },
+                    }
+                ]
+            },
+            confidence=0.9,
+        )
+        xhtml = (
+            '<ac:structured-macro ac:name="custom-board">'
+            "<ac:rich-text-body><p>Board content</p></ac:rich-text-body>"
+            "</ac:structured-macro>"
+        )
+        result = convert_page(xhtml, _default_ruleset(), page_id="pg-1", store=store)
+
+        assert len(result.blocks) == 1
+        assert result.blocks[0]["type"] == "callout"
+        assert result.unresolved == []
+
+    def test_unresolved_macro_still_placeholder(self, tmp_path: Path) -> None:
+        """Macro NOT in store → placeholder + unresolved (same as before)."""
+        store = ResolutionStore(tmp_path / "res.json")
+        xhtml = '<ac:structured-macro ac:name="unknown-thing" />'
+        result = convert_page(xhtml, _default_ruleset(), store=store)
+
+        assert result.blocks[0]["type"] == "paragraph"
+        assert len(result.unresolved) == 1
+
+    def test_resolved_page_link_uses_notion_url(self, tmp_path: Path) -> None:
+        """Page link resolved in store → real Notion URL, no unresolved."""
+        store = ResolutionStore(tmp_path / "res.json")
+        store.add(
+            key="page_link:Setup Guide",
+            resolved_by="auto_lookup",
+            value={"notion_page_id": "abc123def456"},
+        )
+        xhtml = (
+            "<p>See "
+            '<ac:link><ri:page ri:content-title="Setup Guide" /></ac:link>'
+            "</p>"
+        )
+        result = convert_page(xhtml, _default_ruleset(), page_id="pg-1", store=store)
+
+        rt = result.blocks[0]["paragraph"]["rich_text"]
+        link_seg = next(s for s in rt if s["text"].get("link"))
+        assert "abc123def456" in link_seg["text"]["link"]["url"]
+        assert "placeholder" not in link_seg["text"]["link"]["url"]
+        # No unresolved items for this link
+        page_links = [u for u in result.unresolved if u.kind == "page_link"]
+        assert page_links == []
+
+    def test_unresolved_page_link_still_placeholder(self, tmp_path: Path) -> None:
+        """Page link NOT in store → placeholder URL + unresolved."""
+        store = ResolutionStore(tmp_path / "res.json")
+        xhtml = (
+            "<p>See "
+            '<ac:link><ri:page ri:content-title="Unknown Page" /></ac:link>'
+            "</p>"
+        )
+        result = convert_page(xhtml, _default_ruleset(), store=store)
+
+        rt = result.blocks[0]["paragraph"]["rich_text"]
+        link_seg = next(s for s in rt if s["text"].get("link"))
+        assert "placeholder" in link_seg["text"]["link"]["url"]
+        assert len(result.unresolved) == 1
+
+    def test_no_store_same_as_before(self) -> None:
+        """Without store param, behavior is identical to previous tests."""
+        xhtml = '<ac:structured-macro ac:name="mystery" />'
+        result = convert_page(xhtml, _default_ruleset())
+        assert result.blocks[0]["type"] == "paragraph"
+        assert len(result.unresolved) == 1

--- a/tests/unit/test_resolution.py
+++ b/tests/unit/test_resolution.py
@@ -1,0 +1,157 @@
+"""Unit tests for the Resolution Store — schema and CRUD."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from confluence_to_notion.converter.resolution import ResolutionStore
+from confluence_to_notion.converter.schemas import (
+    ResolutionData,
+    ResolutionEntry,
+    UnresolvedItem,
+)
+
+# --- Schema tests ---
+
+
+class TestResolutionEntry:
+    def test_create_user_input_entry(self) -> None:
+        entry = ResolutionEntry(
+            resolved_by="user_input",
+            value={"url": "https://issues.apache.org/jira"},
+        )
+        assert entry.resolved_by == "user_input"
+        assert entry.confidence is None
+        assert entry.resolved_at is not None
+
+    def test_create_ai_entry_with_confidence(self) -> None:
+        entry = ResolutionEntry(
+            resolved_by="ai_inference",
+            value={"notion_block_type": "callout"},
+            confidence=0.85,
+        )
+        assert entry.confidence == 0.85
+
+    def test_confidence_bounds(self) -> None:
+        with pytest.raises(ValueError):
+            ResolutionEntry(
+                resolved_by="ai_inference",
+                value={},
+                confidence=1.5,
+            )
+
+
+class TestUnresolvedItem:
+    def test_create_macro_unresolved(self) -> None:
+        item = UnresolvedItem(
+            kind="macro",
+            identifier="custom-status-board",
+            source_page_id="12345",
+            context_xhtml='<ac:structured-macro ac:name="custom-status-board"/>',
+        )
+        assert item.kind == "macro"
+        assert item.identifier == "custom-status-board"
+
+    def test_create_jira_server_unresolved(self) -> None:
+        item = UnresolvedItem(
+            kind="jira_server",
+            identifier="Company JIRA",
+            source_page_id="67890",
+        )
+        assert item.kind == "jira_server"
+        assert item.context_xhtml is None
+
+    def test_create_page_link_unresolved(self) -> None:
+        item = UnresolvedItem(
+            kind="page_link",
+            identifier="Some Page Title",
+            source_page_id="11111",
+        )
+        assert item.kind == "page_link"
+
+
+class TestResolutionData:
+    def test_empty_data(self) -> None:
+        data = ResolutionData()
+        assert data.entries == {}
+
+    def test_roundtrip_json(self) -> None:
+        entry = ResolutionEntry(
+            resolved_by="user_input",
+            value={"url": "https://jira.example.com"},
+        )
+        data = ResolutionData(entries={"jira_server:Company JIRA": entry})
+        raw = data.model_dump_json()
+        restored = ResolutionData.model_validate_json(raw)
+        assert restored.entries["jira_server:Company JIRA"].value == entry.value
+
+
+# --- ResolutionStore tests ---
+
+
+class TestResolutionStore:
+    def test_load_nonexistent_returns_empty(self, tmp_path: Path) -> None:
+        store = ResolutionStore(tmp_path / "resolution.json")
+        assert store.data.entries == {}
+
+    def test_load_existing_file(self, tmp_path: Path) -> None:
+        path = tmp_path / "resolution.json"
+        path.write_text(json.dumps({
+            "entries": {
+                "jira_server:ASF JIRA": {
+                    "resolved_by": "user_input",
+                    "value": {"url": "https://issues.apache.org/jira"},
+                    "resolved_at": "2026-04-16T00:00:00",
+                }
+            }
+        }))
+        store = ResolutionStore(path)
+        assert "jira_server:ASF JIRA" in store.data.entries
+
+    def test_lookup_hit(self, tmp_path: Path) -> None:
+        store = ResolutionStore(tmp_path / "resolution.json")
+        store.add(
+            key="macro:toc",
+            resolved_by="ai_inference",
+            value={"notion_block_type": "table_of_contents"},
+            confidence=0.95,
+        )
+        result = store.lookup("macro:toc")
+        assert result is not None
+        assert result.value["notion_block_type"] == "table_of_contents"
+
+    def test_lookup_miss(self, tmp_path: Path) -> None:
+        store = ResolutionStore(tmp_path / "resolution.json")
+        assert store.lookup("macro:nonexistent") is None
+
+    def test_add_and_save(self, tmp_path: Path) -> None:
+        path = tmp_path / "resolution.json"
+        store = ResolutionStore(path)
+        store.add(
+            key="jira_server:My JIRA",
+            resolved_by="user_input",
+            value={"url": "https://jira.mycompany.com"},
+        )
+        store.save()
+
+        # Reload from disk
+        store2 = ResolutionStore(path)
+        entry = store2.lookup("jira_server:My JIRA")
+        assert entry is not None
+        assert entry.value["url"] == "https://jira.mycompany.com"
+
+    def test_add_overwrites_existing(self, tmp_path: Path) -> None:
+        store = ResolutionStore(tmp_path / "resolution.json")
+        store.add(key="macro:x", resolved_by="ai_inference", value={"a": 1}, confidence=0.5)
+        store.add(key="macro:x", resolved_by="user_input", value={"a": 2})
+        entry = store.lookup("macro:x")
+        assert entry is not None
+        assert entry.value == {"a": 2}
+        assert entry.resolved_by == "user_input"
+
+    def test_keys(self, tmp_path: Path) -> None:
+        store = ResolutionStore(tmp_path / "resolution.json")
+        store.add(key="macro:a", resolved_by="ai_inference", value={}, confidence=0.9)
+        store.add(key="jira_server:b", resolved_by="user_input", value={})
+        assert set(store.keys()) == {"macro:a", "jira_server:b"}

--- a/tests/unit/test_resolver.py
+++ b/tests/unit/test_resolver.py
@@ -1,0 +1,187 @@
+"""Unit tests for the Resolver — store lookup, dedup, strategy dispatch."""
+
+from pathlib import Path
+
+from confluence_to_notion.converter.resolution import ResolutionStore
+from confluence_to_notion.converter.resolver import Resolver
+from confluence_to_notion.converter.schemas import (
+    ResolutionEntry,
+    UnresolvedItem,
+)
+
+
+def _macro(name: str, page: str = "pg-1") -> UnresolvedItem:
+    return UnresolvedItem(kind="macro", identifier=name, source_page_id=page)
+
+
+def _page_link(title: str, page: str = "pg-1") -> UnresolvedItem:
+    return UnresolvedItem(kind="page_link", identifier=title, source_page_id=page)
+
+
+class FakeStrategy:
+    """Strategy that resolves specific identifiers."""
+
+    def __init__(self, known: dict[str, dict]) -> None:
+        self._known = known
+        self.call_count = 0
+
+    async def try_resolve(self, item: UnresolvedItem) -> ResolutionEntry | None:
+        self.call_count += 1
+        value = self._known.get(item.identifier)
+        if value is None:
+            return None
+        return ResolutionEntry(resolved_by="ai_inference", value=value, confidence=0.9)
+
+
+class FailStrategy:
+    """Strategy that never resolves anything."""
+
+    async def try_resolve(self, item: UnresolvedItem) -> ResolutionEntry | None:
+        return None
+
+
+class TestResolverStoreLookup:
+    """Items already in the store are reused without calling strategies."""
+
+    async def test_store_hit_skips_strategy(self, tmp_path: Path) -> None:
+        store = ResolutionStore(tmp_path / "res.json")
+        store.add(
+            key="macro:known-macro",
+            resolved_by="user_input",
+            value={"notion_block_type": "callout"},
+        )
+        strategy = FakeStrategy({})
+        resolver = Resolver(store, strategies=[strategy])
+
+        report = await resolver.resolve([_macro("known-macro")])
+
+        assert report.resolved_count == 1
+        assert report.from_store == 1
+        assert report.newly_resolved == 0
+        assert report.still_unresolved == []
+        assert strategy.call_count == 0
+
+    async def test_store_miss_calls_strategy(self, tmp_path: Path) -> None:
+        store = ResolutionStore(tmp_path / "res.json")
+        strategy = FakeStrategy({"new-macro": {"notion_block_type": "table"}})
+        resolver = Resolver(store, strategies=[strategy])
+
+        report = await resolver.resolve([_macro("new-macro")])
+
+        assert report.resolved_count == 1
+        assert report.from_store == 0
+        assert report.newly_resolved == 1
+        assert strategy.call_count == 1
+        # Should be saved to store
+        assert store.lookup("macro:new-macro") is not None
+
+
+class TestDeduplication:
+    """Same identifier appearing multiple times is resolved only once."""
+
+    async def test_duplicate_items_resolved_once(self, tmp_path: Path) -> None:
+        store = ResolutionStore(tmp_path / "res.json")
+        strategy = FakeStrategy({"dup-macro": {"type": "callout"}})
+        resolver = Resolver(store, strategies=[strategy])
+
+        items = [_macro("dup-macro", "pg-1"), _macro("dup-macro", "pg-2")]
+        report = await resolver.resolve(items)
+
+        assert report.resolved_count == 1
+        assert strategy.call_count == 1
+
+    async def test_different_kinds_same_identifier_not_deduped(self, tmp_path: Path) -> None:
+        """macro:foo and page_link:foo are different keys."""
+        store = ResolutionStore(tmp_path / "res.json")
+        strategy = FakeStrategy({"foo": {"value": "resolved"}})
+        resolver = Resolver(store, strategies=[strategy])
+
+        items = [_macro("foo"), _page_link("foo")]
+        report = await resolver.resolve(items)
+
+        assert report.resolved_count == 2
+        assert strategy.call_count == 2
+
+
+class TestStrategyChain:
+    """Strategies are tried in order; first success wins."""
+
+    async def test_first_strategy_wins(self, tmp_path: Path) -> None:
+        store = ResolutionStore(tmp_path / "res.json")
+        s1 = FakeStrategy({"x": {"from": "s1"}})
+        s2 = FakeStrategy({"x": {"from": "s2"}})
+        resolver = Resolver(store, strategies=[s1, s2])
+
+        report = await resolver.resolve([_macro("x")])
+
+        assert report.newly_resolved == 1
+        entry = store.lookup("macro:x")
+        assert entry is not None
+        assert entry.value == {"from": "s1"}
+        assert s1.call_count == 1
+        assert s2.call_count == 0
+
+    async def test_fallthrough_to_second(self, tmp_path: Path) -> None:
+        store = ResolutionStore(tmp_path / "res.json")
+        s1 = FailStrategy()
+        s2 = FakeStrategy({"y": {"from": "s2"}})
+        resolver = Resolver(store, strategies=[s1, s2])
+
+        report = await resolver.resolve([_macro("y")])
+
+        assert report.newly_resolved == 1
+        assert store.lookup("macro:y") is not None
+
+    async def test_all_fail_stays_unresolved(self, tmp_path: Path) -> None:
+        store = ResolutionStore(tmp_path / "res.json")
+        resolver = Resolver(store, strategies=[FailStrategy()])
+
+        report = await resolver.resolve([_macro("mystery")])
+
+        assert report.resolved_count == 0
+        assert report.still_unresolved == [_macro("mystery")]
+
+
+class TestResolveReport:
+    """Report accurately counts resolved/unresolved/store/new."""
+
+    async def test_mixed_report(self, tmp_path: Path) -> None:
+        store = ResolutionStore(tmp_path / "res.json")
+        store.add(key="macro:cached", resolved_by="user_input", value={"cached": True})
+
+        strategy = FakeStrategy({"resolvable": {"new": True}})
+        resolver = Resolver(store, strategies=[strategy])
+
+        items = [_macro("cached"), _macro("resolvable"), _macro("impossible")]
+        report = await resolver.resolve(items)
+
+        assert report.resolved_count == 2
+        assert report.from_store == 1
+        assert report.newly_resolved == 1
+        assert len(report.still_unresolved) == 1
+        assert report.still_unresolved[0].identifier == "impossible"
+
+    async def test_empty_input(self, tmp_path: Path) -> None:
+        store = ResolutionStore(tmp_path / "res.json")
+        resolver = Resolver(store, strategies=[])
+
+        report = await resolver.resolve([])
+
+        assert report.resolved_count == 0
+        assert report.still_unresolved == []
+
+
+class TestStorePersistence:
+    """Newly resolved items are persisted via store.save()."""
+
+    async def test_auto_save(self, tmp_path: Path) -> None:
+        path = tmp_path / "res.json"
+        store = ResolutionStore(path)
+        strategy = FakeStrategy({"widget": {"type": "database"}})
+        resolver = Resolver(store, strategies=[strategy])
+
+        await resolver.resolve([_macro("widget")])
+
+        # Reload from disk
+        store2 = ResolutionStore(path)
+        assert store2.lookup("macro:widget") is not None


### PR DESCRIPTION
## Summary

- **ResolutionStore**: persistent store (`resolution.json`) for resolved facts — JIRA servers, custom macros, page links
- **Unresolved collection**: converter now returns `ConversionResult(blocks, unresolved)` instead of plain block list
- **Resolver**: deduplicates items, checks store first, then tries pluggable strategies in order
- **Re-conversion**: when store has entries, converter uses resolved values instead of placeholders (deepcopy-safe)

## Architecture

```
convert_page(xhtml, ruleset, store=store)
  ├─ rule 있음 → 바로 변환
  ├─ store에 해결 이력 → 재사용
  └─ 미해결 → placeholder + UnresolvedItem 수집
                    ↓
          resolver.resolve(unresolved)
            ├─ store hit → skip
            ├─ strategy 성공 → store에 저장
            └─ 실패 → still_unresolved
```

## New files

| File | Purpose |
|------|---------|
| `converter/schemas.py` | `ResolutionEntry`, `UnresolvedItem`, `ConversionResult`, `ResolutionData` |
| `converter/resolution.py` | `ResolutionStore` — load/save/lookup/add |
| `converter/resolver.py` | `Resolver`, `ResolveStrategy` protocol, `ResolveReport` |
| `tests/unit/test_resolution.py` | 15 tests |
| `tests/unit/test_resolver.py` | 10 tests |

## Next steps (not in this PR)

- AI strategy implementation (Claude API)
- User interaction strategy (CLI prompts)
- API strategy (Confluence applinks)
- CLI wiring (`--resolution` option)
- JIRA server collection + resolution

Closes #43

## Test plan

- [x] `uv run ruff check src/ tests/` passes
- [x] `uv run mypy src/` passes
- [x] `uv run pytest` — 211 tests pass (excluding pre-existing `.env` config test issue)
- [ ] Manual review of converter behavior with/without store

🤖 Generated with [Claude Code](https://claude.com/claude-code)