### PR TITLE
feat: feat: NotionClient.create_database + child_database emission (issue #57 part 3)

### DIFF
--- a/src/confluence_to_notion/cli.py
+++ b/src/confluence_to_notion/cli.py
@@ -583,6 +583,9 @@ def migrate_tree_pages(
                 page = await confluence.get_page(confluence_id)
                 xhtml_cache[confluence_id] = page.storage_body
 
+            # Tracks every unresolved table instance discovered during pre-convert,
+            # so a single signature can be created once and applied to every instance.
+            unresolved_tables: list[tuple[str, str, list[str]]] = []
             seen_signatures: set[str] = set()
             interactive = _stdin_is_tty()
             for confluence_id, xhtml in xhtml_cache.items():
@@ -599,6 +602,7 @@ def migrate_tree_pages(
                     headers = extract_headers_from_xhtml(item.context_xhtml)
                     if not headers:
                         continue
+                    unresolved_tables.append((confluence_id, item.identifier, headers))
                     sig = normalize_header_signature(headers)
                     if sig in seen_signatures:
                         continue
@@ -620,6 +624,33 @@ def migrate_tree_pages(
                     )
                     table_rule_store.upsert(headers, rule)
                     table_rule_store.save()
+
+            # For every is_database=True signature, create the Notion database once
+            # under the page where it was first observed and write a resolution
+            # entry for every instance so Pass 2 emits child_database blocks.
+            db_id_by_signature: dict[str, str] = {}
+            for confluence_id, identifier, headers in unresolved_tables:
+                resolved_rule = table_rule_store.lookup(headers)
+                if resolved_rule is None or not resolved_rule.is_database:
+                    continue
+                if resolved_rule.column_types is None or resolved_rule.title_column is None:
+                    continue
+                sig = normalize_header_signature(headers)
+                if sig not in db_id_by_signature:
+                    parent_for_db = id_to_notion[confluence_id]
+                    db_id_by_signature[sig] = await notion.create_database(
+                        parent_id=parent_for_db,
+                        title=resolved_rule.title_column,
+                        title_column=resolved_rule.title_column,
+                        column_types=resolved_rule.column_types,
+                    )
+                store.add(
+                    key=f"table:{identifier}",
+                    resolved_by="notion_migration",
+                    value={"database_id": db_id_by_signature[sig]},
+                )
+            if db_id_by_signature:
+                store.save()
 
             # --- Pass 2: convert with both stores and append to Notion ---
             succeeded = 0

--- a/src/confluence_to_notion/converter/converter.py
+++ b/src/confluence_to_notion/converter/converter.py
@@ -632,6 +632,13 @@ def _convert_table(
 
     if ctx.store:
         entry = ctx.store.lookup(f"table:{identifier}")
+        if entry and "database_id" in entry.value:
+            return [
+                {
+                    "type": "child_database",
+                    "child_database": {"database_id": entry.value["database_id"]},
+                }
+            ]
         if entry and "notion_blocks" in entry.value:
             resolved: list[dict[str, Any]] = copy.deepcopy(entry.value["notion_blocks"])
             return resolved

--- a/src/confluence_to_notion/converter/schemas.py
+++ b/src/confluence_to_notion/converter/schemas.py
@@ -9,7 +9,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
-NotionPropertyType = Literal["title", "rich_text", "select", "date", "people"]
+NotionPropertyType = Literal["title", "rich_text", "select", "date", "people", "url"]
 
 
 class ResolutionEntry(BaseModel):

--- a/src/confluence_to_notion/notion/client.py
+++ b/src/confluence_to_notion/notion/client.py
@@ -9,6 +9,7 @@ from notion_client import APIResponseError, AsyncClient
 
 from confluence_to_notion.config import Settings
 from confluence_to_notion.confluence.schemas import PageTreeNode
+from confluence_to_notion.converter.schemas import NotionPropertyType
 from confluence_to_notion.notion.schemas import NotionPageResult
 
 logger = logging.getLogger(__name__)
@@ -109,6 +110,50 @@ class NotionClientWrapper:
             child_mapping = await self.create_page_tree(new_page_id, child)
             mapping.update(child_mapping)
         return mapping
+
+    async def create_database(
+        self,
+        parent_id: str,
+        title: str,
+        title_column: str,
+        column_types: dict[str, NotionPropertyType],
+    ) -> str:
+        """Create a Notion database under ``parent_id`` and return its database id.
+
+        ``title_column`` is forced to the ``title`` Notion property type even if
+        ``column_types`` declares a different type for it. All other columns map to
+        ``{<type>: {}}``. Inherits the same 429 + exponential-backoff retry shape
+        as ``_create_page_with_retry``.
+        """
+        properties: dict[str, dict[str, dict[str, Any]]] = {}
+        for column, prop_type in column_types.items():
+            effective = "title" if column == title_column else prop_type
+            properties[column] = {effective: {}}
+
+        last_error: APIResponseError | None = None
+        for attempt in range(MAX_RETRIES + 1):
+            try:
+                resp: Any = await self._client.databases.create(
+                    parent={"page_id": parent_id},
+                    title=[{"type": "text", "text": {"content": title}}],
+                    properties=properties,
+                )
+                return str(resp["id"])
+            except APIResponseError as e:
+                if e.status != 429 or attempt == MAX_RETRIES:
+                    raise
+                last_error = e
+                delay = BASE_DELAY * (2**attempt) + random.uniform(0, 1)
+                logger.warning(
+                    "Notion rate limited (429) on database create, retry %d/%d in %.1fs",
+                    attempt + 1,
+                    MAX_RETRIES,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+
+        assert last_error is not None  # unreachable, satisfies mypy
+        raise last_error
 
     async def _create_page_with_retry(
         self, parent_id: str, title: str, children: list[dict[str, Any]]

--- a/tests/unit/test_cli_migrate_tree_pages.py
+++ b/tests/unit/test_cli_migrate_tree_pages.py
@@ -119,6 +119,7 @@ def _build_notion_mock() -> Any:
 
     mock.create_subpage = AsyncMock(side_effect=_create_subpage)
     mock.append_blocks = AsyncMock(return_value=None)
+    mock.create_database = AsyncMock(return_value="db-default")
     return mock
 
 
@@ -745,6 +746,279 @@ def test_migrate_tree_pages_notion_api_error_on_body_upload(
 
     assert result.exit_code != 0
     assert "Notion" in result.output or "API" in result.output
+
+
+# --- Pass 1.5: Notion database creation for is_database=True signatures ---
+
+
+@patch("confluence_to_notion.cli._prompt_table_rule")
+@patch("confluence_to_notion.cli.NotionClientWrapper")
+@patch("confluence_to_notion.cli.ConfluenceClient")
+@patch("confluence_to_notion.cli._load_settings")
+def test_pass15_creates_notion_db_once_per_is_database_signature(
+    mock_settings: Any,
+    mock_conf_cls: Any,
+    mock_notion_cls: Any,
+    mock_prompt: Any,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two pages share the same is_database=True signature → create_database called once;
+    each affected table gets a resolution entry; Pass 2 emits child_database blocks."""
+    monkeypatch.setattr("confluence_to_notion.cli._stdin_is_tty", lambda: True)
+
+    tree = PageTreeNode(
+        id="root",
+        title="Root Page",
+        children=[
+            PageTreeNode(id="c1", title="Child 1"),
+            PageTreeNode(id="c2", title="Child 2"),
+        ],
+    )
+    body_a = _table_xhtml(["Name", "Role"], [["Alice", "Dev"], ["Bob", "PM"]])
+    body_b = _table_xhtml(["Name", "Role"], [["Carol", "QA"], ["Dan", "PM"]])
+    bodies = {"root": "<p/>", "c1": body_a, "c2": body_b}
+
+    mock_settings.return_value = _make_settings_mock()
+    mock_conf_cls.return_value = _build_confluence_mock_with_bodies(tree, bodies)
+    notion_mock = _build_notion_mock()
+    notion_mock.create_database = AsyncMock(return_value="db-shared-123")
+    mock_notion_cls.return_value = notion_mock
+
+    mock_prompt.return_value = TableRule(
+        is_database=True,
+        title_column="name",
+        column_types={"name": "title", "role": "select"},
+    )
+
+    rules_path = tmp_path / "rules.json"
+    _write_rules(rules_path)
+    table_rules_path = tmp_path / "table-rules.json"
+    resolution_path = tmp_path / "resolution.json"
+
+    result = runner.invoke(
+        app,
+        [
+            "migrate-tree-pages",
+            "--root-id",
+            "root",
+            "--target",
+            "parent-xyz",
+            "--rules",
+            str(rules_path),
+            "--resolution-out",
+            str(resolution_path),
+            "--table-rules",
+            str(table_rules_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    # (a) create_database invoked exactly once for the shared signature.
+    assert notion_mock.create_database.await_count == 1
+    db_call = notion_mock.create_database.await_args_list[0]
+    db_kwargs = db_call.kwargs
+    # The DB lives under the page where the signature was first observed (c1, → np-c1).
+    assert db_kwargs.get("parent_id", db_call.args[0] if db_call.args else None) == "np-c1"
+    assert db_kwargs["title_column"] == "name"
+    assert db_kwargs["column_types"] == {"name": "title", "role": "select"}
+
+    # (b) Resolution store carries database_id entries for the affected tables.
+    res_store = ResolutionStore(resolution_path)
+    table_entries = [
+        (k, v) for k, v in res_store.data.entries.items() if k.startswith("table:")
+    ]
+    assert table_entries, "expected at least one table:* entry"
+    for _key, entry in table_entries:
+        assert entry.value == {"database_id": "db-shared-123"}
+
+    # (c) Pass 2 output for c1/c2 is a child_database referencing db-shared-123,
+    # never a layout table block.
+    blocks_per_page: dict[str, list[dict[str, Any]]] = {}
+    for call in notion_mock.append_blocks.await_args_list:
+        page_id = call.kwargs.get(
+            "page_id", call.args[0] if call.args else None
+        )
+        blocks = call.kwargs.get(
+            "blocks", call.args[1] if len(call.args) > 1 else []
+        )
+        blocks_per_page[page_id] = blocks
+
+    for np_id in ("np-c1", "np-c2"):
+        blocks = blocks_per_page[np_id]
+        child_db_blocks = [b for b in blocks if b.get("type") == "child_database"]
+        assert len(child_db_blocks) == 1, f"page {np_id} blocks={blocks}"
+        assert child_db_blocks[0]["child_database"] == {"database_id": "db-shared-123"}
+        assert not any(b.get("type") == "table" for b in blocks)
+
+
+@patch("confluence_to_notion.cli._prompt_table_rule")
+@patch("confluence_to_notion.cli.NotionClientWrapper")
+@patch("confluence_to_notion.cli.ConfluenceClient")
+@patch("confluence_to_notion.cli._load_settings")
+def test_pass15_layout_signature_keeps_table_block_and_no_db_create(
+    mock_settings: Any,
+    mock_conf_cls: Any,
+    mock_notion_cls: Any,
+    mock_prompt: Any,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """is_database=False → no create_database, page keeps layout table block."""
+    monkeypatch.setattr("confluence_to_notion.cli._stdin_is_tty", lambda: True)
+
+    tree = PageTreeNode(id="root", title="Root Page")
+    body = _table_xhtml(["Name", "Role"], [["Alice", "Dev"]])
+    mock_settings.return_value = _make_settings_mock()
+    mock_conf_cls.return_value = _build_confluence_mock_with_bodies(tree, {"root": body})
+    notion_mock = _build_notion_mock()
+    notion_mock.create_database = AsyncMock(return_value="db-should-not-be-used")
+    mock_notion_cls.return_value = notion_mock
+
+    mock_prompt.return_value = TableRule(is_database=False)
+
+    rules_path = tmp_path / "rules.json"
+    _write_rules(rules_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "migrate-tree-pages",
+            "--root-id",
+            "root",
+            "--target",
+            "parent-xyz",
+            "--rules",
+            str(rules_path),
+            "--resolution-out",
+            str(tmp_path / "resolution.json"),
+            "--table-rules",
+            str(tmp_path / "table-rules.json"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    notion_mock.create_database.assert_not_awaited()
+    # Page got a real table block (not child_database).
+    blocks = notion_mock.append_blocks.await_args_list[0].kwargs.get(
+        "blocks", notion_mock.append_blocks.await_args_list[0].args[1]
+    )
+    table_blocks = [b for b in blocks if b.get("type") == "table"]
+    child_db_blocks = [b for b in blocks if b.get("type") == "child_database"]
+    assert len(table_blocks) == 1
+    assert child_db_blocks == []
+
+
+@patch("confluence_to_notion.cli._prompt_table_rule")
+@patch("confluence_to_notion.cli.NotionClientWrapper")
+@patch("confluence_to_notion.cli.ConfluenceClient")
+@patch("confluence_to_notion.cli._load_settings")
+def test_pass15_non_tty_does_not_create_db(
+    mock_settings: Any,
+    mock_conf_cls: Any,
+    mock_notion_cls: Any,
+    mock_prompt: Any,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-TTY: rule is never set → no create_database invoked."""
+    monkeypatch.setattr("confluence_to_notion.cli._stdin_is_tty", lambda: False)
+
+    tree = PageTreeNode(id="root", title="Root Page")
+    body = _table_xhtml(["Name", "Role"], [["Alice", "Dev"]])
+    mock_settings.return_value = _make_settings_mock()
+    mock_conf_cls.return_value = _build_confluence_mock_with_bodies(tree, {"root": body})
+    notion_mock = _build_notion_mock()
+    notion_mock.create_database = AsyncMock(return_value="db-x")
+    mock_notion_cls.return_value = notion_mock
+
+    rules_path = tmp_path / "rules.json"
+    _write_rules(rules_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "migrate-tree-pages",
+            "--root-id",
+            "root",
+            "--target",
+            "parent-xyz",
+            "--rules",
+            str(rules_path),
+            "--resolution-out",
+            str(tmp_path / "resolution.json"),
+            "--table-rules",
+            str(tmp_path / "table-rules.json"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    notion_mock.create_database.assert_not_awaited()
+    mock_prompt.assert_not_called()
+
+
+@patch("confluence_to_notion.cli._prompt_table_rule")
+@patch("confluence_to_notion.cli.NotionClientWrapper")
+@patch("confluence_to_notion.cli.ConfluenceClient")
+@patch("confluence_to_notion.cli._load_settings")
+def test_pass15_existing_is_database_rule_creates_db_without_prompt(
+    mock_settings: Any,
+    mock_conf_cls: Any,
+    mock_notion_cls: Any,
+    mock_prompt: Any,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pre-existing is_database=True rule (no prompt) still triggers create_database."""
+    monkeypatch.setattr("confluence_to_notion.cli._stdin_is_tty", lambda: True)
+
+    tree = PageTreeNode(id="root", title="Root Page")
+    body = _table_xhtml(["Name", "Role"], [["Alice", "Dev"]])
+    mock_settings.return_value = _make_settings_mock()
+    mock_conf_cls.return_value = _build_confluence_mock_with_bodies(tree, {"root": body})
+    notion_mock = _build_notion_mock()
+    notion_mock.create_database = AsyncMock(return_value="db-pre-existing")
+    mock_notion_cls.return_value = notion_mock
+
+    table_rules_path = tmp_path / "table-rules.json"
+    pre = TableRuleStore(table_rules_path)
+    pre.upsert(
+        ["Name", "Role"],
+        TableRule(
+            is_database=True,
+            title_column="name",
+            column_types={"name": "title", "role": "select"},
+        ),
+    )
+    pre.save()
+
+    rules_path = tmp_path / "rules.json"
+    _write_rules(rules_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "migrate-tree-pages",
+            "--root-id",
+            "root",
+            "--target",
+            "parent-xyz",
+            "--rules",
+            str(rules_path),
+            "--resolution-out",
+            str(tmp_path / "resolution.json"),
+            "--table-rules",
+            str(table_rules_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    mock_prompt.assert_not_called()
+    assert notion_mock.create_database.await_count == 1
+    blocks = notion_mock.append_blocks.await_args_list[0].kwargs.get(
+        "blocks", notion_mock.append_blocks.await_args_list[0].args[1]
+    )
+    child_db_blocks = [b for b in blocks if b.get("type") == "child_database"]
+    assert len(child_db_blocks) == 1
+    assert child_db_blocks[0]["child_database"] == {"database_id": "db-pre-existing"}
 
 
 # --- _prompt_table_rule direct regression: store must survive round-trip ---

--- a/tests/unit/test_converter.py
+++ b/tests/unit/test_converter.py
@@ -1222,3 +1222,108 @@ class TestTableConversionWithTableRules:
         ]
         tables_unresolved = [u for u in result.unresolved if u.kind == "table"]
         assert tables_unresolved == []
+
+
+# --- ResolutionStore database_id → child_database emission ---
+
+
+class TestResolutionStoreDatabaseIdEmission:
+    """When a 'table:{identifier}' entry carries database_id, emit a child_database
+    block referring to it INSTEAD of the layout table, and suppress the UnresolvedItem
+    so Pass 1.5 doesn't re-prompt forever.
+    """
+
+    @staticmethod
+    def _xhtml() -> str:
+        return (
+            "<table>"
+            "<thead><tr><th>Name</th><th>Role</th></tr></thead>"
+            "<tbody><tr><td>Alice</td><td>Dev</td></tr></tbody>"
+            "</table>"
+        )
+
+    def _identifier_for(self, xhtml: str) -> str:
+        first = convert_page(xhtml, _default_ruleset(), page_id="pg-1")
+        return next(u.identifier for u in first.unresolved if u.kind == "table")
+
+    def test_database_id_emits_child_database_reference_block(
+        self, tmp_path: Path
+    ) -> None:
+        """database_id in store → exactly one child_database block, zero UnresolvedItems."""
+        xhtml = self._xhtml()
+        identifier = self._identifier_for(xhtml)
+
+        store = ResolutionStore(tmp_path / "res.json")
+        store.add(
+            key=f"table:{identifier}",
+            resolved_by="notion_migration",
+            value={"database_id": "db-abc-123"},
+        )
+
+        result = convert_page(xhtml, _default_ruleset(), page_id="pg-1", store=store)
+
+        assert result.blocks == [
+            {"type": "child_database", "child_database": {"database_id": "db-abc-123"}}
+        ]
+        tables_unresolved = [u for u in result.unresolved if u.kind == "table"]
+        assert tables_unresolved == []
+
+    def test_legacy_notion_blocks_entry_unchanged(self, tmp_path: Path) -> None:
+        """Pre-existing notion_blocks entries (no database_id) still pass through verbatim."""
+        xhtml = self._xhtml()
+        identifier = self._identifier_for(xhtml)
+
+        store = ResolutionStore(tmp_path / "res.json")
+        legacy_blocks = [
+            {"type": "child_database", "child_database": {"title": "Legacy"}}
+        ]
+        store.add(
+            key=f"table:{identifier}",
+            resolved_by="ai_inference",
+            value={"notion_blocks": legacy_blocks},
+        )
+
+        result = convert_page(xhtml, _default_ruleset(), page_id="pg-1", store=store)
+        assert result.blocks == legacy_blocks
+        tables_unresolved = [u for u in result.unresolved if u.kind == "table"]
+        assert tables_unresolved == []
+
+    def test_store_miss_preserves_layout_table_path(self, tmp_path: Path) -> None:
+        """Store miss → existing layout table block + UnresolvedItem(kind='table')."""
+        xhtml = self._xhtml()
+        store = ResolutionStore(tmp_path / "res.json")  # empty
+
+        result = convert_page(xhtml, _default_ruleset(), page_id="pg-1", store=store)
+        table_blocks = [b for b in result.blocks if b["type"] == "table"]
+        assert len(table_blocks) == 1
+        tables_unresolved = [u for u in result.unresolved if u.kind == "table"]
+        assert len(tables_unresolved) == 1
+
+    def test_database_id_takes_precedence_over_notion_blocks(
+        self, tmp_path: Path
+    ) -> None:
+        """Entry carrying BOTH database_id and notion_blocks → database_id wins."""
+        xhtml = self._xhtml()
+        identifier = self._identifier_for(xhtml)
+
+        store = ResolutionStore(tmp_path / "res.json")
+        store.add(
+            key=f"table:{identifier}",
+            resolved_by="notion_migration",
+            value={
+                "database_id": "db-precedence",
+                "notion_blocks": [
+                    {"type": "child_database", "child_database": {"title": "Stale"}}
+                ],
+            },
+        )
+
+        result = convert_page(xhtml, _default_ruleset(), page_id="pg-1", store=store)
+        assert result.blocks == [
+            {
+                "type": "child_database",
+                "child_database": {"database_id": "db-precedence"},
+            }
+        ]
+        tables_unresolved = [u for u in result.unresolved if u.kind == "table"]
+        assert tables_unresolved == []

--- a/tests/unit/test_notion_client.py
+++ b/tests/unit/test_notion_client.py
@@ -401,6 +401,151 @@ class TestAppendBlocks:
         assert mock_append.call_count == 2
 
 
+# --- create_database tests ---
+
+
+class TestCreateDatabase:
+    """Verify NotionClientWrapper.create_database payload, mapping, and retry."""
+
+    @staticmethod
+    def _mock_response(database_id: str = "db-new-id") -> dict[str, Any]:
+        return {"id": database_id, "object": "database"}
+
+    async def test_payload_shape_and_returns_database_id(
+        self, notion_client: NotionClientWrapper
+    ) -> None:
+        """parent={'page_id'}, title as rich_text, properties built from column_types."""
+        mock_create = AsyncMock(return_value=self._mock_response("db-123"))
+        with patch.object(notion_client._client.databases, "create", mock_create):
+            db_id = await notion_client.create_database(
+                parent_id="parent-xyz",
+                title="My DB",
+                title_column="name",
+                column_types={"name": "title", "role": "select"},
+            )
+        assert db_id == "db-123"
+        mock_create.assert_called_once()
+        kwargs = mock_create.call_args.kwargs
+        assert kwargs["parent"] == {"page_id": "parent-xyz"}
+        assert kwargs["title"] == [{"type": "text", "text": {"content": "My DB"}}]
+        # title_column ('name') becomes the title property; others become their declared type.
+        properties = kwargs["properties"]
+        assert properties == {
+            "name": {"title": {}},
+            "role": {"select": {}},
+        }
+
+    async def test_maps_every_supported_property_type(
+        self, notion_client: NotionClientWrapper
+    ) -> None:
+        """Each NotionPropertyType (plus 'url') maps to {<type>: {}}."""
+        mock_create = AsyncMock(return_value=self._mock_response())
+        with patch.object(notion_client._client.databases, "create", mock_create):
+            await notion_client.create_database(
+                parent_id="parent-xyz",
+                title="All Types",
+                title_column="name",
+                column_types={
+                    "name": "title",
+                    "notes": "rich_text",
+                    "status": "select",
+                    "due": "date",
+                    "owner": "people",
+                    "link": "url",
+                },
+            )
+        properties = mock_create.call_args.kwargs["properties"]
+        assert properties == {
+            "name": {"title": {}},
+            "notes": {"rich_text": {}},
+            "status": {"select": {}},
+            "due": {"date": {}},
+            "owner": {"people": {}},
+            "link": {"url": {}},
+        }
+
+    async def test_title_column_overrides_declared_type(
+        self, notion_client: NotionClientWrapper
+    ) -> None:
+        """The caller-supplied title_column wins over its column_types entry."""
+        mock_create = AsyncMock(return_value=self._mock_response())
+        with patch.object(notion_client._client.databases, "create", mock_create):
+            await notion_client.create_database(
+                parent_id="parent-xyz",
+                title="Override Title",
+                title_column="name",
+                # Even if 'name' is declared as rich_text, it must be emitted as title.
+                column_types={"name": "rich_text", "role": "select"},
+            )
+        properties = mock_create.call_args.kwargs["properties"]
+        assert properties["name"] == {"title": {}}
+        assert properties["role"] == {"select": {}}
+        # Exactly one title property.
+        title_props = [k for k, v in properties.items() if "title" in v]
+        assert title_props == ["name"]
+
+    async def test_retries_on_429_then_succeeds(
+        self, notion_client: NotionClientWrapper
+    ) -> None:
+        """One 429 followed by success → single retry, no re-raise."""
+        rate_limit_error = _make_api_error(429, "Rate limited")
+        rate_limit_error.status = 429
+        mock_create = AsyncMock(
+            side_effect=[rate_limit_error, self._mock_response("db-after-retry")]
+        )
+        with (
+            patch.object(notion_client._client.databases, "create", mock_create),
+            patch("confluence_to_notion.notion.client.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            db_id = await notion_client.create_database(
+                parent_id="parent-xyz",
+                title="Retry DB",
+                title_column="name",
+                column_types={"name": "title"},
+            )
+        assert db_id == "db-after-retry"
+        assert mock_create.call_count == 2
+
+    async def test_raises_after_max_retries_on_persistent_429(
+        self, notion_client: NotionClientWrapper
+    ) -> None:
+        """Persistent 429 → raises APIResponseError after max retries."""
+        rate_limit_error = _make_api_error(429, "Rate limited")
+        rate_limit_error.status = 429
+        mock_create = AsyncMock(side_effect=rate_limit_error)
+        with (
+            patch.object(notion_client._client.databases, "create", mock_create),
+            patch("confluence_to_notion.notion.client.asyncio.sleep", new_callable=AsyncMock),
+            pytest.raises(APIResponseError),
+        ):
+            await notion_client.create_database(
+                parent_id="parent-xyz",
+                title="Max Retry DB",
+                title_column="name",
+                column_types={"name": "title"},
+            )
+        assert mock_create.call_count == 6
+
+    async def test_no_retry_on_non_429(
+        self, notion_client: NotionClientWrapper
+    ) -> None:
+        """Non-429 errors are raised immediately."""
+        auth_error = _make_api_error(401, "Unauthorized")
+        auth_error.status = 401
+        mock_create = AsyncMock(side_effect=auth_error)
+        with (
+            patch.object(notion_client._client.databases, "create", mock_create),
+            pytest.raises(APIResponseError),
+        ):
+            await notion_client.create_database(
+                parent_id="parent-xyz",
+                title="No Retry DB",
+                title_column="name",
+                column_types={"name": "title"},
+            )
+        assert mock_create.call_count == 1
+
+
 async def test_create_page_tree_builds_hierarchy(
     notion_client: NotionClientWrapper,
 ) -> None:


### PR DESCRIPTION
## Summary

Automated implementation for #66.

Closes #66

## Pipeline

Generated by `scripts/develop.sh 66` — Plan, Implement, Test, Review, Fix, Verify, PR.

## Artifacts

- Plan: `output/dev/plan.json`
- Review: `output/dev/review.json`

## Test plan

- [ ] `uv run ruff check src/ tests/` passes
- [ ] `uv run mypy src/` passes
- [ ] `uv run pytest` passes
- [ ] Manual review of changes against issue requirements