### PR TITLE
feat: table → DB rule store + heuristics (issue #57 part 1)

### DIFF
--- a/src/confluence_to_notion/converter/schemas.py
+++ b/src/confluence_to_notion/converter/schemas.py
@@ -7,7 +7,9 @@ custom macro mappings, page ID lookups — so they're not re-asked on subsequent
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
+
+NotionPropertyType = Literal["title", "rich_text", "select", "date", "people"]
 
 
 class ResolutionEntry(BaseModel):
@@ -77,3 +79,52 @@ class ConversionResult(BaseModel):
         default_factory=list,
         description="Elements the converter couldn't handle deterministically",
     )
+
+
+class TableRule(BaseModel):
+    """Rule entry describing how a table (identified by its header signature) maps to Notion.
+
+    When ``is_database`` is True, the converter will later emit a ``child_database`` reference
+    instead of a layout table. ``column_types`` maps each (normalized) header to a Notion
+    property type, and ``title_column`` picks which column becomes the database's title.
+    """
+
+    is_database: bool = Field(
+        description="Whether tables matching this signature should become a Notion database",
+    )
+    title_column: str | None = Field(
+        default=None,
+        description="Column name to use as the Notion database's title property",
+    )
+    column_types: dict[str, NotionPropertyType] | None = Field(
+        default=None,
+        description="Map of column name → Notion property type",
+    )
+
+
+class TableRuleSet(BaseModel):
+    """Root model for output/rules/table-rules.json.
+
+    Keys are normalized header signatures (columns joined by '|', lowercased and trimmed,
+    order preserved). A rule may assert ``title_column`` — it must appear in the signature's
+    column list.
+    """
+
+    rules: dict[str, TableRule] = Field(
+        default_factory=dict,
+        description="Map of normalized header signature → table rule",
+    )
+
+    @model_validator(mode="after")
+    def _validate_rules(self) -> "TableRuleSet":
+        for key, rule in self.rules.items():
+            if not key:
+                raise ValueError("TableRuleSet rule key must be a non-empty signature")
+            if rule.title_column is not None:
+                columns = key.split("|")
+                if rule.title_column not in columns:
+                    raise ValueError(
+                        f"title_column {rule.title_column!r} not in signature columns "
+                        f"{columns!r}"
+                    )
+        return self

