### PR TITLE
docs: English README + Slack/OpenClaw bridge handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,12 @@ the same way.
 
 - Python 3.11+
 - [`uv`](https://docs.astral.sh/uv/) package manager
-- Claude Code CLI (`claude`) — required to run the discovery agents
+- Claude Code CLI (`claude`) — required to run the discovery agents (`claude -p`)
 - A Notion integration token with access to a target parent page
 - For private Confluence Cloud: Atlassian email + API token.
   Public wikis (e.g. `cwiki.apache.org`) need only the base URL.
+- **Windows:** `scripts/discover.sh` requires **Bash** (e.g. Git Bash). Run MCP and
+  CLI from an environment where `bash`, `uv`, and `claude` are on `PATH`.
 
 ## Setup
 
@@ -54,20 +56,26 @@ uv run c2n notion-ping
 
 ## Pipeline stages
 
-A migration flows through four stages. Stages 1–2 populate local files from
-your wiki and derive rules; stage 3 turns XHTML into Notion blocks; stage 4
-pushes the result to Notion.
+A full migration moves through the stages below. Stages 1–2 pull wiki data and
+run agents; stage 3 turns proposals into `rules.json`; stage 4 converts XHTML
+offline; stage 5 publishes to Notion (often wrapped in a single `migrate`
+command).
 
-| Stage      | What happens                                       | Produces                                         |
-|------------|----------------------------------------------------|--------------------------------------------------|
-| 1. fetch   | Pull Confluence XHTML (and optionally the tree).   | `samples/*.xhtml`, `output/page-tree.json`       |
-| 2. discover| Claude agents propose transformation rules.        | `output/patterns.json`, `output/proposals.json`  |
-| 3. convert | Deterministic converter maps XHTML → Notion blocks.| `output/rules.json`, `output/converted/*.json`   |
-| 4. migrate | Create Notion pages and upload converted bodies.   | Pages under `NOTION_ROOT_PAGE_ID`                |
+| Stage        | What happens                                              | Produces                                                |
+|--------------|-----------------------------------------------------------|---------------------------------------------------------|
+| 1. fetch     | Pull Confluence XHTML (and optionally the tree).          | `samples/*.xhtml`, `output/page-tree.json`              |
+| 2. discover  | Claude agents emit patterns and proposed rules.           | `output/patterns.json`, `output/proposals.json`         |
+| 3. finalize  | Deterministic step: proposals → migration rules.          | `output/rules.json`                                     |
+| 4. convert   | Deterministic converter maps XHTML → Notion block JSON.     | `output/runs/<slug>/converted/*.json`                   |
+| 5. migrate   | Create or update Notion pages and upload bodies.          | Pages under `NOTION_ROOT_PAGE_ID`                       |
 
-The discovery stage is orchestrated by a bash script, not by a Claude command —
-each agent runs as an independent `claude -p` session and communicates via
-files on disk.
+The discovery path is orchestrated by **`bash scripts/discover.sh`**, not by a
+Claude slash command — each agent runs as an independent `claude -p` session
+and communicates via files on disk. The script runs finalize (step 3) and
+convert (step 4) after the agents finish.
+
+If `output/rules.json` already exists, you can skip re-discovery and run
+convert/migrate only (see `--rediscover` on `migrate`).
 
 ## Migration walkthrough (Apache cwiki → Notion)
 
@@ -94,8 +102,8 @@ uv run c2n migrate <confluence-url> --rediscover
 `c2n migrate` classifies the URL (new-Cloud `/spaces/<KEY>/pages/<id>/...`,
 legacy `/display/<SPACE>/<Title>`, or space-root `/spaces/<KEY>`), runs
 `scripts/discover.sh` if `output/rules.json` is missing, converts, and publishes
-everything under `output/runs/<slug>/` (source.json, status.json, report.md,
-converted/, resolution.json for trees).
+everything under `output/runs/<slug>/` (`source.json`, `status.json`, `report.md`,
+`converted/`, `resolution.json` for trees).
 
 ### Low-level escape hatch
 
@@ -107,7 +115,7 @@ intermediate artifacts, re-running a single step, wiring into CI):
 uv run c2n fetch --space KAFKA --limit 25
 uv run c2n fetch --pages 27846297,27838103
 
