### PR TITLE
chore: agent prompts — expand macro coverage (jira/drawio/expand/status/code)

### DIFF
--- a/.claude/agents/discover/pattern-discovery.md
+++ b/.claude/agents/discover/pattern-discovery.md
@@ -32,6 +32,24 @@ You are a pattern discovery agent. Your job is to analyze Confluence XHTML conte
    - Total `frequency` count across all pages
 4. **Write the output** as JSON to the specified output path
 
+### Required macro coverage checklist
+
+The following five macros are **first-class migration targets**. Whenever the input contains any of these, you MUST emit a pattern entry for them — never skip or merge them into other categories. If a macro is not present in the input, omit it; do not invent entries.
+
+| Macro | `ac:name` value | Body type | Key parameters to capture in snippets |
+|---|---|---|---|
+| Jira issue | `jira` | self-closing (no body) | `key` (issue key, e.g. `PROJ-123`), `server`, `serverId` |
+| Draw.io diagram | `drawio` | self-closing (no body) | `diagramName`, `revision`, optional `width`/`height` |
+| Expand (collapsible) | `expand` | `ac:rich-text-body` | `title` (heading text); body may contain nested blocks including other macros |
+| Status label | `status` | self-closing (no body) | `title` (label text), `colour` (Green/Red/Yellow/Blue/Grey) |
+| Code block | `code` | `ac:plain-text-body` CDATA | `language`, optional `title`, optional `linenumbers` |
+
+Recognition tips:
+- A macro is the `<ac:structured-macro ac:name="..."/>` element — match on the `ac:name` attribute, not the surrounding context.
+- `expand` wraps a `<ac:rich-text-body>` that can contain arbitrary block children, including nested `code`, `status`, and other macros. Report each inner macro as its own pattern too — do not merge them into the `expand` entry.
+- `code` always uses `<ac:plain-text-body><![CDATA[...]]></ac:plain-text-body>` — never `rich-text-body`. `status`, `jira`, and `drawio` have no body.
+- `status` may appear inline inside a paragraph (multiple per paragraph is common).
+
 ### Important rules
 
 - Extract snippets **verbatim** from the source — do not modify or prettify the XHTML

--- a/.claude/agents/discover/rule-proposer.md
+++ b/.claude/agents/discover/rule-proposer.md
@@ -40,6 +40,18 @@ You are a rule proposer agent. Your job is to read discovered Confluence pattern
 - **Standard HTML**: `<h1-6>` → `heading_1/2/3`, `<ul>/<ol>` → list items, `<pre><code>` → `code` block, `<table>` → `table` block, `<blockquote>` → `quote`
 - For patterns with no Notion equivalent, propose the closest approximation and mark confidence as "low"
 
+### Target macro mapping (required)
+
+These five macros are the primary migration targets. When any of them appears in `output/patterns.json`, you MUST emit a rule following this table exactly. Treat these as canonical — extend, do not override.
+
+| Macro pattern | Notion block | Key mapping details | Confidence |
+|---|---|---|---|
+| `macro:jira` | `paragraph` w/ rich_text link | Link text = `key` parameter (e.g. `PROJ-1234`). URL = `{jira_base_url}/browse/{key}` where `jira_base_url` is derived from the `server`/`serverId` parameters (resolved via environment config). If no base URL is resolvable, fall back to plain text with the key. | medium |
+| `macro:drawio` | `image` (external) | URL = attachment URL derived from `diagramName` (+ optional `revision`), typically `{confluence_base}/download/attachments/{pageId}/{diagramName}.png`. Use the rendered PNG, not the XML source. Add a caption with the diagram name so the block is traceable when auth blocks the image. | low |
+| `macro:expand` | `toggle` | Toggle rich_text = `title` parameter. Recursively convert `ac:rich-text-body` children into Notion blocks and attach as `children`. Inner macros (e.g. nested `code`, `status`) are converted by their own rules — do not flatten them. | high |
+| `macro:status` | `paragraph` rich_text w/ color annotation | Text = `title` parameter. `colour` → Notion annotation color: `Green→green`, `Red→red`, `Yellow→yellow`, `Blue→blue`, `Grey→gray` (note `gray`, not `grey`). Missing `colour` → `default`. When multiple status macros appear inline in one paragraph, emit multiple rich_text runs inside the same paragraph rather than separate blocks. | medium |
+| `macro:code` | `code` | `language` parameter → Notion `code.language` (lowercase; fall back to `plain text` when absent). Body = CDATA content of `ac:plain-text-body` placed verbatim into a single rich_text text run. Drop `title` and `linenumbers` — Notion has no equivalent. | high |
+
 ### Important rules
 
 - The `example_output` must be valid Notion API block JSON (as used in the `children` array of `pages.create`)

