### PR TITLE
feat(runs): run directory manager and layout drift fixture (#144)

### DIFF
--- a/src/runs/index.ts
+++ b/src/runs/index.ts
@@ -1,0 +1,324 @@
+import { existsSync } from "node:fs";
+import { appendFile, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { basename, join } from "node:path";
+import type { TableRuleSet } from "../converter/schemas.js";
+import { TableRuleSetSchema } from "../converter/schemas.js";
+import {
+  type RunResolution,
+  RunResolutionSchema,
+  type RunStatus,
+  RunStatusSchema,
+  type RunStepName,
+  type SourceInfo,
+  SourceInfoSchema,
+  type StepRecord,
+  type StepStatus,
+  defaultRunStatus,
+} from "./schemas.js";
+
+export {
+  type RunResolution,
+  type RunStatus,
+  type RunStepName,
+  type SourceInfo,
+  type StepRecord,
+  type StepStatus,
+  RunResolutionSchema,
+  RunStatusSchema,
+  RunStepNameSchema,
+  SourceInfoSchema,
+  StepRecordSchema,
+  StepStatusSchema,
+  defaultRunStatus,
+} from "./schemas.js";
+
+const KEBAB_RE = /[^a-z0-9]+/g;
+
+function kebab(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(KEBAB_RE, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/** Derive `hostPrefix-key` slug from a Confluence URL (port of legacy `slug_for_url`). */
+export function slugForUrl(url: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new TypeError(`slugForUrl: invalid URL: ${url}`);
+  }
+
+  const hostPrefix = (parsed.hostname ?? "").split(".")[0]?.toLowerCase() ?? "run";
+
+  const pageId = parsed.searchParams.get("pageId");
+  if (pageId) {
+    return `${hostPrefix}-${kebab(pageId)}`;
+  }
+
+  const segments = parsed.pathname.split("/").filter((s) => s.length > 0);
+  for (let i = 0; i < segments.length; i += 1) {
+    if (segments[i] === "pages" && i + 1 < segments.length) {
+      const page = segments[i + 1];
+      if (page !== undefined) {
+        return `${hostPrefix}-${kebab(page)}`;
+      }
+    }
+  }
+  for (let i = 0; i < segments.length; i += 1) {
+    if (segments[i] === "spaces" && i + 1 < segments.length) {
+      const space = segments[i + 1];
+      if (space !== undefined) {
+        return `${hostPrefix}-${kebab(space)}`;
+      }
+    }
+  }
+
+  if (segments.length > 0) {
+    const last = segments[segments.length - 1];
+    if (last !== undefined) {
+      return `${hostPrefix}-${kebab(last)}`;
+    }
+  }
+
+  return hostPrefix;
+}
+
+export interface RunPaths {
+  sourceJson: string;
+  statusJson: string;
+  reportMd: string;
+  resolutionJson: string;
+  convertedDir: string;
+  rulesDir: string;
+  tableRulesJson: string;
+  logsDir: string;
+}
+
+export interface RunContext {
+  readonly runDir: string;
+  /** Final directory name under `runs/` (includes `-2` when allocated on collision). */
+  readonly slug: string;
+  readonly paths: RunPaths;
+}
+
+export interface StartRunOptions {
+  outputRoot: string;
+  url: string;
+  sourceType: string;
+  rootId?: string | null;
+  notionTarget?: Record<string, unknown> | null;
+  slugOverride?: string | null;
+}
+
+function buildPaths(runDir: string): RunPaths {
+  return {
+    sourceJson: join(runDir, "source.json"),
+    statusJson: join(runDir, "status.json"),
+    reportMd: join(runDir, "report.md"),
+    resolutionJson: join(runDir, "resolution.json"),
+    convertedDir: join(runDir, "converted"),
+    rulesDir: join(runDir, "rules"),
+    tableRulesJson: join(runDir, "rules", "table-rules.json"),
+    logsDir: join(runDir, "logs"),
+  };
+}
+
+export async function allocateRunDirectory(outputRoot: string, slug: string): Promise<string> {
+  const runsRoot = join(outputRoot, "runs");
+  await mkdir(runsRoot, { recursive: true });
+  let candidate = join(runsRoot, slug);
+  let suffix = 2;
+  while (existsSync(candidate)) {
+    candidate = join(runsRoot, `${slug}-${suffix}`);
+    suffix += 1;
+  }
+  await mkdir(candidate);
+  return candidate;
+}
+
+async function ensureRunSubdirectories(runDir: string, paths: RunPaths): Promise<void> {
+  await mkdir(paths.convertedDir, { recursive: true });
+  await mkdir(paths.rulesDir, { recursive: true });
+  await mkdir(paths.logsDir, { recursive: true });
+  await mkdir(join(runDir, "samples"), { recursive: true });
+}
+
+const STEP_ORDER: RunStepName[] = ["fetch", "discover", "convert", "migrate"];
+
+function formatStepLine(name: RunStepName, record: StepRecord): string {
+  const parts: string[] = [`**${name}**: ${record.status}`];
+  if (record.at !== null) {
+    parts.push(`at ${record.at}`);
+  }
+  if (record.count !== null) {
+    parts.push(`count=${record.count}`);
+  }
+  if (record.warnings !== null) {
+    parts.push(`warnings=${record.warnings}`);
+  }
+  return `- ${parts.join(" · ")}`;
+}
+
+export function renderReport(
+  source: SourceInfo,
+  status: RunStatus,
+  rulesSummary?: string | null,
+): string {
+  const lines: string[] = [
+    "# Run Report",
+    "",
+    "## Source",
+    `- url: ${source.url}`,
+    `- type: ${source.type}`,
+  ];
+  if (source.root_id !== undefined && source.root_id !== null) {
+    lines.push(`- root_id: ${source.root_id}`);
+  }
+  if (source.notion_target !== undefined && source.notion_target !== null) {
+    lines.push(`- notion_target: ${JSON.stringify(source.notion_target)}`);
+  }
+  lines.push("", "## Steps");
+  for (const name of STEP_ORDER) {
+    lines.push(formatStepLine(name, status[name]));
+  }
+  if (source.rules_source !== undefined && source.rules_source !== null) {
+    lines.push("", "## Rules source", `- source: ${source.rules_source}`);
+    if (source.rules_generated_at !== undefined && source.rules_generated_at !== null) {
+      lines.push(`- last generated_at: ${source.rules_generated_at}`);
+    }
+  }
+  if (rulesSummary !== undefined && rulesSummary !== null && rulesSummary.length > 0) {
+    lines.push("", "## Rules usage", rulesSummary);
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+export function formatRulesSummary(usedRules: Record<string, number>): string | null {
+  const keys = Object.keys(usedRules);
+  if (keys.length === 0) {
+    return null;
+  }
+  return keys
+    .sort((a, b) => a.localeCompare(b))
+    .map((ruleId) => `- ${ruleId}: ${usedRules[ruleId]}`)
+    .join("\n");
+}
+
+export async function readSource(runDir: string): Promise<SourceInfo> {
+  const raw = await readFile(join(runDir, "source.json"), "utf8");
+  return SourceInfoSchema.parse(JSON.parse(raw));
+}
+
+export async function writeSource(runDir: string, source: SourceInfo): Promise<void> {
+  const parsed = SourceInfoSchema.parse(source);
+  await writeFile(join(runDir, "source.json"), `${JSON.stringify(parsed, null, 2)}\n`, "utf8");
+}
+
+export async function readStatus(runDir: string): Promise<RunStatus> {
+  const raw = await readFile(join(runDir, "status.json"), "utf8");
+  return RunStatusSchema.parse(JSON.parse(raw));
+}
+
+export async function writeStatus(runDir: string, status: RunStatus): Promise<void> {
+  const parsed = RunStatusSchema.parse(status);
+  await writeFile(join(runDir, "status.json"), `${JSON.stringify(parsed, null, 2)}\n`, "utf8");
+}
+
+export async function startRun(
+  options: StartRunOptions,
+): Promise<{ context: RunContext; source: SourceInfo }> {
+  const baseSlug =
+    options.slugOverride !== undefined &&
+    options.slugOverride !== null &&
+    options.slugOverride.trim() !== ""
+      ? options.slugOverride.trim()
+      : slugForUrl(options.url);
+  const runDir = await allocateRunDirectory(options.outputRoot, baseSlug);
+  const paths = buildPaths(runDir);
+  await ensureRunSubdirectories(runDir, paths);
+
+  const source: SourceInfo = {
+    url: options.url,
+    type: options.sourceType,
+    root_id: options.rootId ?? null,
+    notion_target: options.notionTarget === undefined ? null : options.notionTarget,
+  };
+  await writeSource(runDir, source);
+  await writeStatus(runDir, defaultRunStatus());
+
+  const context: RunContext = {
+    runDir,
+    slug: basename(runDir),
+    paths,
+  };
+  return { context, source };
+}
+
+export async function updateStep(
+  context: RunContext,
+  step: RunStepName,
+  status: StepStatus,
+  opts?: { count?: number | null; warnings?: number | null },
+): Promise<void> {
+  const current = await readStatus(context.runDir);
+  const at = new Date().toISOString();
+  const record = {
+    status,
+    at,
+    count: opts?.count === undefined ? null : opts.count,
+    warnings: opts?.warnings === undefined ? null : opts.warnings,
+  };
+  const updated: RunStatus = { ...current, [step]: record };
+  await writeStatus(context.runDir, updated);
+}
+
+export interface FinalizeRunOptions {
+  rulesSummary?: string | null;
+}
+
+export async function finalizeRun(
+  context: RunContext,
+  options?: FinalizeRunOptions,
+): Promise<void> {
+  const source = await readSource(context.runDir);
+  const status = await readStatus(context.runDir);
+  const body = renderReport(source, status, options?.rulesSummary ?? null);
+  await writeFile(context.paths.reportMd, body, "utf8");
+}
+
+export async function writeResolution(context: RunContext, entries: RunResolution): Promise<void> {
+  const parsed = RunResolutionSchema.parse(entries);
+  await writeFile(context.paths.resolutionJson, `${JSON.stringify(parsed, null, 2)}\n`, "utf8");
+}
+
+export async function writeConvertedPage(
+  context: RunContext,
+  pageId: string,
+  payload: unknown,
+): Promise<void> {
+  const safeId = pageId.replace(/[^\w.-]+/g, "_");
+  const filePath = join(context.paths.convertedDir, `${safeId}.json`);
+  await writeFile(filePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+}
+
+export async function writeTableRules(context: RunContext, ruleSet: TableRuleSet): Promise<void> {
+  const parsed = TableRuleSetSchema.parse(ruleSet);
+  await writeFile(context.paths.tableRulesJson, `${JSON.stringify(parsed, null, 2)}\n`, "utf8");
+}
+
+export async function appendLog(context: RunContext, name: string, line: string): Promise<void> {
+  const safe = name.replace(/[^\w.-]+/g, "_");
+  const filePath = join(context.paths.logsDir, `${safe}.log`);
+  await appendFile(filePath, `${line}\n`, "utf8");
+}
+
+/** Sorted top-level names; directories include a trailing `/` (for drift fixtures). */
+export async function listRunLayoutTopLevel(runDir: string): Promise<string[]> {
+  const entries = await readdir(runDir, { withFileTypes: true });
+  return entries
+    .map((e) => (e.isDirectory() ? `${e.name}/` : e.name))
+    .sort((a, b) => a.localeCompare(b));
+}

--- a/src/runs/schemas.ts
+++ b/src/runs/schemas.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+
+export const StepStatusSchema = z.enum(["pending", "running", "done", "skipped", "failed"]);
+export type StepStatus = z.infer<typeof StepStatusSchema>;
+
+export const StepRecordSchema = z.object({
+  status: StepStatusSchema,
+  at: z.string().nullable(),
+  count: z.number().nullable(),
+  warnings: z.number().nullable(),
+});
+export type StepRecord = z.infer<typeof StepRecordSchema>;
+
+export const RunStepNameSchema = z.enum(["fetch", "discover", "convert", "migrate"]);
+export type RunStepName = z.infer<typeof RunStepNameSchema>;
+
+export const RunStatusSchema = z.object({
+  fetch: StepRecordSchema,
+  discover: StepRecordSchema,
+  convert: StepRecordSchema,
+  migrate: StepRecordSchema,
+});
+export type RunStatus = z.infer<typeof RunStatusSchema>;
+
+export const RulesSourceSchema = z.enum(["reused", "regenerated", "generated"]);
+export type RulesSource = z.infer<typeof RulesSourceSchema>;
+
+export const SourceInfoSchema = z
+  .object({
+    url: z.string(),
+    type: z.string(),
+    root_id: z.string().nullable().optional(),
+    notion_target: z.record(z.string(), z.unknown()).nullable().optional(),
+    rules_source: RulesSourceSchema.nullable().optional(),
+    rules_generated_at: z.string().nullable().optional(),
+  })
+  .passthrough();
+export type SourceInfo = z.infer<typeof SourceInfoSchema>;
+
+export const RunResolutionSchema = z.record(z.string(), z.string());
+export type RunResolution = z.infer<typeof RunResolutionSchema>;
+
+export function defaultRunStatus(): RunStatus {
+  const pending = (): StepRecord => ({
+    status: "pending",
+    at: null,
+    count: null,
+    warnings: null,
+  });
+  return {
+    fetch: pending(),
+    discover: pending(),
+    convert: pending(),
+    migrate: pending(),
+  };
+}

--- a/tests/fixtures/runs/reference-tree.json
+++ b/tests/fixtures/runs/reference-tree.json
@@ -1,0 +1,11 @@
+{
+  "topLevel": [
+    "converted/",
+    "logs/",
+    "report.md",
+    "rules/",
+    "samples/",
+    "source.json",
+    "status.json"
+  ]
+}

--- a/tests/runs/layout.test.ts
+++ b/tests/runs/layout.test.ts
@@ -1,0 +1,35 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { finalizeRun, listRunLayoutTopLevel, startRun } from "../../src/runs/index.js";
+import { rmTempOutputRoot, tempOutputRoot } from "./testUtils.js";
+
+const fixtureDir = fileURLToPath(new URL("../fixtures/runs", import.meta.url));
+
+afterEach(async () => {
+  await rmTempOutputRoot();
+});
+
+describe("run directory layout", () => {
+  it("matches reference-tree.json after startRun + finalizeRun", async () => {
+    const refRaw = await readFile(join(fixtureDir, "reference-tree.json"), "utf8");
+    const ref = JSON.parse(refRaw) as { topLevel: string[] };
+    const expected = [...ref.topLevel].sort();
+
+    const outputRoot = await tempOutputRoot();
+    const url = "https://cwiki.apache.org/confluence/display/TEST/Integration+Page";
+    const { context } = await startRun({
+      outputRoot,
+      url,
+      sourceType: "page",
+      rootId: null,
+      notionTarget: { page_id: "test-parent-page-id" },
+    });
+
+    await finalizeRun(context);
+
+    const actual = (await listRunLayoutTopLevel(context.runDir)).sort();
+    expect(actual).toEqual(expected);
+  });
+});

--- a/tests/runs/runContext.test.ts
+++ b/tests/runs/runContext.test.ts
@@ -1,0 +1,108 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  appendLog,
+  finalizeRun,
+  formatRulesSummary,
+  startRun,
+  updateStep,
+  writeConvertedPage,
+  writeResolution,
+  writeTableRules,
+} from "../../src/runs/index.js";
+import { rmTempOutputRoot, tempOutputRoot } from "./testUtils.js";
+
+afterEach(async () => {
+  vi.useRealTimers();
+  await rmTempOutputRoot();
+});
+
+describe("run lifecycle", () => {
+  it("persists source and status, updates a step, and renders report.md", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-19T10:53:24.391Z"));
+
+    const outputRoot = await tempOutputRoot();
+    const { context, source } = await startRun({
+      outputRoot,
+      url: "https://cwiki.apache.org/confluence/display/TEST/Integration+Page",
+      sourceType: "page",
+      rootId: null,
+      notionTarget: { page_id: "test-parent-page-id" },
+    });
+
+    expect(source.url).toContain("cwiki.apache.org");
+    await updateStep(context, "migrate", "done", { count: 2 });
+
+    await finalizeRun(context);
+
+    const report = await readFile(context.paths.reportMd, "utf8");
+    expect(report).toContain("# Run Report");
+    expect(report).toContain("**migrate**: done");
+    expect(report).toContain("count=2");
+    expect(report).toContain("2026-04-19T10:53:24.391Z");
+  });
+
+  it("allocates -2 suffix when the slug directory already exists", async () => {
+    const outputRoot = await tempOutputRoot();
+    const url = "https://cwiki.apache.org/confluence/display/TEST/Integration+Page";
+    const first = await startRun({ outputRoot, url, sourceType: "page" });
+    const second = await startRun({ outputRoot, url, sourceType: "page" });
+
+    expect(first.context.slug).toBe("cwiki-integration-page");
+    expect(second.context.slug).toBe("cwiki-integration-page-2");
+  });
+
+  it("writes resolution, converted JSON, table rules, and log lines under the run tree", async () => {
+    const outputRoot = await tempOutputRoot();
+    const { context } = await startRun({
+      outputRoot,
+      url: "https://example.atlassian.net/wiki/spaces/ENG/pages/1/T",
+      sourceType: "tree",
+    });
+
+    await writeResolution(context, { "page_link:Foo": "notion-page-1" });
+    await writeConvertedPage(context, "12345", { blocks: [{ object: "block" }] });
+    await writeTableRules(context, { rules: {} });
+    await appendLog(context, "migrate", "line one");
+    await appendLog(context, "migrate", "line two");
+
+    const resolution = JSON.parse(await readFile(context.paths.resolutionJson, "utf8")) as Record<
+      string,
+      string
+    >;
+    expect(resolution["page_link:Foo"]).toBe("notion-page-1");
+
+    const converted = JSON.parse(
+      await readFile(join(context.paths.convertedDir, "12345.json"), "utf8"),
+    ) as { blocks: unknown[] };
+    expect(converted.blocks).toHaveLength(1);
+
+    const rules = JSON.parse(await readFile(context.paths.tableRulesJson, "utf8")) as {
+      rules: Record<string, unknown>;
+    };
+    expect(rules.rules).toEqual({});
+
+    const logText = await readFile(join(context.paths.logsDir, "migrate.log"), "utf8");
+    expect(logText.trim().split("\n")).toEqual(["line one", "line two"]);
+  });
+
+  it("formatRulesSummary returns sorted lines or null when empty", () => {
+    expect(formatRulesSummary({})).toBeNull();
+    expect(formatRulesSummary({ b: 2, a: 1 })).toBe("- a: 1\n- b: 2");
+  });
+
+  it("finalizeRun appends Rules usage when rulesSummary is provided", async () => {
+    const outputRoot = await tempOutputRoot();
+    const { context } = await startRun({
+      outputRoot,
+      url: "https://example.atlassian.net/wiki/spaces/X/pages/1",
+      sourceType: "page",
+    });
+    await finalizeRun(context, { rulesSummary: "- rule-a: 3\n- rule-b: 1" });
+    const report = await readFile(context.paths.reportMd, "utf8");
+    expect(report).toContain("## Rules usage");
+    expect(report).toContain("- rule-a: 3");
+  });
+});

--- a/tests/runs/slugForUrl.test.ts
+++ b/tests/runs/slugForUrl.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { slugForUrl } from "../../src/runs/index.js";
+
+describe("slugForUrl", () => {
+  it("derives cwiki-integration-page from the Apache cwiki display URL", () => {
+    expect(slugForUrl("https://cwiki.apache.org/confluence/display/TEST/Integration+Page")).toBe(
+      "cwiki-integration-page",
+    );
+  });
+
+  it("uses pageId query when present", () => {
+    expect(slugForUrl("https://example.atlassian.net/wiki/spaces/ENG/pages?pageId=12345")).toBe(
+      "example-12345",
+    );
+  });
+
+  it("uses the numeric pages segment when present", () => {
+    expect(
+      slugForUrl("https://example.atlassian.net/wiki/spaces/ENG/pages/99999/Some-Title?foo=bar"),
+    ).toBe("example-99999");
+  });
+
+  it("uses the space key after /spaces/", () => {
+    expect(slugForUrl("https://example.atlassian.net/wiki/spaces/ENG")).toBe("example-eng");
+  });
+
+  it("falls back to the last path segment", () => {
+    expect(slugForUrl("https://host.example.com/confluence/x/AbCdEf")).toBe("host-abcdef");
+  });
+
+  it("returns only the host label when the path is empty", () => {
+    expect(slugForUrl("https://solo.example.com/")).toBe("solo");
+  });
+});

--- a/tests/runs/testUtils.ts
+++ b/tests/runs/testUtils.ts
@@ -1,0 +1,18 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let lastRoot: string | null = null;
+
+export async function tempOutputRoot(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "c2n-runs-test-"));
+  lastRoot = dir;
+  return dir;
+}
+
+export async function rmTempOutputRoot(): Promise<void> {
+  if (lastRoot) {
+    await rm(lastRoot, { recursive: true, force: true });
+    lastRoot = null;
+  }
+}


### PR DESCRIPTION
## Summary

Adds `src/runs/` (zod schemas, `slugForUrl`, `startRun` / `updateStep` / `finalizeRun`, resolution / converted / table-rules / log writers, `RunContext` paths via `node:path` only) and vitest coverage including `tests/fixtures/runs/reference-tree.json` as an anti-drift gate for the `output/runs/<slug>/` layout in `architecture.md`.

## Test plan

- [x] `pnpm test`
- [x] `pnpm lint`
- [x] `pnpm typecheck`

Closes #144

Made with [Cursor](https://cursor.com)