### PR TITLE
fix: patch-handoff for protected `.claude/**` paths (#76)

### DIFF
--- a/.claude/agents/develop/dev-fixer.md
+++ b/.claude/agents/develop/dev-fixer.md
@@ -38,6 +38,31 @@ You are a code fixer agent. Your job is to resolve the issues identified in the 
 - **Intent conflicts** (`intent_conflict: true`): the implementer deliberately chose this approach. Read their `implement_intent` reason carefully. Only override if the reviewer's argument is clearly stronger. If the implementer's decision was valid, skip the fix and document why in `output/dev/fix-log.json`
 - If a fix would require significant restructuring beyond the review's scope, skip it and note in the output
 
+### Editing protected paths under `.claude/` — patch handoff
+
+Claude Code blocks writes to most paths under `.claude/` in every permission mode; this guard applies to the Edit/Write tools AND to `Bash` subprocesses in non-interactive (`-p`) sessions. Exempt subtrees: `.claude/commands/**`, `.claude/agents/**`, `.claude/skills/**`, `.claude/worktrees/**`.
+
+For a non-exempt target (e.g. `.claude/rules/*.md`, `.claude/docs/**`), do NOT attempt a direct write — emit a unified-diff patch to `output/dev/protected-paths.patch` instead. `scripts/develop.sh` applies it with `git apply` after your session exits.
+
+Workflow:
+1. Read the target file (the guard is write-only; reads work fine).
+2. Build a unified diff with `--- a/<path>`, `+++ b/<path>`, `@@ ... @@` hunk headers. Paths are relative to the repo root.
+3. Write the diff to `output/dev/protected-paths.patch` via the Write tool (`output/` is not protected). Multiple protected files go in one patch.
+4. Note the handoff in `fix-log.json` so the reviewer can trace the change.
+
+Example `output/dev/protected-paths.patch`:
+
+```
+--- a/.claude/rules/prompts.md
++++ b/.claude/rules/prompts.md
+@@ -10,7 +10,7 @@
+ - All prompt text lives in the agent `.md` file — never in Python source code
+-- old line
++- new line
+```
+
+Do NOT use this mechanism for paths outside `.claude/` — the Edit tool is correct there.
+
 ### Important rules
 
 - Read the full file before making changes — understand the context

--- a/.claude/agents/develop/dev-implementer.md
+++ b/.claude/agents/develop/dev-implementer.md
@@ -51,6 +51,31 @@ You are a development implementer agent. Your job is to execute each task in the
 - `pathlib.Path` over `os.path`
 - ruff line length 100, target py311
 
+### Editing protected paths under `.claude/` — patch handoff
+
+Claude Code blocks writes to most paths under `.claude/` in every permission mode; this guard applies to the Edit/Write tools AND to `Bash` subprocesses in non-interactive (`-p`) sessions. Exempt subtrees: `.claude/commands/**`, `.claude/agents/**`, `.claude/skills/**`, `.claude/worktrees/**`.
+
+For a non-exempt target (e.g. `.claude/rules/*.md`, `.claude/docs/**`), do NOT attempt a direct write — emit a unified-diff patch to `output/dev/protected-paths.patch` instead. `scripts/develop.sh` applies it with `git apply` after your session exits.
+
+Workflow:
+1. Read the target file (the guard is write-only; reads work fine).
+2. Build a unified diff with `--- a/<path>`, `+++ b/<path>`, `@@ ... @@` hunk headers. Paths are relative to the repo root.
+3. Write the diff to `output/dev/protected-paths.patch` via the Write tool (`output/` is not protected). Multiple protected files go in one patch.
+4. Note the handoff in `implement-log.json` so the reviewer can trace the change.
+
+Example `output/dev/protected-paths.patch`:
+
+```
+--- a/.claude/rules/prompts.md
++++ b/.claude/rules/prompts.md
+@@ -10,7 +10,7 @@
+ - All prompt text lives in the agent `.md` file — never in Python source code
+-- old line
++- new line
+```
+
+Do NOT use this mechanism for paths outside `.claude/` — the Edit tool is correct there.
+
 ### Important rules
 
 - Follow the plan exactly — do not add features, refactoring, or improvements beyond what's specified

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -100,6 +100,45 @@ run_agent() {
     echo "    Done: $log_file"
 }
 
+# --- Helper: apply protected-paths.patch emitted by an agent ---
+#
+# Subagents cannot write to most paths under `.claude/` — the write guard applies to
+# Edit/Write tools AND to Bash subprocesses in non-interactive (`-p`) sessions (local
+# smoke tests for #76 confirmed Bash is also blocked). The dev-implementer/dev-fixer
+# prompts instruct agents to emit a unified diff to $OUTPUT_DIR/protected-paths.patch
+# instead; this helper runs `git apply` from the script context (no guard here), then
+# deletes the patch so the next step starts clean. Fails loud — silent skip would let
+# the pipeline produce a PR that omits intended protected-path changes.
+apply_protected_patch() {
+    local step_num="$1"
+    local source_label="$2"
+
+    if [[ "$step_num" -lt "$FROM_STEP" ]]; then
+        return 0
+    fi
+
+    local patch_file="$OUTPUT_DIR/protected-paths.patch"
+    if [[ ! -f "$patch_file" ]]; then
+        return 0
+    fi
+    if [[ ! -s "$patch_file" ]]; then
+        echo "    [protected-patch] empty patch file from $source_label — removing"
+        rm -f "$patch_file"
+        return 0
+    fi
+
+    echo "==> Applying protected-paths.patch (emitted by $source_label)"
+    if git apply --verbose "$patch_file"; then
+        echo "    [protected-patch] applied successfully"
+        rm -f "$patch_file"
+        return 0
+    fi
+    echo "[ERROR] git apply failed on $patch_file"
+    echo "    Patch preserved for manual inspection. First 50 lines:"
+    head -50 "$patch_file"
+    return 1
+}
+
 # --- Helper: run lint + type check + tests ---
 run_checks() {
     local step_num="$1"
@@ -423,6 +462,10 @@ Execute the development plan in ${OUTPUT_DIR}/plan.json.
 Read the plan, then implement each task in order following TDD.
 After implementation, write your decisions and known risks to ${OUTPUT_DIR}/implement-log.json"
 
+# Apply any patch the implementer emitted for protected `.claude/**` paths (see
+# apply_protected_patch docstring). Runs before Step 3 so test/lint sees the changes.
+apply_protected_patch 2 "dev-implementer" || { echo "[ERROR] Step 2: protected patch apply failed"; exit 1; }
+
 # --- Step 3: Test ---
 if [[ "$FROM_STEP" -le 3 ]]; then
     if ! run_checks 3 "test"; then
@@ -496,6 +539,9 @@ while [[ "$retry" -lt "$max_attempts" ]]; do
 
 Fix the issues in ${OUTPUT_DIR}/review.json.
 Read the review, then apply fixes to resolve each issue."
+
+        # Apply any patch the fixer emitted for protected `.claude/**` paths.
+        apply_protected_patch 5 "dev-fixer" || { echo "[ERROR] Step 5: protected patch apply failed"; exit 1; }
     fi
 
     if [[ "$FROM_STEP" -le 6 ]]; then
@@ -561,6 +607,9 @@ Write the new plan to ${OUTPUT_DIR}/plan.json"
 Execute the development plan in ${OUTPUT_DIR}/plan.json.
 Read the plan, then implement each task in order following TDD.
 After implementation, write your decisions and known risks to ${OUTPUT_DIR}/implement-log.json"
+
+    # Apply any patch the re-plan implementer emitted for protected `.claude/**` paths.
+    apply_protected_patch 2 "dev-implementer (re-plan)" || { echo "[ERROR] Re-plan: protected patch apply failed"; exit 1; }
 
     # Half-open probe: one verify attempt
     circuit_announce "re-plan probe verify"


### PR DESCRIPTION
## Summary

이슈 #76 를 옵션 B (patch handoff) 로 구현.

- `dev-implementer.md` / `dev-fixer.md`: protected path 수정 시 `output/dev/protected-paths.patch` 에 unified-diff 를 출력하도록 가이드 섹션 추가.
- `scripts/develop.sh`: Step 2 (Implement) / Step 5 (Fix) / re-plan Step 2 직후 `apply_protected_patch` 호출 → `git apply --verbose` + 파일 삭제. apply 실패 시 파이프라인 abort, patch 파일은 inspection 용으로 보존.

## Why not (a)/(b)/(c)

이슈 #76 본문의 초기 옵션들이 모두 작동하지 않음:

| Option | 결과 |
|---|---|
| (a) `--permission-mode acceptEdits` | protected path 는 모든 모드에서 prompt → non-interactive 에서 auto-deny |
| (b) `permissions.allow` 의 `Edit(./.claude/rules/**)` | protected-path 가드는 allow-rule 레이어보다 위 |
| (c) Bash heredoc 우회 (PR #78 가설) | 로컬 smoke test 6건에서 Bash subprocess write 도 동일 guard → 가설 폐기, PR #78 close |

## DoD 충족

- [x] dev-implementer/dev-fixer 가 protected `.claude/**` 변경을 PR 1회로 완결 (patch handoff 경유)
- [x] main agent manual 보강 commit 불필요 — 자동화 흐름 유지
- [x] sensitive 파일 보호 로직 (`stage_intended_changes` SENSITIVE_PATTERNS) 그대로
- [x] `git apply` 실패 시 명확한 에러 + abort

## Test plan

- [ ] 다음 `/develop` 호출에서 dev-implementer 또는 dev-fixer 가 `.claude/rules/*.md` 수정 task 를 받았을 때:
  - [ ] `output/dev/protected-paths.patch` 생성 확인
  - [ ] Step 2/5 직후 `==> Applying protected-paths.patch` 로그 출력
  - [ ] `git apply --verbose` 성공 메시지
  - [ ] 적용 후 patch 파일 삭제 확인
- [ ] 인위적으로 깨진 patch 주입 시 파이프라인이 abort + patch 파일 보존하는지 확인 (optional smoke)

Closes #76
