### PR TITLE
feat: cont: cont: cont: cont: cont: refactor: 런 단위 아티팩트 레이아웃 + status.json + report.md (remaining) (remaining) (remaining) (remaining) (remaining)

### DIFF
--- a/src/confluence_to_notion/cli.py
+++ b/src/confluence_to_notion/cli.py
@@ -578,6 +578,11 @@ def migrate_tree(
         "--resolution-out",
         help="Where to persist title→Notion page ID mapping",
     ),
+    url: str | None = typer.Option(
+        None,
+        "--url",
+        help="Confluence source URL; when set, writes artifacts to output/runs/<slug>/",
+    ),
 ) -> None:
     """Create an empty Notion page hierarchy mirroring a Confluence tree.
 
@@ -585,6 +590,10 @@ def migrate_tree(
     page for each node under --target (or NOTION_ROOT_PAGE_ID), and persists
     the resulting ``title → notion_page_id`` mapping to the resolution store
     so that later conversion passes can resolve internal page links.
+
+    When --url is provided, resolution.json lands under ``output/runs/<slug>/``
+    alongside source.json, status.json, and report.md; ``--resolution-out`` is
+    ignored in that mode.
     """
     if not tree.exists():
         console.print(f"[red]Tree file not found: {tree}[/red]")
@@ -615,27 +624,51 @@ def migrate_tree(
 
     client = NotionClientWrapper(settings)
 
+    run_dir: Path | None = None
+    resolution_path = resolution_out
+    if url is not None:
+        run_dir, _ = start_run(
+            Path("output"),
+            url,
+            "tree",
+            root_id=tree_node.id,
+            notion_target={"page_id": parent_id},
+        )
+        resolution_path = run_dir / "resolution.json"
+        update_step(run_dir, "migrate", StepStatus.RUNNING)
+
     async def _run() -> dict[str, str]:
         return await client.create_page_tree(parent_id=parent_id, tree=tree_node)
 
     try:
-        mapping = asyncio.run(_run())
-    except APIResponseError as e:
-        console.print(f"[red]Notion API error {e.status} — {e.body}[/red]")
-        raise typer.Exit(code=1) from None
+        try:
+            mapping = asyncio.run(_run())
+        except APIResponseError as e:
+            if run_dir is not None:
+                update_step(run_dir, "migrate", StepStatus.FAILED)
+            console.print(f"[red]Notion API error {e.status} — {e.body}[/red]")
+            raise typer.Exit(code=1) from None
 
-    store = ResolutionStore(resolution_out)
-    for title, notion_page_id in mapping.items():
-        store.add(
-            key=f"page_link:{title}",
-            resolved_by="notion_migration",
-            value={"notion_page_id": notion_page_id},
+        store = ResolutionStore(resolution_path)
+        for title, notion_page_id in mapping.items():
+            store.add(
+                key=f"page_link:{title}",
+                resolved_by="notion_migration",
+                value={"notion_page_id": notion_page_id},
+            )
+        store.save()
+
+        if run_dir is not None:
+            update_step(
+                run_dir, "migrate", StepStatus.DONE, count=len(mapping)
+            )
+
+        console.print(
+            f"[green]Created {len(mapping)} Notion pages → {resolution_path}[/green]"
         )
-    store.save()
-
-    console.print(
-        f"[green]Created {len(mapping)} Notion pages → {resolution_out}[/green]"
-    )
+    finally:
+        if run_dir is not None:
+            finalize_run(run_dir)
 
 
 @app.command(name="migrate-tree-pages")

--- a/tests/unit/test_cli_migrate_tree.py
+++ b/tests/unit/test_cli_migrate_tree.py
@@ -1,5 +1,6 @@
 """Unit tests for the CLI migrate-tree command."""
 
+import json
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -250,3 +251,124 @@ def test_migrate_tree_handles_notion_api_error(
 def _isolate_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Run tests in a temporary cwd so default output paths don't collide."""
     monkeypatch.chdir(tmp_path)
+
+
+class TestMigrateTreeWithUrl:
+    """`cli migrate-tree --url ...` writes artifacts under output/runs/<slug>/."""
+
+    _URL = (
+        "https://example.atlassian.net/wiki/spaces/ENG/pages/12345/Some-Title"
+    )
+
+    @patch("confluence_to_notion.cli.NotionClientWrapper")
+    @patch("confluence_to_notion.cli._load_settings")
+    def test_url_success_writes_run_dir_artifacts(
+        self,
+        mock_settings: Any,
+        mock_client_cls: Any,
+        tmp_path: Path,
+    ) -> None:
+        """--url: run dir gets source.json/status.json/resolution.json/report.md."""
+        mock_settings.return_value = _make_settings_mock()
+
+        mock_client = mock_client_cls.return_value
+        mapping = {
+            "Root Page": "np-root",
+            "Child 1": "np-c1",
+            "Child 2": "np-c2",
+            "Grandchild 1": "np-gc1",
+        }
+        mock_client.create_page_tree = AsyncMock(return_value=mapping)
+
+        tree_path = tmp_path / "page-tree.json"
+        _write_tree(tree_path, _fixture_tree())
+
+        result = runner.invoke(
+            app,
+            [
+                "migrate-tree",
+                "--tree",
+                str(tree_path),
+                "--target",
+                "parent-xyz",
+                "--url",
+                self._URL,
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+
+        run_dir = tmp_path / "output" / "runs" / "example-12345"
+        assert run_dir.is_dir()
+
+        source_data = json.loads((run_dir / "source.json").read_text())
+        assert source_data["url"] == self._URL
+        assert source_data["type"] == "tree"
+        assert source_data["root_id"] == "root"
+        assert source_data["notion_target"] == {"page_id": "parent-xyz"}
+
+        status = json.loads((run_dir / "status.json").read_text())
+        assert status["migrate"]["status"] == "done"
+        assert status["migrate"]["count"] == len(mapping)
+        assert status["migrate"]["at"] is not None
+
+        resolution_path = run_dir / "resolution.json"
+        assert resolution_path.exists()
+        assert not (tmp_path / "output" / "resolution.json").exists()
+
+        store = ResolutionStore(resolution_path)
+        for title, notion_page_id in mapping.items():
+            entry = store.lookup(f"page_link:{title}")
+            assert entry is not None, f"missing entry for {title}"
+            assert entry.value == {"notion_page_id": notion_page_id}
+
+        report = (run_dir / "report.md").read_text()
+        assert "# Run Report" in report
+        assert self._URL in report
+
+    @patch("confluence_to_notion.cli.NotionClientWrapper")
+    @patch("confluence_to_notion.cli._load_settings")
+    def test_url_api_error_records_failure_and_renders_report(
+        self,
+        mock_settings: Any,
+        mock_client_cls: Any,
+        tmp_path: Path,
+    ) -> None:
+        """On APIResponseError the migrate step is failed; report.md is still rendered."""
+        mock_settings.return_value = _make_settings_mock()
+
+        mock_client = mock_client_cls.return_value
+        api_error = APIResponseError(
+            code="unauthorized",
+            status=401,
+            message="Unauthorized",
+            headers=httpx.Headers(),
+            raw_body_text="Unauthorized",
+        )
+        mock_client.create_page_tree = AsyncMock(side_effect=api_error)
+
+        tree_path = tmp_path / "page-tree.json"
+        _write_tree(tree_path, _fixture_tree())
+
+        result = runner.invoke(
+            app,
+            [
+                "migrate-tree",
+                "--tree",
+                str(tree_path),
+                "--target",
+                "parent-xyz",
+                "--url",
+                self._URL,
+            ],
+        )
+
+        assert result.exit_code != 0
+
+        run_dir = tmp_path / "output" / "runs" / "example-12345"
+        assert run_dir.is_dir()
+
+        status = json.loads((run_dir / "status.json").read_text())
+        assert status["migrate"]["status"] == "failed"
+
+        assert (run_dir / "report.md").exists()


### PR DESCRIPTION
## Summary

Automated implementation for #107.

Closes #107

## Pipeline

Generated by `scripts/develop.sh 107` — Plan, Implement, Test, Review, Fix, Verify, PR.

## Artifacts

- Plan: `output/dev/plan.json`
- Review: `output/dev/review.json`

## Test plan

- [ ] `uv run ruff check src/ tests/` passes
- [ ] `uv run mypy src/` passes
- [ ] `uv run pytest` passes
- [ ] Manual review of changes against issue requirements