### PR TITLE
chore: ADR-004 — eval as signal, not merge gate

### DIFF
--- a/.claude/docs/ADR.md
+++ b/.claude/docs/ADR.md
@@ -19,3 +19,9 @@
 - **Decision**: develop.sh의 Fix 루프에 서킷브레이커 적용. OPEN 시 exit가 아니라 re-plan (다른 접근법 시도).
 - **Why**: 같은 에러 반복 fix는 토큰 낭비. OPEN → re-plan → HALF_OPEN probe로 자동 복구 시도 후 실패시만 사람 개입.
 - **Impact**: `output/dev/circuit.json`으로 상태 persist. `--from 5`가 HALF_OPEN 트리거.
+
+## ADR-004: Eval as Signal, Not Merge Gate
+
+- **Decision**: `tests/fixtures/eval/expected_*.json` rule_id 매칭은 회귀 감지 신호로만 사용. 머지 게이트로 쓰지 않음. 향후 의미적 커버리지 + LLM-as-judge로 재설계.
+- **Why**: 같은 매크로도 문서 맥락에 따라 다양한 Notion 매핑이 자연스러움(N:M). 매크로 종류는 무한 확장(유저 플러그인) + LLM 출력의 rule_id 비결정성 때문에 정답표 enumerate는 본질적 한계.
+- **Impact**: CLAUDE.md "프롬프트 변경 전 run-eval.sh" 규칙은 변경의 영향 가시화 용도로만 유지. PR 머지 결정에서 `partial`/낮은 F1을 자동 reject 사유로 쓰지 않음.


### PR DESCRIPTION
## Summary

- ADR-004 추가: fixture 기반 rule_id 매칭은 회귀 감지 신호로만 사용, 머지 게이트로 쓰지 않음
- 향후 의미적 커버리지 + LLM-as-judge 방식으로 eval 재설계 예정 (별도 이슈로 추적)

## Why

- **N:M 매핑**: 같은 매크로(`info` 등)도 문서 맥락에 따라 callout/quote/toggle/plain 등 다양한 Notion 매핑이 자연스러움 — 정답이 1개로 고정될 수 없음
- **무한 확장성**: Confluence 매크로는 수십~수백 종 + 유저 플러그인. 손으로 정답표 enumerate 불가능
- **LLM 비결정성**: 같은 패턴도 매번 다른 rule_id(`pre` vs `pre-block`)로 명명되어 문자열 매칭 fragile

## Impact

- CLAUDE.md "프롬프트 변경 전 \`run-eval.sh\`" 규칙은 **변경 영향 가시화** 용도로 유지
- PR 머지 결정에서 \`partial\`/낮은 F1을 자동 reject 사유로 쓰지 않음
- 후속 작업(eval 재설계)은 별도 이슈

## Test plan

- [x] ADR.md 형식 일관성 (3줄: Decision/Why/Impact) 유지