--- a/tests/fixtures/eval/expected_patterns.json
+++ b/tests/fixtures/eval/expected_patterns.json
@@ -1,6 +1,6 @@
 {
   "sample_dir": "samples/",
-  "pages_analyzed": 3,
+  "pages_analyzed": 4,
   "patterns": [
     {
       "pattern_id": "macro:toc",
@@ -16,13 +16,56 @@
     {
       "pattern_id": "macro:code",
       "pattern_type": "macro",
-      "description": "Code block macro — renders syntax-highlighted source code",
+      "description": "Code block macro with optional language parameter — renders syntax-highlighted source in an ac:plain-text-body CDATA block",
       "example_snippets": [
-        "<ac:structured-macro ac:name=\"code\"><ac:parameter ac:name=\"language\">java</ac:parameter><ac:plain-text-body><![CDATA[public class Main {}]]></ac:plain-text-body></ac:structured-macro>",
-        "<ac:structured-macro ac:name=\"code\"><ac:parameter ac:name=\"language\">python</ac:parameter><ac:plain-text-body><![CDATA[print('hello')]]></ac:plain-text-body></ac:structured-macro>",
+        "<ac:structured-macro ac:name=\"code\" ac:schema-version=\"1\"><ac:parameter ac:name=\"language\">java</ac:parameter><ac:parameter ac:name=\"title\">AuthAdapter.java</ac:parameter><ac:parameter ac:name=\"linenumbers\">true</ac:parameter><ac:plain-text-body><![CDATA[public final class AuthAdapter {}]]></ac:plain-text-body></ac:structured-macro>",
+        "<ac:structured-macro ac:name=\"code\" ac:schema-version=\"1\"><ac:parameter ac:name=\"language\">bash</ac:parameter><ac:parameter ac:name=\"title\">deploy.sh</ac:parameter><ac:plain-text-body><![CDATA[kubectl apply -f manifests/]]></ac:plain-text-body></ac:structured-macro>",
         "<ac:structured-macro ac:name=\"code\"><ac:plain-text-body><![CDATA[ls -la]]></ac:plain-text-body></ac:structured-macro>"
       ],
-      "source_pages": ["27835336", "27849051", "27800100"],
+      "source_pages": ["27835336", "27849051", "29130800"],
+      "frequency": 4
+    },
+    {
+      "pattern_id": "macro:jira",
+      "pattern_type": "macro",
+      "description": "Jira issue macro — references a ticket by key; renders inline as an issue link/badge",
+      "example_snippets": [
+        "<ac:structured-macro ac:name=\"jira\" ac:schema-version=\"1\"><ac:parameter ac:name=\"server\">System Jira</ac:parameter><ac:parameter ac:name=\"serverId\">00000000-0000-0000-0000-000000000000</ac:parameter><ac:parameter ac:name=\"key\">PROJ-1234</ac:parameter></ac:structured-macro>",
+        "<ac:structured-macro ac:name=\"jira\" ac:schema-version=\"1\"><ac:parameter ac:name=\"server\">System Jira</ac:parameter><ac:parameter ac:name=\"serverId\">00000000-0000-0000-0000-000000000000</ac:parameter><ac:parameter ac:name=\"key\">PROJ-5678</ac:parameter></ac:structured-macro>"
+      ],
+      "source_pages": ["29130800"],
+      "frequency": 2
+    },
+    {
+      "pattern_id": "macro:drawio",
+      "pattern_type": "macro",
+      "description": "Draw.io diagram macro — embeds a diagram stored as an attachment; resolves by diagramName (and optional revision)",
+      "example_snippets": [
+        "<ac:structured-macro ac:name=\"drawio\" ac:schema-version=\"1\"><ac:parameter ac:name=\"diagramName\">release-topology</ac:parameter><ac:parameter ac:name=\"revision\">4</ac:parameter><ac:parameter ac:name=\"width\">800</ac:parameter><ac:parameter ac:name=\"height\">600</ac:parameter></ac:structured-macro>"
+      ],
+      "source_pages": ["29130800"],
+      "frequency": 1
+    },
+    {
+      "pattern_id": "macro:expand",
+      "pattern_type": "macro",
+      "description": "Expand macro — renders a collapsible block with a title; body is rich text and may contain nested macros/blocks",
+      "example_snippets": [
+        "<ac:structured-macro ac:name=\"expand\" ac:schema-version=\"1\"><ac:parameter ac:name=\"title\">Click to view step-by-step deployment commands</ac:parameter><ac:rich-text-body><p>Run the following commands in order on the release host:</p></ac:rich-text-body></ac:structured-macro>"
+      ],
+      "source_pages": ["29130800"],
+      "frequency": 1
+    },
+    {
+      "pattern_id": "macro:status",
+      "pattern_type": "macro",
+      "description": "Status macro — inline labeled chip; 'title' is the label text and 'colour' selects the chip color (Green/Red/Yellow/Blue/Grey)",
+      "example_snippets": [
+        "<ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\"><ac:parameter ac:name=\"title\">IN PROGRESS</ac:parameter><ac:parameter ac:name=\"colour\">Yellow</ac:parameter></ac:structured-macro>",
+        "<ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\"><ac:parameter ac:name=\"title\">BLOCKED</ac:parameter><ac:parameter ac:name=\"colour\">Red</ac:parameter></ac:structured-macro>",
+        "<ac:structured-macro ac:name=\"status\" ac:schema-version=\"1\"><ac:parameter ac:name=\"title\">HEALTHY</ac:parameter><ac:parameter ac:name=\"colour\">Green</ac:parameter></ac:structured-macro>"
+      ],
+      "source_pages": ["29130800"],
       "frequency": 5
     },
     {

--- a/tests/fixtures/eval/expected_proposals.json
+++ b/tests/fixtures/eval/expected_proposals.json
@@ -19,9 +19,9 @@
     {
       "rule_id": "rule:macro:code",
       "source_pattern_id": "macro:code",
-      "source_description": "Code block macro with optional language parameter",
+      "source_description": "Code block macro with optional language parameter and CDATA body",
       "notion_block_type": "code",
-      "mapping_description": "Map ac:structured-macro[code] to a Notion code block. Extract the 'language' parameter for syntax highlighting. Map the CDATA body text to rich_text content.",
+      "mapping_description": "Map ac:structured-macro[code] to a Notion code block. Extract the 'language' parameter for syntax highlighting (lowercase; fall back to 'plain text' when absent). Place the CDATA contents from ac:plain-text-body verbatim into a single rich_text text run. The 'title' and 'linenumbers' parameters have no Notion equivalent and are dropped.",
       "example_input": "<ac:structured-macro ac:name=\"code\"><ac:parameter ac:name=\"language\">python</ac:parameter><ac:plain-text-body><![CDATA[print('hello')]]></ac:plain-text-body></ac:structured-macro>",
       "example_output": {
         "type": "code",
@@ -38,6 +38,119 @@
         }
       },
       "confidence": "high"
+    },
+    {
+      "rule_id": "rule:macro:jira",
+      "source_pattern_id": "macro:jira",
+      "source_description": "Jira issue macro referencing a ticket by key",
+      "notion_block_type": "paragraph",
+      "mapping_description": "Map ac:structured-macro[jira] to an inline rich_text link inside a paragraph. Use the 'key' parameter (e.g. 'PROJ-1234') as the link text. Construct the URL from the Jira server base URL (resolved from the 'server'/'serverId' parameters via environment config, e.g. '{jira_base_url}/browse/{key}'). If the server base URL cannot be resolved, fall back to plain text with the key.",
+      "example_input": "<ac:structured-macro ac:name=\"jira\"><ac:parameter ac:name=\"server\">System Jira</ac:parameter><ac:parameter ac:name=\"serverId\">00000000-0000-0000-0000-000000000000</ac:parameter><ac:parameter ac:name=\"key\">PROJ-1234</ac:parameter></ac:structured-macro>",
+      "example_output": {
+        "type": "paragraph",
+        "paragraph": {
+          "rich_text": [
+            {
+              "type": "text",
+              "text": {
+                "content": "PROJ-1234",
+                "link": {
+                  "url": "https://jira.example.com/browse/PROJ-1234"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "confidence": "medium"
+    },
+    {
+      "rule_id": "rule:macro:drawio",
+      "source_pattern_id": "macro:drawio",
+      "source_description": "Draw.io diagram macro embedding a diagram attachment by name",
+      "notion_block_type": "image",
+      "mapping_description": "Map ac:structured-macro[drawio] to a Notion external image block. Resolve the attachment URL from the Confluence page using the 'diagramName' parameter (and 'revision' if present) — typically '{confluence_base}/download/attachments/{pageId}/{diagramName}.png'. Draw.io stores both the diagram source and a rendered PNG as attachments; use the PNG. Because Notion cannot render draw.io natively and the URL may require auth, mark confidence as low and surface a caption with the diagram name for traceability.",
+      "example_input": "<ac:structured-macro ac:name=\"drawio\"><ac:parameter ac:name=\"diagramName\">release-topology</ac:parameter><ac:parameter ac:name=\"revision\">4</ac:parameter></ac:structured-macro>",
+      "example_output": {
+        "type": "image",
+        "image": {
+          "type": "external",
+          "external": {
+            "url": "https://confluence.example.com/download/attachments/29130800/release-topology.png"
+          },
+          "caption": [
+            {
+              "type": "text",
+              "text": {
+                "content": "release-topology"
+              }
+            }
+          ]
+        }
+      },
+      "confidence": "low"
+    },
+    {
+      "rule_id": "rule:macro:expand",
+      "source_pattern_id": "macro:expand",
+      "source_description": "Expand macro — collapsible section with title and rich-text body",
+      "notion_block_type": "toggle",
+      "mapping_description": "Map ac:structured-macro[expand] to a Notion toggle block. Use the 'title' parameter as the toggle's rich_text heading. Recursively convert the nested ac:rich-text-body into Notion blocks and attach them as the toggle's children. Preserve nested macros (code, status, etc.) by applying their own rules to the converted children.",
+      "example_input": "<ac:structured-macro ac:name=\"expand\"><ac:parameter ac:name=\"title\">Deployment commands</ac:parameter><ac:rich-text-body><p>Run the commands in order.</p></ac:rich-text-body></ac:structured-macro>",
+      "example_output": {
+        "type": "toggle",
+        "toggle": {
+          "rich_text": [
+            {
+              "type": "text",
+              "text": {
+                "content": "Deployment commands"
+              }
+            }
+          ],
+          "children": [
+            {
+              "type": "paragraph",
+              "paragraph": {
+                "rich_text": [
+                  {
+                    "type": "text",
+                    "text": {
+                      "content": "Run the commands in order."
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "confidence": "high"
+    },
+    {
+      "rule_id": "rule:macro:status",
+      "source_pattern_id": "macro:status",
+      "source_description": "Status macro — inline colored label chip",
+      "notion_block_type": "paragraph",
+      "mapping_description": "Map ac:structured-macro[status] to an inline rich_text run with a Notion color annotation. Use the 'title' parameter as the text content. Map the 'colour' parameter to a Notion color: Green→green, Red→red, Yellow→yellow, Blue→blue, Grey→gray (note the 'gray' vs 'grey' spelling). When multiple status macros appear inline within a paragraph, emit multiple rich_text runs inside the same paragraph rather than separate blocks. If colour is missing, default to 'default'.",
+      "example_input": "<ac:structured-macro ac:name=\"status\"><ac:parameter ac:name=\"title\">IN PROGRESS</ac:parameter><ac:parameter ac:name=\"colour\">Yellow</ac:parameter></ac:structured-macro>",
+      "example_output": {
+        "type": "paragraph",
+        "paragraph": {
+          "rich_text": [
+            {
+              "type": "text",
+              "text": {
+                "content": "IN PROGRESS"
+              },
+              "annotations": {
+                "color": "yellow"
+              }
+            }
+          ]
+        }
+      },
+      "confidence": "medium"
     },
     {
       "rule_id": "rule:element:ac-link",


### PR DESCRIPTION
## Summary

이슈 #21의 매크로 커버리지 확장. discover 에이전트(pattern-discovery + rule-proposer) 프롬프트에 5종 타겟 매크로(jira/drawio/expand/status/code-block) 처리 가이드 추가.

Closes #21

## Changes

- `.claude/agents/discover/pattern-discovery.md` — target macro checklist 추가
- `.claude/agents/discover/rule-proposer.md` — target macro mapping table 추가
- `tests/fixtures/eval/expected_*.json` — 5종 매크로 룰 추가 (signal용, gate 아님)
- `samples/29130800.xhtml` — 5종 매크로 합성 샘플 (gitignored, 로컬 검증용)

## Verification

discover 재실행 + eval 측정 결과 (PR 작성 후 수동 검증):
- 5종 타겟 매크로 모두 출력에 포함 (toc, jira, info, status, drawio, expand, code) ✓
- F1 26.7% → 54.5%, Recall 50% → 75% (큰 개선)
- 단, eval은 여전히 \`partial\` 상태 — 이유는 ADR-004 / 후속 이슈 #62 참조 (정답표 매칭 본질적 한계)

## eval 한계 인지

본 PR 작업 중 eval 프레임워크의 본질적 한계가 드러나, 별도 트랙으로 분리:
- **ADR-004**: eval은 회귀 감지 신호로만 사용, 머지 게이트 아님 (#61)
- **eval 재설계 이슈**: 의미적 커버리지 + LLM-as-judge로 갈아엎기 (#62)

## Test plan

- [x] \`uv run ruff check src/ tests/\` passes
- [x] \`uv run mypy src/\` passes
- [x] \`uv run pytest\` — 262 passed (3 \`test_config\` 실패는 사전 존재 결함, 로컬 \`.env\` 영향, #21과 무관)
- [x] \`bash scripts/discover.sh samples/\` 재실행으로 5종 매크로 출력 확인
- [x] \`bash scripts/run-eval.sh\` 실행 (signal 확인)