-# Run just the discover pipeline
+# Run just the discover pipeline (agents + finalize + convert)
 bash scripts/discover.sh samples/ --url <confluence-url>
 
 # Finalize + convert offline
@@ -143,14 +151,12 @@ validate-output     Validate an agent output file against its Pydantic schema
 
 Run `uv run c2n <command> --help` for the full option list.
 
-## MCP 설치
+## MCP (Claude Code, OpenClaw, other clients)
 
-`c2n` 는 stdio transport 기반 MCP 서버(`c2n-mcp`) 를 번들한다. Claude Code 에서
-레포 루트에 `.mcp.json` 을 두고 아래 스니펫을 추가하면 로컬 세션에서 바로 연결된다.
+The repo ships a **stdio MCP server** entrypoint: `c2n-mcp` (via `uv run c2n-mcp`).
 
-`c2n-mcp` 는 `uv run c2n …` / `discover.sh` 자식 프로세스를 **항상 레포 루트를 `cwd` 로**
-실행한다(JSON-RPC용 stdout 에 Rich/쉘 로그가 섞이지 않도록, 자식 stdout/stderr 는 캡처).
-클라이언트 cwd 와 무관하게 `output/`, `samples/` 등은 레포 기준 경로로 해석된다.
+- **Child processes** (`uv run c2n …`, `discover.sh`) always run with the **repository root as the working directory**, so `output/`, `samples/`, and `.env` resolve correctly regardless of the MCP client’s cwd. Rich and shell logs from children are captured so they do not corrupt JSON-RPC on stdout.
+- **Claude Code:** add a `.mcp.json` at the repo root:
 
 ```json
 {
@@ -163,35 +169,59 @@ Run `uv run c2n <command> --help` for the full option list.
 }
 ```
 
-### Tools (요약)
+- **OpenClaw** (and similar gateways): register the same command in your MCP
+  registry, and set **`cwd` / `workingDirectory` to this repo’s absolute path**
+  if the client does not implicitly use the project folder. Example shape (see
+  your OpenClaw version for exact keys):
 
-| Tool | 역할 |
+```json
+{
+  "mcp": {
+    "servers": {
+      "c2n": {
+        "command": "uv",
+        "args": ["run", "c2n-mcp"],
+        "cwd": "/absolute/path/to/confluence-to-notion"
+      }
+    }
+  }
+}
+```
+
+For **Slack / chat–driven orchestration** and custom bridges (proposals from
+outside the default discover flow), see `docs/slack-openclaw-c2n-bridge.md`.
+
+### Tools (summary)
+
+| Tool | Role |
 |------|------|
-| `c2n_list_runs` | `output/runs/` 아래 런 요약 |
-| `c2n_status` | 특정 slug의 `status.json` (또는 slug 생략 시 목록) |
+| `c2n_list_runs` | Summarize runs under `output/runs/` |
+| `c2n_status` | Read `status.json` for a slug (or list when slug omitted) |
 | `c2n_resolve_url` | Confluence URL → `source_type` / `identifier` |
-| `c2n_migrate` | `uv run c2n migrate <url>` 서브프로세스(MCP stdio 보호). 선택 인자: `to`(Notion 부모 URL·page id), `name`(런 슬러그), `rediscover`, `dry_run`. 성공 시 `{returncode, stdout}` |
-| `c2n_fetch` | `uv run c2n fetch` (`space` 또는 `pages`, 선택 `url`) → `{returncode, stdout}` |
+| `c2n_migrate` | Runs `uv run c2n migrate <url>` in a subprocess (stdio-safe). Optional: `to` (Notion parent URL or page id), `name` (run slug), `rediscover`, `dry_run`. Returns `{returncode, stdout}` on success |
+| `c2n_fetch` | `uv run c2n fetch` (`space` or `pages`, optional `url`) → `{returncode, stdout}` |
 | `c2n_discover` | `bash scripts/discover.sh <samples> --url <url>` → `{returncode, stdout}` |
 | `c2n_convert` | `uv run c2n convert --rules … --input … --url …` → `{returncode, stdout}` |