--- a/src/confluence_to_notion/converter/table_rules.py
+++ b/src/confluence_to_notion/converter/table_rules.py
@@ -1,0 +1,165 @@
+"""Table rule store — header-signature keyed rules for table → Notion database mapping.
+
+The store persists user decisions (and AI-drafted defaults) about whether a given
+Confluence table should be migrated as a Notion database, which column becomes the
+title, and what Notion property type each column maps to. Rules are keyed by a
+normalized header signature so the same layout across many pages resolves once.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from confluence_to_notion.converter.schemas import (
+    NotionPropertyType,
+    TableRule,
+    TableRuleSet,
+)
+
+logger = logging.getLogger(__name__)
+
+_DATE_RE = re.compile(
+    r"^(?:\d{4}[-/.]\d{1,2}[-/.]\d{1,2}|\d{1,2}[-/.]\d{1,2}[-/.]\d{4})$"
+)
+_SELECT_MAX_DISTINCT = 5
+_SELECT_MIN_ROWS = 3
+
+
+def normalize_header_signature(headers: list[str]) -> str:
+    """Normalize a header list into a canonical signature string.
+
+    Headers are lowercased, stripped, and joined with ``|`` preserving order.
+    Raises ``ValueError`` if the list is empty.
+    """
+    if not headers:
+        raise ValueError("normalize_header_signature requires at least one header")
+    return "|".join(h.strip().lower() for h in headers)
+
+
+def _local_tag(elem: ET.Element) -> str:
+    tag = elem.tag
+    if "}" in tag:
+        return tag.split("}", 1)[1]
+    return tag
+
+
+def _header_text(th: ET.Element) -> str:
+    return " ".join("".join(th.itertext()).split()).strip()
+
+
+def extract_headers_from_xhtml(context_xhtml: str) -> list[str]:
+    """Extract the column headers from a ``<table>`` XHTML snippet.
+
+    Prefers the first row inside ``<thead>``; falls back to the first ``<tr>`` in the
+    table. Returns ``[]`` if the snippet can't be parsed or no ``<th>`` cells are found.
+    Inline formatting tags inside ``<th>`` are stripped; colspan/rowspan are ignored
+    (each ``<th>`` contributes one header).
+    """
+    try:
+        root = ET.fromstring(context_xhtml)
+    except ET.ParseError:
+        logger.debug("extract_headers_from_xhtml: failed to parse snippet")
+        return []
+
+    thead = next((c for c in root.iter() if _local_tag(c) == "thead"), None)
+    header_row: ET.Element | None = None
+    if thead is not None:
+        header_row = next((c for c in thead if _local_tag(c) == "tr"), None)
+    if header_row is None:
+        header_row = next((c for c in root.iter() if _local_tag(c) == "tr"), None)
+    if header_row is None:
+        return []
+
+    headers: list[str] = []
+    for cell in header_row:
+        if _local_tag(cell) == "th":
+            headers.append(_header_text(cell))
+    return headers
+
+
+def _looks_like_date(values: list[str]) -> bool:
+    stripped = [v.strip() for v in values if v and v.strip()]
+    if not stripped:
+        return False
+    return all(_DATE_RE.match(v) for v in stripped)
+
+
+def _looks_like_select(values: list[str]) -> bool:
+    non_empty = [v.strip() for v in values if v and v.strip()]
+    if len(non_empty) < _SELECT_MIN_ROWS:
+        return False
+    distinct = set(non_empty)
+    if len(distinct) > _SELECT_MAX_DISTINCT:
+        return False
+    # Require at least one repeat so free-form short strings don't look categorical.
+    return len(distinct) < len(non_empty)
+
+
+def infer_column_types(
+    rows: list[list[str]],
+    headers: list[str],
+) -> dict[str, NotionPropertyType]:
+    """Draft a property type for each header using simple content heuristics.
+
+    Returns a mapping whose keys are the input header names (order matches ``headers``).
+    ISO/common date columns → ``'date'``; low-cardinality string columns (≤5 distinct
+    values, ≥3 rows, at least one repeat) → ``'select'``; everything else → ``'rich_text'``.
+    The caller decides which column becomes the ``'title'``.
+    """
+    result: dict[str, NotionPropertyType] = {}
+    for idx, header in enumerate(headers):
+        column_values = [row[idx] if idx < len(row) else "" for row in rows]
+        if _looks_like_date(column_values):
+            result[header] = "date"
+        elif _looks_like_select(column_values):
+            result[header] = "select"
+        else:
+            result[header] = "rich_text"
+    return result
+
+
+class TableRuleStore:
+    """Load, query, and persist table rules keyed by header signature.
+
+    Mirrors the ``ResolutionStore`` pattern: ``pathlib.Path`` init, load-on-construct,
+    explicit ``save()``. A missing file yields an empty store.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self.data = self._load()
+
+    def _load(self) -> TableRuleSet:
+        if not self._path.exists():
+            return TableRuleSet()
+        try:
+            return TableRuleSet.model_validate_json(
+                self._path.read_text(encoding="utf-8")
+            )
+        except (ValueError, OSError):
+            logger.warning("Failed to load %s, starting fresh", self._path)
+            return TableRuleSet()
+
+    def lookup(self, headers: list[str]) -> TableRule | None:
+        """Return the rule for the given headers, or ``None`` if absent."""
+        try:
+            key = normalize_header_signature(headers)
+        except ValueError:
+            return None
+        return self.data.rules.get(key)
+
+    def upsert(self, headers: list[str], rule: TableRule) -> None:
+        """Insert or overwrite the rule for the given headers."""
+        key = normalize_header_signature(headers)
+        self.data.rules[key] = rule
+
+    def save(self) -> None:
+        """Persist the store to disk, creating parent directories as needed."""
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._path.write_text(
+            self.data.model_dump_json(indent=2),
+            encoding="utf-8",
+        )

