### PR TITLE
docs: add ADR-005 (ambiguity → ask human → persist as rule)

### DIFF
--- a/.claude/docs/ADR.md
+++ b/.claude/docs/ADR.md
@@ -25,3 +25,9 @@
 - **Decision**: `tests/fixtures/eval/expected_*.json` rule_id 매칭은 회귀 감지 신호로만 사용. 머지 게이트로 쓰지 않음. 향후 의미적 커버리지 + LLM-as-judge로 재설계.
 - **Why**: 같은 매크로도 문서 맥락에 따라 다양한 Notion 매핑이 자연스러움(N:M). 매크로 종류는 무한 확장(유저 플러그인) + LLM 출력의 rule_id 비결정성 때문에 정답표 enumerate는 본질적 한계.
 - **Impact**: CLAUDE.md "프롬프트 변경 전 run-eval.sh" 규칙은 변경의 영향 가시화 용도로만 유지. PR 머지 결정에서 `partial`/낮은 F1을 자동 reject 사유로 쓰지 않음.
+
+## ADR-005: Ambiguity → Ask Human → Persist as Rule
+
+- **Decision**: 변환 모호성(테이블 vs DB, 매크로 N:M 매핑 등)은 자동 판정·휴리스틱으로 해결하지 않고 `rule lookup → 없으면 사람에게 질의 → 답을 규칙으로 저장`을 기본 흐름으로 한다. discover 파이프라인의 patterns→rules 모델을 신규 변환 기능에도 동일하게 적용.
+- **Why**: Confluence는 회사·팀별 사용 패턴 차이가 커서 (커스텀 매크로, 자유로운 테이블 구조 등) 하드코딩 휴리스틱·LLM 단독 판정으로 일반화 불가. 사람이 한 번 결정한 룰은 같은 시그니처가 다시 나올 때 재사용되어 인터랙션 비용이 점근적으로 0으로 수렴.
+- **Impact**: 새 기능 설계 시 자동 판정을 1순위로 제안하지 않음(보조 수단으로만). 룰 저장소 위치·key 시그니처·비대화형(CI) 실행 시 fallback 정책을 기능별로 명시. LLM은 룰 초안 제안 등 보조 역할.


### PR DESCRIPTION
## Summary
- Codifies an architectural philosophy that's already implicit in the discover pipeline (patterns → rules accumulation) so it can be cited as the basis for upcoming features.
- Establishes \`rule lookup → ask human if missing → persist answer as a rule\` as the default flow for ambiguous conversion decisions, rather than automatic heuristics or single-shot LLM judgments.
- Immediate consumer: issue #57 (table → Notion DB auto-detection), where the design will follow this ADR rather than relying on an LLM classifier in isolation.

## Why now
Confluence usage patterns vary too much across companies and teams (custom macros, free-form table structures) for hardcoded heuristics or LLM-only judgments to generalize. The discover pipeline already operates this way for macro mappings; this ADR makes the principle explicit so future features apply it consistently.

## Test plan
- [x] Documentation only — no code changes.
- [ ] Reviewer reads ADR-005 and confirms the wording matches the intended philosophy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)