-| `c2n_push` | `uv run c2n migrate --url … --rules … --input … --target …` (레거시 배치) → `{returncode, stdout}` |
+| `c2n_push` | Legacy batch form: `uv run c2n migrate --url … --rules … --input … --target …` → `{returncode, stdout}` |
 
 ### Resources
 
 - `c2n://runs`, `c2n://runs/<slug>/status|report|converted/<page>`, `c2n://rules`
 
-### 예제 워크플로우 (Claude Code)
+### Example workflow (MCP client)
 
-1. `.env` 를 채우고 `uv sync` 로 의존성을 맞춘다.
-2. MCP 패널에서 `c2n_resolve_url` 로 붙여넣은 Confluence URL 분류를 확인한다.
-3. `c2n_migrate` 에 같은 URL을 넘겨 한 번에 fetch → discover(필요 시) → convert → Notion 까지 돌린다 (`dry_run: true` 로 먼저 아티팩트만 확인할 수 있다).
-4. `c2n_list_runs` 로 방금 생긴 런의 **slug** 를 확인한 뒤, `c2n_status(slug=…)` 또는 `c2n://runs/<slug>/report` 리소스로 상태·리포트를 읽는다. (도구 응답은 `{returncode, stdout}` 이므로 slug는 목록/리소스에서 회수한다.)
+1. Fill `.env` and run `uv sync`.
+2. Call `c2n_resolve_url` with a Confluence URL to see how it is classified.
+3. Call `c2n_migrate` with the same URL to run fetch → discover (if needed) → convert → Notion. Use `dry_run: true` first to inspect artifacts only.
+4. Use `c2n_list_runs` to get the run **slug**, then `c2n_status(slug=…)` or the `c2n://runs/<slug>/report` resource. Tool responses are `{returncode, stdout}`; recover the slug from list/resources.
 
-저수준 단계만 쪼개서 돌리려면 `c2n_fetch` → `c2n_discover` → `c2n_convert` → `c2n_push` 순으로 호출하면 CLI와 동일한 파이프라인을 재구성할 수 있다.
+To mirror the CLI pipeline step by step: `c2n_fetch` → `c2n_discover` → `c2n_convert` → `c2n_push`.
 
-### 수동 검증 (PR 시 기재)
+### Manual verification (for PRs)
 
-Claude Code 에서 stdio MCP 연결 후, 위 예제 중 **한 페이지 URL**에 대해 `c2n_migrate`(또는 `dry_run` → 실제 push)가 끝까지 성공하는지, 그리고 `c2n_status` / `c2n://…/report` 로 해당 런이 보이는지 확인한다. 실패 시 MCP 에러 메시지와 `output/runs/<slug>/report.md` 를 함께 첨부한다.
+With stdio MCP connected, confirm that for **one page URL**, `c2n_migrate` (or
+`dry_run` then a real push) completes, and that `c2n_status` / `c2n://…/report`
+shows the run. On failure, attach the MCP error and `output/runs/<slug>/report.md`.
 
 ## Development
 

--- a/docs/slack-openclaw-c2n-bridge.md
+++ b/docs/slack-openclaw-c2n-bridge.md
@@ -1,58 +1,73 @@
-# Slack · OpenClaw · confluence-to-notion 브리지 — 에이전트 핸드오프
+# Slack · OpenClaw · confluence-to-notion bridge — agent handoff
 
-회사 내부 에이전트/구현팀이 **채팅 기반 규칙 반영 + Confluence → Notion 마이그레이션**을 구성할 때 참고하는 요약 문서다.  
-이 레포(`confluence-to-notion`, 이하 **c2n**)는 **마이그레이션 엔진 + MCP**를 제공하고, **슬랙 대화 → 규칙 JSON** 브리지는 **본 레포 밖에서** 만든다는 전제다.
-
----
-
-## 1. 목표 유저 플로우 (의도)
-
-1. 사용자가 **Slack**(또는 OpenClaw가 붙은 채널)에서 자연어로 요구·검토·질문을 한다.  
-2. **OpenClaw**가 대화를 처리하고, 필요 시 **다음 단계**(파일 쓰기, 스크립트, MCP 호출)를 실행한다.  
-3. 대화에서 정리된 요구가 **마이그레이션 규칙**(`rules.json`으로 이어지는 산출물)에 반영된다.  
-4. 같은 규칙으로 **사내 Confluence → Notion** 변환이 수행된다.  
-5. 이상적인 그림은 **채팅에만 응답했는데 노션 반영까지 끝난 상태**이나, **보안·품질**상 완전 무인보다 **`dry_run` + 사람 승인** 한 번을 두는 편이 현실적이다.
+This note is for internal agent / implementation teams wiring **chat-driven rule
+updates + Confluence → Notion migration**. The repository (`confluence-to-notion`,
+**c2n**) supplies the **migration engine and MCP**; the **Slack conversation →
+rules JSON** bridge is built **outside** this repo.
 
 ---
 