--- a/tests/unit/test_table_rules.py
+++ b/tests/unit/test_table_rules.py
@@ -1,0 +1,287 @@
+"""Unit tests for the Table Rule store — schemas, extractors, and heuristics."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from confluence_to_notion.converter.schemas import TableRule, TableRuleSet
+
+
+class TestTableRule:
+    def test_defaults(self) -> None:
+        rule = TableRule(is_database=False)
+        assert rule.is_database is False
+        assert rule.title_column is None
+        assert rule.column_types is None
+
+    def test_with_column_types(self) -> None:
+        rule = TableRule(
+            is_database=True,
+            title_column="Name",
+            column_types={
+                "Name": "title",
+                "Owner": "people",
+                "Due": "date",
+                "Status": "select",
+                "Notes": "rich_text",
+            },
+        )
+        assert rule.title_column == "Name"
+        assert rule.column_types is not None
+        assert rule.column_types["Owner"] == "people"
+
+    def test_invalid_column_type(self) -> None:
+        with pytest.raises(ValueError):
+            TableRule(
+                is_database=True,
+                title_column="Name",
+                column_types={"Name": "title", "X": "not_a_real_type"},  # type: ignore[dict-item]
+            )
+
+
+class TestTableRuleSet:
+    def test_empty(self) -> None:
+        rs = TableRuleSet()
+        assert rs.rules == {}
+
+    def test_rejects_empty_signature_key(self) -> None:
+        with pytest.raises(ValueError):
+            TableRuleSet(rules={"": TableRule(is_database=False)})
+
+    def test_title_column_must_be_in_signature(self) -> None:
+        with pytest.raises(ValueError):
+            TableRuleSet(
+                rules={
+                    "name|owner|due": TableRule(
+                        is_database=True,
+                        title_column="Missing",
+                        column_types={"Name": "title"},
+                    ),
+                }
+            )
+
+    def test_title_column_in_signature_ok(self) -> None:
+        rs = TableRuleSet(
+            rules={
+                "name|owner|due": TableRule(
+                    is_database=True,
+                    title_column="name",
+                    column_types={
+                        "name": "title",
+                        "owner": "people",
+                        "due": "date",
+                    },
+                ),
+            }
+        )
+        assert rs.rules["name|owner|due"].title_column == "name"
+
+    def test_roundtrip_preserves_key_order(self) -> None:
+        ordered_keys = [
+            "alpha|beta|gamma",
+            "name|owner|status",
+            "a|b",
+        ]
+        rules = {
+            key: TableRule(is_database=False) for key in ordered_keys
+        }
+        rs = TableRuleSet(rules=rules)
+        raw = rs.model_dump_json()
+        restored = TableRuleSet.model_validate_json(raw)
+        assert list(restored.rules.keys()) == ordered_keys
+
+        # Also verify underlying JSON preserves order (Python 3.7+ dict guarantees
+        # insertion order; json.loads mirrors that).
+        parsed = json.loads(raw)
+        assert list(parsed["rules"].keys()) == ordered_keys
+
+
+# --- Tests for extractors and heuristics in converter/table_rules.py ---
+
+
+class TestNormalizeHeaderSignature:
+    def test_basic(self) -> None:
+        from confluence_to_notion.converter.table_rules import normalize_header_signature
+
+        assert normalize_header_signature(["Name", "Owner", "Due"]) == "name|owner|due"
+
+    def test_strip_and_lowercase(self) -> None:
+        from confluence_to_notion.converter.table_rules import normalize_header_signature
+
+        assert (
+            normalize_header_signature(["  Task  ", "STATUS", " Due Date "])
+            == "task|status|due date"
+        )
+
+    def test_order_preserved(self) -> None:
+        from confluence_to_notion.converter.table_rules import normalize_header_signature
+
+        assert (
+            normalize_header_signature(["Z", "A", "M"]) == "z|a|m"
+        )
+
+    def test_empty_raises(self) -> None:
+        from confluence_to_notion.converter.table_rules import normalize_header_signature
+
+        with pytest.raises(ValueError):
+            normalize_header_signature([])
+
+
+class TestExtractHeadersFromXhtml:
+    def test_thead_preferred(self) -> None:
+        from confluence_to_notion.converter.table_rules import extract_headers_from_xhtml
+
+        xhtml = (
+            "<table>"
+            "<thead><tr><th>Name</th><th>Owner</th></tr></thead>"
+            "<tbody><tr><td>x</td><td>y</td></tr></tbody>"
+            "</table>"
+        )
+        assert extract_headers_from_xhtml(xhtml) == ["Name", "Owner"]
+
+    def test_first_tr_fallback(self) -> None:
+        from confluence_to_notion.converter.table_rules import extract_headers_from_xhtml
+
+        xhtml = (
+            "<table>"
+            "<tr><th>Task</th><th>Status</th></tr>"
+            "<tr><td>a</td><td>b</td></tr>"
+            "</table>"
+        )
+        assert extract_headers_from_xhtml(xhtml) == ["Task", "Status"]
+
+    def test_no_th_returns_empty(self) -> None:
+        from confluence_to_notion.converter.table_rules import extract_headers_from_xhtml
+
+        xhtml = (
+            "<table>"
+            "<tr><td>a</td><td>b</td></tr>"
+            "</table>"
+        )
+        assert extract_headers_from_xhtml(xhtml) == []
+
+    def test_ignores_colspan_rowspan(self) -> None:
+        from confluence_to_notion.converter.table_rules import extract_headers_from_xhtml
+
+        xhtml = (
+            "<table>"
+            '<thead><tr><th colspan="2">Name</th><th rowspan="1">Owner</th></tr></thead>'
+            "</table>"
+        )
+        assert extract_headers_from_xhtml(xhtml) == ["Name", "Owner"]
+
+    def test_strips_inline_tags(self) -> None:
+        from confluence_to_notion.converter.table_rules import extract_headers_from_xhtml
+
+        xhtml = (
+            "<table>"
+            "<thead><tr><th><strong>Name</strong></th><th><em>Due</em> date</th></tr></thead>"
+            "</table>"
+        )
+        assert extract_headers_from_xhtml(xhtml) == ["Name", "Due date"]
+
+    def test_empty_table_returns_empty(self) -> None:
+        from confluence_to_notion.converter.table_rules import extract_headers_from_xhtml
+
+        assert extract_headers_from_xhtml("<table></table>") == []
+
+
+class TestTableRuleStore:
+    def test_load_missing_file_empty(self, tmp_path: Path) -> None:
+        from confluence_to_notion.converter.table_rules import TableRuleStore
+
+        store = TableRuleStore(tmp_path / "table-rules.json")
+        assert store.data.rules == {}
+
+    def test_upsert_and_save(self, tmp_path: Path) -> None:
+        from confluence_to_notion.converter.table_rules import TableRuleStore
+
+        path = tmp_path / "nested" / "table-rules.json"
+        store = TableRuleStore(path)
+        rule = TableRule(
+            is_database=True,
+            title_column="name",
+            column_types={"name": "title", "owner": "people"},
+        )
+        store.upsert(["Name", "Owner"], rule)
+        store.save()
+
+        assert path.exists()
+        reloaded = TableRuleStore(path)
+        found = reloaded.lookup(["Name", "Owner"])
+        assert found is not None
+        assert found.is_database is True
+        assert found.title_column == "name"
+
+    def test_lookup_normalizes_headers(self, tmp_path: Path) -> None:
+        from confluence_to_notion.converter.table_rules import TableRuleStore
+
+        store = TableRuleStore(tmp_path / "table-rules.json")
+        rule = TableRule(is_database=False)
+        store.upsert(["Name", "Owner", "Due"], rule)
+
+        # Different casing / whitespace but same normalized signature.
+        hit = store.lookup(["  name ", "OWNER", "Due"])
+        assert hit is not None
+        assert hit.is_database is False
+
+    def test_lookup_miss(self, tmp_path: Path) -> None:
+        from confluence_to_notion.converter.table_rules import TableRuleStore
+
+        store = TableRuleStore(tmp_path / "table-rules.json")
+        assert store.lookup(["Name"]) is None
+
+
+class TestInferColumnTypes:
+    def test_date_column(self) -> None:
+        from confluence_to_notion.converter.table_rules import infer_column_types
+
+        headers = ["Name", "Due"]
+        rows = [
+            ["Task A", "2026-01-15"],
+            ["Task B", "2026-02-01"],
+            ["Task C", "2026-03-20"],
+        ]
+        types = infer_column_types(rows, headers)
+        assert types["Due"] == "date"
+
+    def test_select_low_cardinality(self) -> None:
+        from confluence_to_notion.converter.table_rules import infer_column_types
+
+        headers = ["Name", "Status"]
+        rows = [
+            ["A", "open"],
+            ["B", "closed"],
+            ["C", "open"],
+            ["D", "in-progress"],
+            ["E", "closed"],
+            ["F", "open"],
+        ]
+        types = infer_column_types(rows, headers)
+        assert types["Status"] == "select"
+
+    def test_rich_text_default(self) -> None:
+        from confluence_to_notion.converter.table_rules import infer_column_types
+
+        headers = ["Name", "Notes"]
+        rows = [
+            ["A", "some long free-form note about project A"],
+            ["B", "different text entirely"],
+            ["C", "yet another unique note with lots of words"],
+            ["D", "and another fully unique block of text"],
+        ]
+        types = infer_column_types(rows, headers)
+        assert types["Notes"] == "rich_text"
+
+    def test_all_headers_mapped(self) -> None:
+        from confluence_to_notion.converter.table_rules import infer_column_types
+
+        headers = ["Name", "Status", "Due"]
+        rows = [
+            ["a", "open", "2026-01-01"],
+            ["b", "closed", "2026-02-01"],
+            ["c", "open", "2026-03-01"],
+        ]
+        types = infer_column_types(rows, headers)
+        assert set(types.keys()) == {"Name", "Status", "Due"}


### PR DESCRIPTION
## Summary
- Adds the rule-lookup foundation for table-vs-database detection per **ADR-005** (ambiguity → ask human → persist as rule).
- New schemas: \`TableRule\`, \`TableRuleSet\`, \`NotionPropertyType\` (\`src/confluence_to_notion/converter/schemas.py\`).
- New module: \`src/confluence_to_notion/converter/table_rules.py\` with \`normalize_header_signature\`, \`extract_headers_from_xhtml\`, \`infer_column_types\`, and \`TableRuleStore\`.
- 26 new unit tests, ruff + mypy clean.

## Scope
This PR delivers the **foundation** only (schemas + rule store + heuristics). Wiring into \`converter.py\` and \`cli.py\` (Pass 1.5 batch prompt, \`NotionClient.create_database\`, \`child_database\` reference emission) is intentionally deferred to follow-up PRs per the plan's \`remaining_description\` — keeps this PR reviewable.

## Design notes (per ADR-005)
- Rule store path: \`output/rules/table-rules.json\` (single file, not per-space).
- Key = normalized header signature (lowercase + trim, **order preserved**).
- Heuristic column-type inference (date regex → \`date\`, low-cardinality enums → \`select\`, etc.) — no LLM in this iteration.

## Test plan
- [x] \`pytest tests/unit/test_table_rules.py\` → 26/26 pass
- [x] \`ruff check src/ tests/\` clean
- [x] \`mypy src/\` clean
- [ ] Reviewer confirms schema shape matches the design before downstream wiring lands

## Known
- 3 pre-existing \`test_config.py\` failures are unrelated (local \`.env\` masks the missing-env-var assertions). Same as #21 / PR #60.

Closes part of #57. Follow-up PR will wire converter + CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)