### PR TITLE
feat: docs: CLAUDE.md run-eval rule을 discover 파이프라인 한정으로 스코프 좁히기

### DIFF
--- a/.claude/rules/prompts.md
+++ b/.claude/rules/prompts.md
@@ -14,7 +14,7 @@ Each agent `.md` file should contain:
 ## Rules
 
 - All prompt text lives in the agent `.md` file — never in Python source code
-- When an agent prompt is changed, run `scripts/run-eval.sh` to verify quality
+- When a discover-pipeline agent prompt (`pattern-discovery`, `rule-proposer`) is changed, run `scripts/run-eval.sh` to verify quality. Develop-pipeline prompts (`dev-planner`, `dev-implementer`, `dev-reviewer`, `dev-fixer`) are not covered by run-eval.
 - Prompts should reference the JSON schema from `src/**/schemas.py` for output format
 - Include examples of expected input/output in the prompt when possible
 - Keep prompts focused: one agent, one responsibility

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Derived rules are applied by a deterministic converter to migrate wiki pages whi
 ## Development Process
 
 - **CRITICAL**: TDD — write a failing test first, then implement (for Python code in `src/`)
-- **CRITICAL**: Before any agent prompt change, run `scripts/run-eval.sh`
+- **CRITICAL**: Before any **discover-pipeline** agent prompt change (`pattern-discovery`, `rule-proposer`), run `scripts/run-eval.sh`
 - Conventional commits: `feat|fix|docs|refactor|test|chore`
 - Squash merge only
 - PR 생성 시 관련 이슈를 `Closes #N` 키워드로 본문에 연결 (머지 시 자동 클로즈)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,7 +185,7 @@ uv run pytest tests/unit/test_foo.py   # 특정 파일
 - [ ] `uv run pytest` 통과
 - [ ] `uv run ruff check src/ tests/` 통과
 - [ ] `uv run mypy src/` 통과 (strict)
-- [ ] 프롬프트 수정 시 `bash scripts/run-eval.sh` 실행
+- [ ] discover 파이프라인 프롬프트 (`pattern-discovery`, `rule-proposer`) 수정 시 `bash scripts/run-eval.sh` 실행 (develop 파이프라인 프롬프트는 대상 아님)
 - [ ] `Closes #N` 링크 포함
 
 ---


### PR DESCRIPTION
## Summary

Automated implementation for #72.

Closes #72

## Pipeline

Generated by `scripts/develop.sh 72` — Plan, Implement, Test, Review, Fix, Verify, PR.

## Artifacts

- Plan: `output/dev/plan.json`
- Review: `output/dev/review.json`

## Test plan

- [ ] `uv run ruff check src/ tests/` passes
- [ ] `uv run mypy src/` passes
- [ ] `uv run pytest` passes
- [ ] Manual review of changes against issue requirements