-## 2. 이 레포가 하는 일 / 하지 않는 일
+## 1. Target user flow (intent)
 
-### 2.1 이 레포가 제공하는 것
-
-- **stdio MCP 서버** `c2n-mcp`: 도구로 `c2n_resolve_url`, `c2n_migrate`, `c2n_discover`, `c2n_fetch`, `c2n_convert`, `c2n_list_runs`, `c2n_status` 등 (README `MCP 설치` 참고).
-- **CLI**: `uv run c2n …` — `finalize`, `migrate`, `convert`, `validate-output` 등.
-- **규칙 확정**: `uv run c2n finalize output/proposals.json` → `rules.json` (및 검증 경로).
-- **마이그레이션**: Confluence URL + `rules.json` 기준으로 Notion 반영.
-
-### 2.2 이 레포가 기본으로 하지 않는 것
-
-- **Slack 스레드 텍스트만으로** `rules.json`을 자동 생성하는 파이프라인은 **없다**.  
-- **Discover(규칙 자동 발견)** 는 **Confluence 샘플/XHTML**과 `scripts/discover.sh` 기준이며, **채팅 로그를 입력으로 삼지 않는다**.
-
-따라서 **“대화 → 규칙”** 은 **별도 브리지(회사 측 코드/스킬)** 의 책임이다.
+1. Users ask for review, clarification, or policy in **Slack** (or any channel
+   OpenClaw is connected to).
+2. **OpenClaw** handles the thread and, when needed, runs the next steps (write
+   files, shell, MCP calls).
+3. Requirements distilled from chat feed into **migration rules** (artifacts
+   that become `rules.json`).
+4. The same rules drive **internal Confluence → Notion** conversion.
+5. The ideal is **“I only replied in chat and Notion is already updated,”** but
+   for security and quality, **`dry_run` plus a human approval step** is the
+   realistic default.
 
 ---
 
-## 3. Discover와 Claude Code CLI (중요)
+## 2. What this repo does / does not do
 
-- `scripts/discover.sh`는 **`claude -p`(Claude Code CLI)** 를 서브프로세스로 실행한다.  
-- **OpenClaw가 쓰는 챗 LLM**(GPT 등)과는 별개다. Discover를 돌리려면 **해당 실행 환경에 `claude` CLI 설치·인증**이 필요하다.  
-- **`output/rules.json`이 이미 있고** 마이그레이션만 할 때는, rediscover를 쓰지 않으면 **런타임에 Claude CLI가 없어도** convert/migrate 쪽은 동작시키기 쉽다.
+### 2.1 What this repo provides
 
-**브리지 설계 시 선택지**
+- **stdio MCP server** `c2n-mcp`: tools such as `c2n_resolve_url`, `c2n_migrate`,
+  `c2n_discover`, `c2n_fetch`, `c2n_convert`, `c2n_list_runs`, `c2n_status` (see
+  README **MCP** section).
+- **CLI**: `uv run c2n …` — `finalize`, `migrate`, `convert`, `validate-output`, etc.
+- **Rule materialization**: `uv run c2n finalize output/proposals.json` →
+  `rules.json` (plus validation paths).
+- **Migration**: Notion updates from a Confluence URL + `rules.json`.
 
