### PR TITLE
feat: feat: _prompt_table_rule — title_col 입력값을 헤더에 대해 검증 (#65 follow-up)

### DIFF
--- a/src/confluence_to_notion/cli.py
+++ b/src/confluence_to_notion/cli.py
@@ -684,14 +684,36 @@ def _prompt_table_rule(
     if not is_db:
         return TableRule(is_database=False)
 
-    title_col = typer.prompt("Title column", default=headers[0])
     # Persisted signatures are lowercased/stripped (normalize_header_signature), so
     # title_column and column_types keys must match that form or TableRuleSet
     # validation rejects the store on the next load and wipes every rule.
-    normalized_title = title_col.strip().lower()
+    normalized_headers = [h.strip().lower() for h in headers]
+    valid_headers = set(normalized_headers)
     normalized_types: dict[str, NotionPropertyType] = {
         k.strip().lower(): v for k, v in column_type_draft.items()
     }
+
+    if _stdin_is_tty():
+        while True:
+            title_col = typer.prompt("Title column", default=headers[0])
+            normalized_title = title_col.strip().lower()
+            if normalized_title in valid_headers:
+                break
+            console.print(
+                f"[yellow]'{title_col}' is not a header. "
+                f"Choose one of: {', '.join(headers)}[/yellow]"
+            )
+    else:
+        title_col = typer.prompt("Title column", default=headers[0])
+        normalized_title = title_col.strip().lower()
+        if normalized_title not in valid_headers:
+            fallback = normalized_headers[0]
+            console.print(
+                f"[yellow]title_col '{title_col}' not in headers; "
+                f"falling back to '{fallback}'[/yellow]"
+            )
+            normalized_title = fallback
+
     return TableRule(
         is_database=True,
         title_column=normalized_title,

--- a/tests/unit/test_cli_migrate_tree_pages.py
+++ b/tests/unit/test_cli_migrate_tree_pages.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -787,3 +787,73 @@ def test_prompt_table_rule_persists_roundtrip_with_title_cased_headers(
     assert reloaded.lookup(headers) == rule
     # Signature key is normalized in the store.
     assert "name|role" in reloaded.data.rules
+
+
+def test_prompt_table_rule_reprompts_on_invalid_title_col(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TTY: a typo'd title_col not in headers re-prompts until a valid header is given."""
+    monkeypatch.setattr("confluence_to_notion.cli._stdin_is_tty", lambda: True)
+    monkeypatch.setattr("typer.confirm", lambda *a, **kw: True)
+
+    prompt_mock = MagicMock(side_effect=["totally_bogus", "Name"])
+    monkeypatch.setattr("typer.prompt", prompt_mock)
+
+    rule = _prompt_table_rule(
+        headers=["Name", "Role"],
+        sample_rows=[["Alice", "Dev"]],
+        column_type_draft={"Name": "title", "Role": "select"},
+    )
+
+    assert prompt_mock.call_count >= 2
+    assert rule.is_database is True
+    assert rule.title_column == "name"
+
+
+def test_prompt_table_rule_accepts_case_variant_without_reprompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TTY: 'NAME' for headers ['Name','Role'] resolves to 'name' on the first try."""
+    monkeypatch.setattr("confluence_to_notion.cli._stdin_is_tty", lambda: True)
+    monkeypatch.setattr("typer.confirm", lambda *a, **kw: True)
+
+    # Only one value supplied — a re-prompt would raise StopIteration and fail the test.
+    prompt_mock = MagicMock(side_effect=["NAME"])
+    monkeypatch.setattr("typer.prompt", prompt_mock)
+
+    rule = _prompt_table_rule(
+        headers=["Name", "Role"],
+        sample_rows=[["Alice", "Dev"]],
+        column_type_draft={"Name": "title", "Role": "select"},
+    )
+
+    assert prompt_mock.call_count == 1
+    assert rule.title_column == "name"
+
+
+def test_prompt_table_rule_non_tty_falls_back_to_first_header(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Non-TTY: a bogus title_col falls back to headers[0] (normalized) with a warning."""
+    monkeypatch.setattr("confluence_to_notion.cli._stdin_is_tty", lambda: False)
+    monkeypatch.setattr("typer.confirm", lambda *a, **kw: True)
+
+    prompt_mock = MagicMock(return_value="totally_bogus")
+    monkeypatch.setattr("typer.prompt", prompt_mock)
+
+    rule = _prompt_table_rule(
+        headers=["Name", "Role"],
+        sample_rows=[["Alice", "Dev"]],
+        column_type_draft={"Name": "title", "Role": "select"},
+    )
+
+    # Fallback to first header (normalized) — never persists a column not in the signature.
+    assert rule.title_column == "name"
+    # No looping in non-TTY: prompt is invoked at most once.
+    assert prompt_mock.call_count <= 1
+
+    captured = capsys.readouterr().out
+    # Operator-visible warning so the silent-wipe trap can't reopen via typos.
+    assert "totally_bogus" in captured
+    assert "name" in captured


### PR DESCRIPTION
## Summary

Automated implementation for #70.

Closes #70

## Pipeline

Generated by `scripts/develop.sh 70` — Plan, Implement, Test, Review, Fix, Verify, PR.

## Artifacts

- Plan: `output/dev/plan.json`
- Review: `output/dev/review.json`

## Test plan

- [ ] `uv run ruff check src/ tests/` passes
- [ ] `uv run mypy src/` passes
- [ ] `uv run pytest` passes
- [ ] Manual review of changes against issue requirements