### PR TITLE
feat: feat: table → DB Pass 1.5 batch prompt + converter wiring (issue #57 part 2)

### DIFF
--- a/src/confluence_to_notion/cli.py
+++ b/src/confluence_to_notion/cli.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -16,10 +17,23 @@ from confluence_to_notion.confluence.client import ConfluenceClient
 from confluence_to_notion.confluence.schemas import PageTreeNode
 from confluence_to_notion.converter.converter import convert_page
 from confluence_to_notion.converter.resolution import ResolutionStore
+from confluence_to_notion.converter.schemas import NotionPropertyType, TableRule
+from confluence_to_notion.converter.table_rules import (
+    TableRuleStore,
+    extract_data_rows_from_xhtml,
+    extract_headers_from_xhtml,
+    infer_column_types,
+    normalize_header_signature,
+)
 from confluence_to_notion.notion.client import NotionClientWrapper
 
 app = typer.Typer(help="confluence-to-notion: auto-discover transformation rules")
 console = Console()
+
+
+def _stdin_is_tty() -> bool:
+    """Indirection for sys.stdin.isatty so tests can patch it through CliRunner."""
+    return sys.stdin.isatty()
 
 
 def _load_settings() -> Settings:
@@ -495,14 +509,19 @@ def migrate_tree_pages(
     rules_file: Path = typer.Option(
         Path("output/rules.json"), "--rules", help="Path to rules.json"
     ),
+    table_rules_file: Path = typer.Option(
+        Path("output/rules/table-rules.json"),
+        "--table-rules",
+        help="Path to table-rules.json (header-signature → Notion DB rule)",
+    ),
 ) -> None:
-    """Run the full 2-pass migration: create the Notion tree, then upload bodies.
+    """Run the multi-pass migration: tree → table-rule discovery → body upload.
 
     Pass 1 collects the Confluence tree, creates empty Notion pages, and persists
-    a ``page_link:{title}`` resolution store so that internal links can resolve
-    to Notion page IDs. Pass 2 fetches each Confluence page's XHTML, converts it
-    against the resolution store (so internal links emit mention blocks), and
-    appends the resulting blocks to the pre-created Notion page.
+    a ``page_link:{title}`` resolution store. Pass 1.5 fetches each page's XHTML,
+    discovers tables whose header signatures lack a rule, and (when run on a TTY)
+    prompts the operator to classify them as layout tables or Notion databases.
+    Pass 2 converts each page using both stores and appends the blocks to Notion.
     """
     from confluence_to_notion.agents.schemas import FinalRuleset
 
@@ -532,11 +551,13 @@ def migrate_tree_pages(
 
     confluence = ConfluenceClient(settings)
     notion = NotionClientWrapper(settings)
+    table_rule_store = TableRuleStore(table_rules_file)
 
     async def _run() -> tuple[int, int]:
         async with confluence:
             tree = await confluence.collect_page_tree(root_id)
 
+            # --- Pass 1: create empty Notion pages mirroring the Confluence tree ---
             id_to_notion: dict[str, str] = {}
             id_to_title: dict[str, str] = {}
             store = ResolutionStore(resolution_out)
@@ -556,17 +577,63 @@ def migrate_tree_pages(
             await _create_subtree(tree, parent_id)
             store.save()
 
+            # --- Pass 1.5: discover unresolved table signatures, prompt for rules ---
+            xhtml_cache: dict[str, str] = {}
+            for confluence_id in id_to_notion:
+                page = await confluence.get_page(confluence_id)
+                xhtml_cache[confluence_id] = page.storage_body
+
+            seen_signatures: set[str] = set()
+            interactive = _stdin_is_tty()
+            for confluence_id, xhtml in xhtml_cache.items():
+                pre_result = convert_page(
+                    xhtml,
+                    ruleset,
+                    page_id=confluence_id,
+                    store=store,
+                    table_rules=table_rule_store,
+                )
+                for item in pre_result.unresolved:
+                    if item.kind != "table" or not item.context_xhtml:
+                        continue
+                    headers = extract_headers_from_xhtml(item.context_xhtml)
+                    if not headers:
+                        continue
+                    sig = normalize_header_signature(headers)
+                    if sig in seen_signatures:
+                        continue
+                    seen_signatures.add(sig)
+                    if table_rule_store.lookup(headers) is not None:
+                        continue
+                    if not interactive:
+                        console.print(
+                            f"[yellow]Unresolved table signature (non-TTY, "
+                            f"skipping prompt): {sig}[/yellow]"
+                        )
+                        continue
+                    sample_rows = extract_data_rows_from_xhtml(item.context_xhtml)
+                    draft = infer_column_types(sample_rows, headers)
+                    rule = _prompt_table_rule(
+                        headers=headers,
+                        sample_rows=sample_rows,
+                        column_type_draft=draft,
+                    )
+                    table_rule_store.upsert(headers, rule)
+                    table_rule_store.save()
+
+            # --- Pass 2: convert with both stores and append to Notion ---
             succeeded = 0
             failed = 0
             for confluence_id, notion_page_id in id_to_notion.items():
                 title = id_to_title[confluence_id]
+                xhtml = xhtml_cache[confluence_id]
                 try:
-                    page = await confluence.get_page(confluence_id)
                     result = convert_page(
-                        page.storage_body,
+                        xhtml,
                         ruleset,
                         page_id=confluence_id,
                         store=store,
+                        table_rules=table_rule_store,
                     )
                     await notion.append_blocks(notion_page_id, result.blocks)
                     succeeded += 1
@@ -590,6 +657,46 @@ def migrate_tree_pages(
     )
     if failed > 0:
         raise typer.Exit(code=1)
+
+
+def _prompt_table_rule(
+    *,
+    headers: list[str],
+    sample_rows: list[list[str]],
+    column_type_draft: dict[str, NotionPropertyType],
+) -> TableRule:
+    """Show a table preview and ask the operator to classify it.
+
+    Returns a ``TableRule`` describing whether the table should become a Notion
+    database and, if so, which column is the title and what type each column is.
+    """
+    from rich.table import Table as RichTable
+
+    preview = RichTable(title="Confluence table preview", show_lines=True)
+    for h in headers:
+        preview.add_column(h)
+    for row in sample_rows[:5]:
+        preview.add_row(*row)
+    console.print(preview)
+    console.print(f"[cyan]Inferred column types:[/cyan] {column_type_draft}")
+
+    is_db = typer.confirm("Convert to Notion database?", default=False)
+    if not is_db:
+        return TableRule(is_database=False)
+
+    title_col = typer.prompt("Title column", default=headers[0])
+    # Persisted signatures are lowercased/stripped (normalize_header_signature), so
+    # title_column and column_types keys must match that form or TableRuleSet
+    # validation rejects the store on the next load and wipes every rule.
+    normalized_title = title_col.strip().lower()
+    normalized_types: dict[str, NotionPropertyType] = {
+        k.strip().lower(): v for k, v in column_type_draft.items()
+    }
+    return TableRule(
+        is_database=True,
+        title_column=normalized_title,
+        column_types=normalized_types,
+    )
 
 
 def _extract_title(blocks: list[dict[str, Any]], *, fallback: str) -> str:

--- a/src/confluence_to_notion/converter/converter.py
+++ b/src/confluence_to_notion/converter/converter.py
@@ -16,6 +16,10 @@ from typing import Any
 from confluence_to_notion.agents.schemas import FinalRuleset
 from confluence_to_notion.converter.resolution import ResolutionStore
 from confluence_to_notion.converter.schemas import ConversionResult, UnresolvedItem
+from confluence_to_notion.converter.table_rules import (
+    TableRuleStore,
+    extract_headers_from_xhtml,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +63,7 @@ class _ConversionContext:
     enabled_ids: set[str]
     page_id: str
     store: ResolutionStore | None = None
+    table_rules: TableRuleStore | None = None
     unresolved: list[UnresolvedItem] = field(default_factory=list)
     table_index: int = 0
 
@@ -69,6 +74,7 @@ def convert_page(
     *,
     page_id: str = "",
     store: ResolutionStore | None = None,
+    table_rules: TableRuleStore | None = None,
 ) -> ConversionResult:
     """Convert a Confluence XHTML page to a list of Notion blocks.
 
@@ -78,6 +84,9 @@ def convert_page(
         page_id: Confluence page ID (used to tag unresolved items).
         store: Resolution store — if provided, resolved entries are used
             instead of placeholders for unknown macros and page links.
+        table_rules: Table rule store — if provided, layout-confirmed tables
+            (is_database=False) are converted without an UnresolvedItem so
+            the resolver/Pass 1.5 doesn't re-prompt on them.
 
     Returns:
         ConversionResult with blocks and any unresolved items.
@@ -90,6 +99,7 @@ def convert_page(
         enabled_ids={r.rule_id for r in ruleset.enabled_rules},
         page_id=page_id,
         store=store,
+        table_rules=table_rules,
     )
     xml_str = _XHTML_WRAPPER.format(xhtml)
     root = ET.fromstring(xml_str)
@@ -647,17 +657,28 @@ def _convert_table(
         while len(row_cells) < max_width:
             row_cells.append([])
 
-    context_xhtml = ET.tostring(elem, encoding="unicode")
+    full_xhtml = ET.tostring(elem, encoding="unicode")
+    context_xhtml = full_xhtml
     if len(context_xhtml) > _TABLE_CONTEXT_MAX_LEN:
         context_xhtml = context_xhtml[:_TABLE_CONTEXT_MAX_LEN]
-    ctx.unresolved.append(
-        UnresolvedItem(
-            kind="table",
-            identifier=identifier,
-            source_page_id=ctx.page_id,
-            context_xhtml=context_xhtml,
+
+    suppress_unresolved = False
+    if ctx.table_rules is not None:
+        headers = extract_headers_from_xhtml(full_xhtml)
+        if headers:
+            rule = ctx.table_rules.lookup(headers)
+            if rule is not None and not rule.is_database:
+                suppress_unresolved = True
+
+    if not suppress_unresolved:
+        ctx.unresolved.append(
+            UnresolvedItem(
+                kind="table",
+                identifier=identifier,
+                source_page_id=ctx.page_id,
+                context_xhtml=context_xhtml,
+            )
         )
-    )
 
     return [
         {

--- a/src/confluence_to_notion/converter/table_rules.py
+++ b/src/confluence_to_notion/converter/table_rules.py
@@ -80,6 +80,36 @@ def extract_headers_from_xhtml(context_xhtml: str) -> list[str]:
     return headers
 
 
+def extract_data_rows_from_xhtml(
+    context_xhtml: str, max_rows: int = 5
+) -> list[list[str]]:
+    """Extract up to ``max_rows`` data (non-header) rows from a ``<table>`` snippet.
+
+    Each row is a list of cell texts with inline formatting stripped. Rows whose
+    cells are all ``<th>`` are treated as headers and skipped.
+    """
+    try:
+        root = ET.fromstring(context_xhtml)
+    except ET.ParseError:
+        return []
+
+    rows: list[list[str]] = []
+    for tr in root.iter():
+        if _local_tag(tr) != "tr":
+            continue
+        cells = [c for c in tr if _local_tag(c) in ("td", "th")]
+        if not cells:
+            continue
+        if all(_local_tag(c) == "th" for c in cells):
+            continue
+        rows.append(
+            [" ".join("".join(c.itertext()).split()).strip() for c in cells]
+        )
+        if len(rows) >= max_rows:
+            break
+    return rows
+
+
 def _looks_like_date(values: list[str]) -> bool:
     stripped = [v.strip() for v in values if v and v.strip()]
     if not stripped:

--- a/tests/unit/test_cli_migrate_tree_pages.py
+++ b/tests/unit/test_cli_migrate_tree_pages.py
@@ -12,10 +12,16 @@ from notion_client import APIResponseError
 from typer.testing import CliRunner
 
 from confluence_to_notion.agents.schemas import FinalRuleset
-from confluence_to_notion.cli import app
+from confluence_to_notion.cli import _prompt_table_rule, app
 from confluence_to_notion.confluence.schemas import ConfluencePage, PageTreeNode
 from confluence_to_notion.converter.resolution import ResolutionStore
-from confluence_to_notion.converter.schemas import ConversionResult
+from confluence_to_notion.converter.schemas import (
+    ConversionResult,
+    TableRule,
+    TableRuleSet,
+    UnresolvedItem,
+)
+from confluence_to_notion.converter.table_rules import TableRuleStore
 
 runner = CliRunner()
 
@@ -186,8 +192,9 @@ def test_migrate_tree_pages_happy_path(
         assert entry is not None, f"missing entry for {title}"
         assert entry.value == {"notion_page_id": notion_id}
 
-    # convert_page got the populated ResolutionStore so internal links resolve
-    assert mock_convert.call_count == 4
+    # convert_page is called twice per page (Pass 1.5 + Pass 2). Both passes
+    # receive the populated ResolutionStore so internal links resolve.
+    assert mock_convert.call_count == 8
     for call in mock_convert.call_args_list:
         store_arg = call.kwargs.get("store")
         assert store_arg is not None
@@ -286,6 +293,405 @@ def test_migrate_tree_pages_missing_target_and_env_exits(
     assert "NOTION_ROOT_PAGE_ID" in result.output
 
 
+# --- Helpers shared by Pass 1.5 tests ---
+
+
+def _table_xhtml(headers: list[str], rows: list[list[str]]) -> str:
+    """Build a Confluence storage body containing a single table."""
+    thead = (
+        "<thead><tr>"
+        + "".join(f"<th>{h}</th>" for h in headers)
+        + "</tr></thead>"
+    )
+    tbody = (
+        "<tbody>"
+        + "".join(
+            "<tr>" + "".join(f"<td>{c}</td>" for c in row) + "</tr>"
+            for row in rows
+        )
+        + "</tbody>"
+    )
+    return f"<table>{thead}{tbody}</table>"
+
+
+def _build_confluence_mock_with_bodies(
+    tree: PageTreeNode,
+    bodies: dict[str, str],
+) -> Any:
+    """Like _build_confluence_mock but returns custom storage bodies per page id."""
+    mock = AsyncMock()
+    mock.__aenter__.return_value = mock
+    mock.__aexit__.return_value = None
+    mock.collect_page_tree = AsyncMock(return_value=tree)
+
+    title_for: dict[str, str] = {}
+
+    def _walk(node: PageTreeNode) -> None:
+        title_for[node.id] = node.title
+        for child in node.children:
+            _walk(child)
+
+    _walk(tree)
+
+    async def _get_page(page_id: str) -> ConfluencePage:
+        return ConfluencePage(
+            id=page_id,
+            title=title_for.get(page_id, page_id),
+            space_key="TEST",
+            storage_body=bodies.get(page_id, "<p/>"),
+            version=1,
+            created_at=datetime(2026, 1, 1, 0, 0, 0),
+        )
+
+    mock.get_page = AsyncMock(side_effect=_get_page)
+    return mock
+
+
+def _make_convert_side_effect(
+    unresolved_per_xhtml: dict[str, list[UnresolvedItem]],
+) -> Any:
+    """convert_page mock: maps storage_body → ConversionResult.unresolved list."""
+
+    def _side(
+        xhtml: str,
+        ruleset: Any,
+        *,
+        page_id: str = "",
+        store: Any = None,
+        table_rules: Any = None,
+    ) -> ConversionResult:
+        return ConversionResult(
+            blocks=[{"object": "block", "type": "paragraph"}],
+            unresolved=list(unresolved_per_xhtml.get(xhtml, [])),
+        )
+
+    return _side
+
+
+# --- Pass 1.5: dedup + persist + non-TTY fallback ---
+
+
+@patch("confluence_to_notion.cli._prompt_table_rule")
+@patch("confluence_to_notion.cli.convert_page")
+@patch("confluence_to_notion.cli.NotionClientWrapper")
+@patch("confluence_to_notion.cli.ConfluenceClient")
+@patch("confluence_to_notion.cli._load_settings")
+def test_pass15_dedups_signature_across_pages_and_persists(
+    mock_settings: Any,
+    mock_conf_cls: Any,
+    mock_notion_cls: Any,
+    mock_convert: Any,
+    mock_prompt: Any,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two pages with the same header signature → ONE prompt; rule persisted to disk."""
+    monkeypatch.setattr("confluence_to_notion.cli._stdin_is_tty", lambda: True)
+
+    tree = PageTreeNode(
+        id="root",
+        title="Root Page",
+        children=[
+            PageTreeNode(id="c1", title="Child 1"),
+            PageTreeNode(id="c2", title="Child 2"),
+        ],
+    )
+    body_a = _table_xhtml(["Name", "Role"], [["Alice", "Dev"], ["Bob", "PM"]])
+    body_b = _table_xhtml(["NAME", " role "], [["Carol", "QA"], ["Dan", "PM"]])
+    bodies = {"root": "<p/>", "c1": body_a, "c2": body_b}
+    mock_settings.return_value = _make_settings_mock()
+    mock_conf_cls.return_value = _build_confluence_mock_with_bodies(tree, bodies)
+    mock_notion_cls.return_value = _build_notion_mock()
+
+    table_unresolved_a = UnresolvedItem(
+        kind="table", identifier="t-c1-0", source_page_id="c1", context_xhtml=body_a
+    )
+    table_unresolved_b = UnresolvedItem(
+        kind="table", identifier="t-c2-0", source_page_id="c2", context_xhtml=body_b
+    )
+    mock_convert.side_effect = _make_convert_side_effect(
+        {body_a: [table_unresolved_a], body_b: [table_unresolved_b]}
+    )
+
+    answered = TableRule(
+        is_database=True,
+        title_column="name",
+        column_types={"name": "title", "role": "select"},
+    )
+    mock_prompt.return_value = answered
+
+    rules_path = tmp_path / "rules.json"
+    _write_rules(rules_path)
+    table_rules_path = tmp_path / "table-rules.json"
+
+    result = runner.invoke(
+        app,
+        [
+            "migrate-tree-pages",
+            "--root-id",
+            "root",
+            "--target",
+            "parent-xyz",
+            "--rules",
+            str(rules_path),
+            "--resolution-out",
+            str(tmp_path / "resolution.json"),
+            "--table-rules",
+            str(table_rules_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    # Same normalized signature (name|role) across pages → exactly ONE prompt.
+    assert mock_prompt.call_count == 1
+
+    # Rule persisted to the configured table-rules file
+    assert table_rules_path.exists()
+    persisted = TableRuleSet.model_validate_json(
+        table_rules_path.read_text(encoding="utf-8")
+    )
+    assert "name|role" in persisted.rules
+    assert persisted.rules["name|role"].is_database is True
+
+
+@patch("confluence_to_notion.cli._prompt_table_rule")
+@patch("confluence_to_notion.cli.convert_page")
+@patch("confluence_to_notion.cli.NotionClientWrapper")
+@patch("confluence_to_notion.cli.ConfluenceClient")
+@patch("confluence_to_notion.cli._load_settings")
+def test_pass15_skips_signatures_already_in_store(
+    mock_settings: Any,
+    mock_conf_cls: Any,
+    mock_notion_cls: Any,
+    mock_convert: Any,
+    mock_prompt: Any,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pre-existing entry → no prompt for that signature; only un-matched is prompted."""
+    monkeypatch.setattr("confluence_to_notion.cli._stdin_is_tty", lambda: True)
+
+    tree = PageTreeNode(
+        id="root",
+        title="Root Page",
+        children=[
+            PageTreeNode(id="c1", title="Child 1"),
+            PageTreeNode(id="c2", title="Child 2"),
+        ],
+    )
+    body_known = _table_xhtml(["Name", "Role"], [["A", "Dev"]])
+    body_new = _table_xhtml(["Task", "Status"], [["X", "open"]])
+    bodies = {"root": "<p/>", "c1": body_known, "c2": body_new}
+    mock_settings.return_value = _make_settings_mock()
+    mock_conf_cls.return_value = _build_confluence_mock_with_bodies(tree, bodies)
+    mock_notion_cls.return_value = _build_notion_mock()
+
+    # convert_page surfaces both as unresolved; the cli must skip the one already in store.
+    mock_convert.side_effect = _make_convert_side_effect(
+        {
+            body_known: [
+                UnresolvedItem(
+                    kind="table",
+                    identifier="t-c1-0",
+                    source_page_id="c1",
+                    context_xhtml=body_known,
+                )
+            ],
+            body_new: [
+                UnresolvedItem(
+                    kind="table",
+                    identifier="t-c2-0",
+                    source_page_id="c2",
+                    context_xhtml=body_new,
+                )
+            ],
+        }
+    )
+    mock_prompt.return_value = TableRule(is_database=False)
+
+    table_rules_path = tmp_path / "table-rules.json"
+    pre_existing = TableRuleStore(table_rules_path)
+    pre_existing.upsert(["Name", "Role"], TableRule(is_database=False))
+    pre_existing.save()
+
+    rules_path = tmp_path / "rules.json"
+    _write_rules(rules_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "migrate-tree-pages",
+            "--root-id",
+            "root",
+            "--target",
+            "parent-xyz",
+            "--rules",
+            str(rules_path),
+            "--resolution-out",
+            str(tmp_path / "resolution.json"),
+            "--table-rules",
+            str(table_rules_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    # Only the un-matched signature triggers a prompt.
+    assert mock_prompt.call_count == 1
+    headers_arg = mock_prompt.call_args.kwargs["headers"]
+    assert headers_arg == ["Task", "Status"]
+
+
+@patch("confluence_to_notion.cli._prompt_table_rule")
+@patch("confluence_to_notion.cli.convert_page")
+@patch("confluence_to_notion.cli.NotionClientWrapper")
+@patch("confluence_to_notion.cli.ConfluenceClient")
+@patch("confluence_to_notion.cli._load_settings")
+def test_pass15_prompt_receives_column_type_draft(
+    mock_settings: Any,
+    mock_conf_cls: Any,
+    mock_notion_cls: Any,
+    mock_convert: Any,
+    mock_prompt: Any,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The prompt's kwargs include a column_type_draft from infer_column_types."""
+    monkeypatch.setattr("confluence_to_notion.cli._stdin_is_tty", lambda: True)
+
+    tree = PageTreeNode(id="root", title="Root Page")
+    # Date column should be inferred as 'date'.
+    body = _table_xhtml(
+        ["Name", "Due"],
+        [
+            ["A", "2026-01-15"],
+            ["B", "2026-02-01"],
+            ["C", "2026-03-20"],
+        ],
+    )
+    mock_settings.return_value = _make_settings_mock()
+    mock_conf_cls.return_value = _build_confluence_mock_with_bodies(
+        tree, {"root": body}
+    )
+    mock_notion_cls.return_value = _build_notion_mock()
+
+    mock_convert.side_effect = _make_convert_side_effect(
+        {
+            body: [
+                UnresolvedItem(
+                    kind="table",
+                    identifier="t-root-0",
+                    source_page_id="root",
+                    context_xhtml=body,
+                )
+            ]
+        }
+    )
+    mock_prompt.return_value = TableRule(
+        is_database=True,
+        title_column="name",
+        column_types={"name": "title", "due": "date"},
+    )
+
+    rules_path = tmp_path / "rules.json"
+    _write_rules(rules_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "migrate-tree-pages",
+            "--root-id",
+            "root",
+            "--target",
+            "parent-xyz",
+            "--rules",
+            str(rules_path),
+            "--resolution-out",
+            str(tmp_path / "resolution.json"),
+            "--table-rules",
+            str(tmp_path / "table-rules.json"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert mock_prompt.call_count == 1
+
+    # Inspect the kwargs passed to _prompt_table_rule.
+    kwargs = mock_prompt.call_args.kwargs
+    draft = kwargs.get("column_type_draft")
+    assert draft is not None, f"missing column_type_draft in kwargs: {kwargs}"
+    assert draft.get("Due") == "date"
+    # Sample rows surfaced too so the user sees what they're labelling.
+    sample_rows = kwargs.get("sample_rows")
+    assert sample_rows is not None and len(sample_rows) >= 1
+
+
+@patch("confluence_to_notion.cli._prompt_table_rule")
+@patch("confluence_to_notion.cli.convert_page")
+@patch("confluence_to_notion.cli.NotionClientWrapper")
+@patch("confluence_to_notion.cli.ConfluenceClient")
+@patch("confluence_to_notion.cli._load_settings")
+def test_pass15_non_tty_does_not_prompt_or_block(
+    mock_settings: Any,
+    mock_conf_cls: Any,
+    mock_notion_cls: Any,
+    mock_convert: Any,
+    mock_prompt: Any,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-TTY → no prompt, no block, page still migrates, exit 0."""
+    monkeypatch.setattr("confluence_to_notion.cli._stdin_is_tty", lambda: False)
+
+    tree = PageTreeNode(id="root", title="Root Page")
+    body = _table_xhtml(["Name", "Role"], [["Alice", "Dev"]])
+    mock_settings.return_value = _make_settings_mock()
+    mock_conf_cls.return_value = _build_confluence_mock_with_bodies(
+        tree, {"root": body}
+    )
+    notion_mock = _build_notion_mock()
+    mock_notion_cls.return_value = notion_mock
+
+    mock_convert.side_effect = _make_convert_side_effect(
+        {
+            body: [
+                UnresolvedItem(
+                    kind="table",
+                    identifier="t-root-0",
+                    source_page_id="root",
+                    context_xhtml=body,
+                )
+            ]
+        }
+    )
+
+    rules_path = tmp_path / "rules.json"
+    _write_rules(rules_path)
+    table_rules_path = tmp_path / "table-rules.json"
+
+    result = runner.invoke(
+        app,
+        [
+            "migrate-tree-pages",
+            "--root-id",
+            "root",
+            "--target",
+            "parent-xyz",
+            "--rules",
+            str(rules_path),
+            "--resolution-out",
+            str(tmp_path / "resolution.json"),
+            "--table-rules",
+            str(table_rules_path),
+        ],
+    )
+
+    # Migration finished, no prompts, no Notion failures
+    assert result.exit_code == 0, result.output
+    assert mock_prompt.call_count == 0
+    assert notion_mock.append_blocks.await_count == 1
+    # Console mentions the unresolved signature so the operator can act later.
+    assert "name|role" in result.output.lower()
+
+
 @patch("confluence_to_notion.cli.convert_page")
 @patch("confluence_to_notion.cli.NotionClientWrapper")
 @patch("confluence_to_notion.cli.ConfluenceClient")
@@ -339,3 +745,45 @@ def test_migrate_tree_pages_notion_api_error_on_body_upload(
 
     assert result.exit_code != 0
     assert "Notion" in result.output or "API" in result.output
+
+
+# --- _prompt_table_rule direct regression: store must survive round-trip ---
+
+
+def test_prompt_table_rule_persists_roundtrip_with_title_cased_headers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Title-cased headers + default title column must produce a rule that survives
+    save→load. Without normalization, TableRuleSet validation rejects the file
+    (title_column 'Name' not in signature columns ['name', 'role']) and
+    TableRuleStore._load silently wipes every previously persisted rule.
+    """
+    monkeypatch.setattr("typer.confirm", lambda *a, **kw: True)
+    monkeypatch.setattr("typer.prompt", lambda *a, **kw: kw.get("default", a[-1]))
+
+    headers = ["Name", "Role"]
+    sample_rows = [["Alice", "Dev"], ["Bob", "PM"]]
+    draft: dict[str, Any] = {"Name": "title", "Role": "select"}
+
+    rule = _prompt_table_rule(
+        headers=headers,
+        sample_rows=sample_rows,
+        column_type_draft=draft,
+    )
+
+    assert rule.is_database is True
+    assert rule.title_column == "name"
+    assert rule.column_types == {"name": "title", "role": "select"}
+
+    # Round-trip through TableRuleStore: save then reload from disk.
+    store_path = tmp_path / "table-rules.json"
+    store = TableRuleStore(store_path)
+    store.upsert(headers, rule)
+    store.save()
+
+    reloaded = TableRuleStore(store_path)
+    assert reloaded.lookup(headers) is not None
+    assert reloaded.lookup(headers) == rule
+    # Signature key is normalized in the store.
+    assert "name|role" in reloaded.data.rules

--- a/tests/unit/test_converter.py
+++ b/tests/unit/test_converter.py
@@ -9,7 +9,8 @@ import pytest
 from confluence_to_notion.agents.schemas import FinalRule, FinalRuleset, ProposedRule
 from confluence_to_notion.converter.converter import convert_page
 from confluence_to_notion.converter.resolution import ResolutionStore
-from confluence_to_notion.converter.schemas import UnresolvedItem
+from confluence_to_notion.converter.schemas import TableRule, UnresolvedItem
+from confluence_to_notion.converter.table_rules import TableRuleStore
 
 FIXTURES_DIR = Path(__file__).parent.parent / "fixtures" / "nested-macros"
 TABLE_FIXTURES_DIR = Path(__file__).parent.parent / "fixtures" / "tables"
@@ -1055,6 +1056,169 @@ class TestTableConversion:
         result = convert_page(xhtml, _default_ruleset(), page_id="pg-1", store=store)
         assert result.blocks == [
             {"type": "child_database", "child_database": {"title": "Team"}}
+        ]
+        tables_unresolved = [u for u in result.unresolved if u.kind == "table"]
+        assert tables_unresolved == []
+
+
+# --- Table conversion with TableRuleStore (Pass 1.5 rule hits) ---
+
+
+class TestTableConversionWithTableRules:
+    """convert_page consults a TableRuleStore by header signature.
+
+    A confirmed-layout rule (is_database=False) suppresses the UnresolvedItem.
+    A confirmed-database rule (is_database=True) still emits the UnresolvedItem
+    so part 3 can pick it up and create the Notion database. In both branches
+    this PR keeps emitting the plain Notion table block — actual database
+    materialization is out-of-scope here.
+    """
+
+    @staticmethod
+    def _table_xhtml(headers: list[str], rows: list[list[str]]) -> str:
+        thead = (
+            "<thead><tr>"
+            + "".join(f"<th>{h}</th>" for h in headers)
+            + "</tr></thead>"
+        )
+        tbody = (
+            "<tbody>"
+            + "".join(
+                "<tr>" + "".join(f"<td>{c}</td>" for c in row) + "</tr>"
+                for row in rows
+            )
+            + "</tbody>"
+        )
+        return f"<table>{thead}{tbody}</table>"
+
+    def test_rule_hit_layout_suppresses_unresolved(self, tmp_path: Path) -> None:
+        """Rule hit with is_database=False → plain table block, NO table unresolved."""
+        store = TableRuleStore(tmp_path / "table-rules.json")
+        # Headers in the page differ in case/whitespace from the upsert call to
+        # exercise normalize_header_signature.
+        store.upsert(
+            ["Name", "Role"],
+            TableRule(is_database=False),
+        )
+        store.save()
+
+        xhtml = self._table_xhtml(
+            ["  name ", "ROLE"],
+            [["Alice", "Dev"], ["Bob", "PM"]],
+        )
+        result = convert_page(
+            xhtml,
+            _default_ruleset(),
+            page_id="pg-1",
+            table_rules=store,
+        )
+
+        # Plain Notion table block still emitted
+        table_blocks = [b for b in result.blocks if b["type"] == "table"]
+        assert len(table_blocks) == 1
+        # Layout rule = resolution final → no UnresolvedItem(kind='table')
+        tables_unresolved = [u for u in result.unresolved if u.kind == "table"]
+        assert tables_unresolved == []
+
+    def test_rule_hit_database_still_emits_unresolved(
+        self, tmp_path: Path
+    ) -> None:
+        """Rule hit with is_database=True → plain table block + table unresolved (part 3)."""
+        store = TableRuleStore(tmp_path / "table-rules.json")
+        store.upsert(
+            ["Name", "Role"],
+            TableRule(
+                is_database=True,
+                title_column="name",
+                column_types={"name": "title", "role": "select"},
+            ),
+        )
+        store.save()
+
+        xhtml = self._table_xhtml(
+            ["Name", "Role"],
+            [["Alice", "Dev"], ["Bob", "PM"]],
+        )
+        result = convert_page(
+            xhtml,
+            _default_ruleset(),
+            page_id="pg-1",
+            table_rules=store,
+        )
+
+        # Plain Notion table block still emitted (DB materialization is part 3)
+        table_blocks = [b for b in result.blocks if b["type"] == "table"]
+        assert len(table_blocks) == 1
+        # Database candidate → UnresolvedItem so part 3 can pick it up
+        tables_unresolved = [u for u in result.unresolved if u.kind == "table"]
+        assert len(tables_unresolved) == 1
+        assert tables_unresolved[0].source_page_id == "pg-1"
+        assert tables_unresolved[0].context_xhtml is not None
+
+    def test_rule_miss_preserves_existing_behavior(self, tmp_path: Path) -> None:
+        """No matching signature → plain table + UnresolvedItem (current behavior)."""
+        store = TableRuleStore(tmp_path / "table-rules.json")
+        # Different headers — no match for the page's table.
+        store.upsert(
+            ["Different", "Headers"],
+            TableRule(is_database=False),
+        )
+        store.save()
+
+        xhtml = self._table_xhtml(
+            ["Name", "Role"],
+            [["Alice", "Dev"]],
+        )
+        result = convert_page(
+            xhtml,
+            _default_ruleset(),
+            page_id="pg-1",
+            table_rules=store,
+        )
+
+        table_blocks = [b for b in result.blocks if b["type"] == "table"]
+        assert len(table_blocks) == 1
+        tables_unresolved = [u for u in result.unresolved if u.kind == "table"]
+        assert len(tables_unresolved) == 1
+        assert tables_unresolved[0].context_xhtml is not None
+
+    def test_resolution_store_short_circuits_before_table_rules(
+        self, tmp_path: Path
+    ) -> None:
+        """Pre-resolved 'table:{identifier}' in ResolutionStore wins over TableRuleStore."""
+        xhtml = self._table_xhtml(["Name", "Role"], [["Alice", "Dev"]])
+
+        # Discover the stable identifier first.
+        first = convert_page(xhtml, _default_ruleset(), page_id="pg-1")
+        identifier = next(u.identifier for u in first.unresolved if u.kind == "table")
+
+        res_store = ResolutionStore(tmp_path / "res.json")
+        res_store.add(
+            key=f"table:{identifier}",
+            resolved_by="notion_migration",
+            value={
+                "notion_blocks": [
+                    {"type": "child_database", "child_database": {"title": "T"}}
+                ]
+            },
+        )
+
+        # TableRuleStore has a database-flagged rule too; ResolutionStore must win.
+        tr_store = TableRuleStore(tmp_path / "table-rules.json")
+        tr_store.upsert(
+            ["Name", "Role"],
+            TableRule(is_database=True, title_column="name"),
+        )
+
+        result = convert_page(
+            xhtml,
+            _default_ruleset(),
+            page_id="pg-1",
+            store=res_store,
+            table_rules=tr_store,
+        )
+        assert result.blocks == [
+            {"type": "child_database", "child_database": {"title": "T"}}
         ]
         tables_unresolved = [u for u in result.unresolved if u.kind == "table"]
         assert tables_unresolved == []


### PR DESCRIPTION
## Summary

Automated implementation for #65.

Closes #65

## Pipeline

Generated by `scripts/develop.sh 65` — Plan, Implement, Test, Review, Fix, Verify, PR.

## Artifacts

- Plan: `output/dev/plan.json`
- Review: `output/dev/review.json`

## Test plan

- [ ] `uv run ruff check src/ tests/` passes
- [ ] `uv run mypy src/` passes
- [ ] `uv run pytest` passes
- [ ] Manual review of changes against issue requirements