-| 전략 | 설명 |
-|------|------|
-| A. 대화 기반 규칙만 쓴다 | LLM/에디터로 `proposals.json` 작성 → `finalize` → `migrate`. Discover는 생략 가능할 수 있음(스키마·품질은 팀 책임). |
-| B. Discover와 병행 | Confluence 샘플로 `discover.sh` 실행 → `rules.json` + (필요 시) 브리지에서 만든 제안과 **병합 정책**을 팀이 정함. |
+### 2.2 What this repo does not provide out of the box
+
+- There is **no** pipeline that builds `rules.json` **from Slack thread text alone**.
+- **Discover** (automatic rule discovery) is driven by **Confluence samples /
+  XHTML** and `scripts/discover.sh`; it does **not** take chat logs as input.
+
+So **“conversation → rules”** is the **bridge** (your code or OpenClaw skills).
 
 ---
 
-## 4. OpenClaw와 MCP 연결 (개념)
+## 3. Discover and Claude Code CLI (important)
 
-- OpenClaw 설정의 **`mcp.servers`** 에 stdio 서버로 등록한다.  
-- **`cwd`(또는 `workingDirectory`)는 반드시 이 레포의 루트 절대 경로** — `c2n-mcp`가 자식 프로세스를 레포 루트 기준으로 실행한다 (README MCP 섹션).  
-- 예시 형태 (실제 키 이름은 OpenClaw 버전 문서 따름):
+- `scripts/discover.sh` runs **`claude -p` (Claude Code CLI)** as a subprocess.
+- That is **separate** from whichever chat LLM OpenClaw uses (e.g. GPT). To run
+  discover, the host needs the **`claude` CLI installed and signed in**.
+- If **`output/rules.json` already exists** and you only migrate, you can often
+  run convert/migrate **without** Claude CLI at runtime when you are not using
+  `--rediscover`.
+
+**Bridge design options**
+
+| Strategy | Description |
+|----------|-------------|
+| A. Conversation-only rules | Author `proposals.json` with an LLM or editor → `finalize` → `migrate`. Discover may be skipped (schema and quality are on your team). |
+| B. Combine with discover | Run `discover.sh` on Confluence samples → `rules.json`, plus **merge policy** with bridge-produced proposals if needed. |
+
+---
+
+## 4. OpenClaw and MCP (concept)
+
+- Register the stdio server under **`mcp.servers`** in OpenClaw config.
+- **`cwd` (or `workingDirectory`) must be this repository’s root** — `c2n-mcp`
+  runs child processes from the repo root (see README MCP section).
+- Example shape (exact keys depend on your OpenClaw version):
 
 ```json
 {
@@ -68,57 +83,66 @@
 }
 ```
 
-- 레포 루트에 **`.env`** (Confluence / Notion 자격 증명 등) 필요.
+- Place **`.env`** at the repo root (Confluence / Notion credentials, etc.).
 
 ---
 
-## 5. Windows + 보안 가이드 (순수 Windows, WSL 없음)
+## 5. Windows + security posture (native Windows, no WSL)
 
-- **Discover**는 **`bash scripts/discover.sh`** 이므로 **Bash**가 필요하다.  
-- **Git for Windows(Git Bash)** 등 회사가 허용한 Bash 환경에서 `bash`가 PATH에 잡혀 있어야 한다.  
-- 레포 경로는 **공백·비ASCII 최소화** 권장.  
-- OpenClaw·Claude Code CLI·`uv`는 **같은 머신**에서 동작 확인 후 MCP `cwd`와 일치시킬 것.
-
----
-
-## 6. MVP 브리지 — 이 레포 변경 최소화
-
-회사 측 브리지만으로도 **레포 수정 없이** 갈 수 있는 최소 경로:
-
-1. 브리지가 대화/승인 결과를 **`output/proposals.json`** (스키마 만족)으로 쓴다.  
-2. `uv run c2n finalize output/proposals.json` → **`rules.json`**.  
-3. `uv run c2n validate-output …` 등으로 검증 (CLI/README 참고).  
-4. `uv run c2n migrate --url …` 또는 MCP `c2n_migrate`로 Notion 반영 (`dry_run` 먼저 권장).
-
-이후 **레포에 손대고 싶어지는 경우**는 선택 사항이다. 예: MCP에 proposals 본문을 직접 넘기는 도구, `proposals` 병합/수리 서브커맨드, discover 산출과의 merge 정책을 코드화 등.
+- **Discover** needs **`bash scripts/discover.sh`** → **Bash** must be available.
+- Use **Git for Windows (Git Bash)** or another approved Bash where `bash` is on
+  `PATH`.
+- Prefer repo paths **without spaces or non-ASCII** characters.
+- Run OpenClaw, Claude Code CLI, and `uv` on the **same machine** and align MCP
+  `cwd` with that layout.
 
 ---
 
-## 7. 현실적인 운영 가드
+## 6. MVP bridge — minimal changes to this repo
 
-- **대화만으로 규칙 JSON이 항상 맞지 않음** → 스키마 검증 실패 시 재시도·사람 확인.  
-- **어떤 Confluence URL/범위를 옮길지**는 채팅만으로 모호할 수 있음 → 명시적 URL 목록·스페이스·승인 단계 권장.  
-- **민감 데이터**가 LLM/로그에 남지 않도록 회사 정책에 맞게 브리지·호스트·토큰 범위를 제한한다.
+You can ship a first version **without forking c2n**:
 
----
+1. The bridge writes **`output/proposals.json`** (valid schema) from chat /
+   approval.
+2. `uv run c2n finalize output/proposals.json` → **`rules.json`**.
+3. Validate with `uv run c2n validate-output …` (see CLI / README).
+4. `uv run c2n migrate --url …` or MCP `c2n_migrate` to push to Notion (prefer
+   `dry_run` first).
 
-## 8. 용어 정리
-
-| 용어 | 설명 |
-|------|------|
-| OpenClaw | 개인/팀 에이전트 런타임(구 Moltbot 등 이전 명칭과 동일 계열). 채널·MCP·스킬로 확장. |
-| c2n / confluence-to-notion | 본 레포. Confluence XHTML → Notion 블록 규칙 + 변환 + MCP. |
-| Discover | `discover.sh` + Claude Code CLI 기반 규칙 제안 파이프라인. |
-| 브리지 | 회사가 구현하는 **Slack/OpenClaw ↔ proposals/finalize/migrate** 오케스트레이션. |
+Optional later improvements: MCP tools that accept proposal payloads inline,
+subcommands to merge or repair proposals, code-level merge rules with discover
+output, etc.
 
 ---
 
-## 9. 참고 (레포 내부)
+## 7. Operational guardrails
 
-- `README.md` — MCP 설치, CLI, 워크플로우.  
-- `CLAUDE.md` — 에이전트·discover·eval 정책.  
-- `scripts/discover.sh` — `claude -p` 호출부.
+- Chat-derived rule JSON will **not** always validate → retry loops and human
+  review on schema failure.
+- **Which Confluence URLs or scopes** to migrate stay ambiguous if only inferred
+  from chat → keep explicit URL lists, spaces, or an approval step.
+- Scope **secrets and logging** so sensitive data does not leak to LLMs or logs
+  against company policy.
 
 ---
 
-*이 문서는 대화 기반으로 작성된 핸드오프용 요약이며, 구현 시 최신 README·CLI 도움말을 우선한다.*
+## 8. Glossary
+
+| Term | Meaning |
+|------|---------|
+| OpenClaw | Agent runtime for individuals or teams (same family of projects formerly known as Moltbot, etc.). Extends with channels, MCP, and skills. |
+| c2n / confluence-to-notion | This repository: Confluence XHTML → Notion block rules, conversion, MCP. |
+| Discover | Rule proposal pipeline: `discover.sh` + Claude Code CLI. |
+| Bridge | Your orchestration layer: **Slack/OpenClaw ↔ proposals / finalize / migrate**. |
+
+---
+
+## 9. References inside the repo
+
+- `README.md` — MCP setup, CLI, workflows.
+- `CLAUDE.md` — agents, discover, eval policy.
+- `scripts/discover.sh` — `claude -p` invocation.
+
+---
+
+*This document is a handoff summary. Prefer the latest README and `uv run c2n --help` when implementing.*

--- a/docs/slack-openclaw-c2n-bridge.md
+++ b/docs/slack-openclaw-c2n-bridge.md
@@ -1,0 +1,124 @@
+# Slack · OpenClaw · confluence-to-notion 브리지 — 에이전트 핸드오프
+
+회사 내부 에이전트/구현팀이 **채팅 기반 규칙 반영 + Confluence → Notion 마이그레이션**을 구성할 때 참고하는 요약 문서다.  
+이 레포(`confluence-to-notion`, 이하 **c2n**)는 **마이그레이션 엔진 + MCP**를 제공하고, **슬랙 대화 → 규칙 JSON** 브리지는 **본 레포 밖에서** 만든다는 전제다.
+
+---
+
+## 1. 목표 유저 플로우 (의도)
+
+1. 사용자가 **Slack**(또는 OpenClaw가 붙은 채널)에서 자연어로 요구·검토·질문을 한다.  
+2. **OpenClaw**가 대화를 처리하고, 필요 시 **다음 단계**(파일 쓰기, 스크립트, MCP 호출)를 실행한다.  
+3. 대화에서 정리된 요구가 **마이그레이션 규칙**(`rules.json`으로 이어지는 산출물)에 반영된다.  
+4. 같은 규칙으로 **사내 Confluence → Notion** 변환이 수행된다.  
+5. 이상적인 그림은 **채팅에만 응답했는데 노션 반영까지 끝난 상태**이나, **보안·품질**상 완전 무인보다 **`dry_run` + 사람 승인** 한 번을 두는 편이 현실적이다.
+
+---
+
+## 2. 이 레포가 하는 일 / 하지 않는 일
+
+### 2.1 이 레포가 제공하는 것
+
+- **stdio MCP 서버** `c2n-mcp`: 도구로 `c2n_resolve_url`, `c2n_migrate`, `c2n_discover`, `c2n_fetch`, `c2n_convert`, `c2n_list_runs`, `c2n_status` 등 (README `MCP 설치` 참고).
+- **CLI**: `uv run c2n …` — `finalize`, `migrate`, `convert`, `validate-output` 등.
+- **규칙 확정**: `uv run c2n finalize output/proposals.json` → `rules.json` (및 검증 경로).
+- **마이그레이션**: Confluence URL + `rules.json` 기준으로 Notion 반영.
+
+### 2.2 이 레포가 기본으로 하지 않는 것
+
+- **Slack 스레드 텍스트만으로** `rules.json`을 자동 생성하는 파이프라인은 **없다**.  
+- **Discover(규칙 자동 발견)** 는 **Confluence 샘플/XHTML**과 `scripts/discover.sh` 기준이며, **채팅 로그를 입력으로 삼지 않는다**.
+
+따라서 **“대화 → 규칙”** 은 **별도 브리지(회사 측 코드/스킬)** 의 책임이다.
+
+---
+
+## 3. Discover와 Claude Code CLI (중요)
+
+- `scripts/discover.sh`는 **`claude -p`(Claude Code CLI)** 를 서브프로세스로 실행한다.  
+- **OpenClaw가 쓰는 챗 LLM**(GPT 등)과는 별개다. Discover를 돌리려면 **해당 실행 환경에 `claude` CLI 설치·인증**이 필요하다.  
+- **`output/rules.json`이 이미 있고** 마이그레이션만 할 때는, rediscover를 쓰지 않으면 **런타임에 Claude CLI가 없어도** convert/migrate 쪽은 동작시키기 쉽다.
+
+**브리지 설계 시 선택지**
+
+| 전략 | 설명 |
+|------|------|
+| A. 대화 기반 규칙만 쓴다 | LLM/에디터로 `proposals.json` 작성 → `finalize` → `migrate`. Discover는 생략 가능할 수 있음(스키마·품질은 팀 책임). |
+| B. Discover와 병행 | Confluence 샘플로 `discover.sh` 실행 → `rules.json` + (필요 시) 브리지에서 만든 제안과 **병합 정책**을 팀이 정함. |
+
+---
+
+## 4. OpenClaw와 MCP 연결 (개념)
+
+- OpenClaw 설정의 **`mcp.servers`** 에 stdio 서버로 등록한다.  
+- **`cwd`(또는 `workingDirectory`)는 반드시 이 레포의 루트 절대 경로** — `c2n-mcp`가 자식 프로세스를 레포 루트 기준으로 실행한다 (README MCP 섹션).  
+- 예시 형태 (실제 키 이름은 OpenClaw 버전 문서 따름):
+
+```json
+{
+  "mcp": {
+    "servers": {
+      "c2n": {
+        "command": "uv",
+        "args": ["run", "c2n-mcp"],
+        "cwd": "C:\\path\\to\\confluence-to-notion"
+      }
+    }
+  }
+}
+```
+
+- 레포 루트에 **`.env`** (Confluence / Notion 자격 증명 등) 필요.
+
+---
+
+## 5. Windows + 보안 가이드 (순수 Windows, WSL 없음)
+
+- **Discover**는 **`bash scripts/discover.sh`** 이므로 **Bash**가 필요하다.  
+- **Git for Windows(Git Bash)** 등 회사가 허용한 Bash 환경에서 `bash`가 PATH에 잡혀 있어야 한다.  
+- 레포 경로는 **공백·비ASCII 최소화** 권장.  
+- OpenClaw·Claude Code CLI·`uv`는 **같은 머신**에서 동작 확인 후 MCP `cwd`와 일치시킬 것.
+
+---
+
+## 6. MVP 브리지 — 이 레포 변경 최소화
+
+회사 측 브리지만으로도 **레포 수정 없이** 갈 수 있는 최소 경로:
+
+1. 브리지가 대화/승인 결과를 **`output/proposals.json`** (스키마 만족)으로 쓴다.  
+2. `uv run c2n finalize output/proposals.json` → **`rules.json`**.  
+3. `uv run c2n validate-output …` 등으로 검증 (CLI/README 참고).  
+4. `uv run c2n migrate --url …` 또는 MCP `c2n_migrate`로 Notion 반영 (`dry_run` 먼저 권장).
+
+이후 **레포에 손대고 싶어지는 경우**는 선택 사항이다. 예: MCP에 proposals 본문을 직접 넘기는 도구, `proposals` 병합/수리 서브커맨드, discover 산출과의 merge 정책을 코드화 등.
+
+---
+
+## 7. 현실적인 운영 가드
+
+- **대화만으로 규칙 JSON이 항상 맞지 않음** → 스키마 검증 실패 시 재시도·사람 확인.  
+- **어떤 Confluence URL/범위를 옮길지**는 채팅만으로 모호할 수 있음 → 명시적 URL 목록·스페이스·승인 단계 권장.  
+- **민감 데이터**가 LLM/로그에 남지 않도록 회사 정책에 맞게 브리지·호스트·토큰 범위를 제한한다.
+
+---
+
+## 8. 용어 정리
+
+| 용어 | 설명 |
+|------|------|
+| OpenClaw | 개인/팀 에이전트 런타임(구 Moltbot 등 이전 명칭과 동일 계열). 채널·MCP·스킬로 확장. |
+| c2n / confluence-to-notion | 본 레포. Confluence XHTML → Notion 블록 규칙 + 변환 + MCP. |
+| Discover | `discover.sh` + Claude Code CLI 기반 규칙 제안 파이프라인. |
+| 브리지 | 회사가 구현하는 **Slack/OpenClaw ↔ proposals/finalize/migrate** 오케스트레이션. |
+
+---
+
+## 9. 참고 (레포 내부)
+
+- `README.md` — MCP 설치, CLI, 워크플로우.  
+- `CLAUDE.md` — 에이전트·discover·eval 정책.  
+- `scripts/discover.sh` — `claude -p` 호출부.
+
+---
+
+*이 문서는 대화 기반으로 작성된 핸드오프용 요약이며, 구현 시 최신 README·CLI 도움말을 우선한다.*


### PR DESCRIPTION
## Summary
- Unify `README.md` in English (MCP for Claude Code/OpenClaw, pipeline stages with finalize, Windows/Bash notes).
- Add `docs/slack-openclaw-c2n-bridge.md`: internal handoff for Slack/OpenClaw orchestration vs c2n responsibilities.

## Notes
- Repository rules require merge via PR (direct `main` push is blocked).

Made with [Cursor](https://cursor.com)