### PR TITLE
refactor(cli): split ADR-00M subcommands + notion-ping (#140)

### DIFF
--- a/src/cli/convert.ts
+++ b/src/cli/convert.ts
@@ -1,0 +1,15 @@
+import type { Command } from "commander";
+import { notImplemented } from "./stub.js";
+
+export function registerConvertCommands(program: Command): void {
+  program
+    .command("convert")
+    .description("Convert XHTML pages to Notion blocks using finalized rules.")
+    .option("--rules <path>", "path to rules.json", "output/rules.json")
+    .option("--input <path>", "directory of XHTML files", "samples")
+    .requiredOption(
+      "--url <url>",
+      "Confluence source URL; converted JSON lands under output/runs/<slug>/converted/",
+    )
+    .action(notImplemented("convert"));
+}

--- a/src/cli/discover.ts
+++ b/src/cli/discover.ts
@@ -1,0 +1,13 @@
+import type { Command } from "commander";
+
+export function registerDiscoverShim(program: Command): void {
+  program
+    .command("discover")
+    .description("Reminder shim: prints the correct `bash scripts/discover.sh` invocation.")
+    .action(() => {
+      process.stdout.write(
+        "discover is not a CLI entry point. Run: bash scripts/discover.sh <samples-dir> --url <confluence-url>\n",
+      );
+      process.exit(1);
+    });
+}

--- a/src/cli/fetch.ts
+++ b/src/cli/fetch.ts
@@ -1,0 +1,22 @@
+import type { Command } from "commander";
+import { notImplemented } from "./stub.js";
+
+export function registerFetchCommands(program: Command): void {
+  program
+    .command("fetch")
+    .description("Fetch Confluence pages and save XHTML to disk.")
+    .option("--space <key>", "Confluence space key (paginates with --limit)")
+    .option("--pages <ids>", "comma-separated Confluence page IDs")
+    .option("--limit <n>", "max pages when using --space", "25")
+    .option("--out-dir <path>", "output directory for XHTML", "samples")
+    .option("--url <url>", "Confluence source URL; writes artifacts under output/runs/<slug>/")
+    .action(notImplemented("fetch"));
+
+  program
+    .command("fetch-tree")
+    .description("Fetch the Confluence page tree starting from a root page.")
+    .requiredOption("--root-id <id>", "Confluence root page ID")
+    .option("--output <path>", "output JSON path", "output/page-tree.json")
+    .option("--url <url>", "Confluence source URL (overrides --output placement)")
+    .action(notImplemented("fetch-tree"));
+}

--- a/src/cli/finalize.ts
+++ b/src/cli/finalize.ts
@@ -1,0 +1,11 @@
+import type { Command } from "commander";
+import { notImplemented } from "./stub.js";
+
+export function registerFinalizeCommands(program: Command): void {
+  program
+    .command("finalize")
+    .description("Convert proposals.json → rules.json by promoting every rule with enabled=true.")
+    .argument("[proposals_file]", "path to proposals.json", "output/proposals.json")
+    .option("--out <path>", "output rules.json path", "output/rules.json")
+    .action(notImplemented("finalize"));
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,122 +1,35 @@
-import { Command, Option } from "commander";
+import { Command } from "commander";
 import pkg from "../../package.json" with { type: "json" };
-
-const notImplemented = (sub: string): (() => never) => {
-  return () => {
-    throw new Error(`not implemented: ${sub}`);
-  };
-};
+import { registerConvertCommands } from "./convert.js";
+import { registerDiscoverShim } from "./discover.js";
+import { registerFetchCommands } from "./fetch.js";
+import { registerFinalizeCommands } from "./finalize.js";
+import { registerMigrateCommands } from "./migrate.js";
+import { registerNotionCommands } from "./notion.js";
+import { registerValidateCommands } from "./validate.js";
 
 export function createProgram(): Command {
   const program = new Command();
   program
     .name("c2n")
     .description(
-      "confluence-to-notion: auto-discover and apply Confluence → Notion transformation rules",
+      [
+        "confluence-to-notion: auto-discover and apply Confluence → Notion transformation rules.",
+        "Load environment variables from a .env file when running locally, e.g. `node --env-file=.env $(pnpm bin)/c2n …`.",
+      ].join(" "),
     )
     .version(pkg.version, "-v, --version", "output the current version")
     .option("--verbose", "enable verbose logging")
     .option("--quiet", "suppress non-essential output")
     .option("--no-color", "disable ANSI color output");
 
-  program
-    .command("fetch")
-    .description("Fetch Confluence pages and save XHTML to disk.")
-    .option("--space <key>", "Confluence space key (paginates with --limit)")
-    .option("--pages <ids>", "comma-separated Confluence page IDs")
-    .option("--limit <n>", "max pages when using --space", "25")
-    .option("--out-dir <path>", "output directory for XHTML", "samples")
-    .option("--url <url>", "Confluence source URL; writes artifacts under output/runs/<slug>/")
-    .action(notImplemented("fetch"));
-
-  program
-    .command("fetch-tree")
-    .description("Fetch the Confluence page tree starting from a root page.")
-    .requiredOption("--root-id <id>", "Confluence root page ID")
-    .option("--output <path>", "output JSON path", "output/page-tree.json")
-    .option("--url <url>", "Confluence source URL (overrides --output placement)")
-    .action(notImplemented("fetch-tree"));
-
-  program
-    .command("notion-ping")
-    .description("Validate the Notion API token by fetching bot user info.")
-    .action(notImplemented("notion-ping"));
-
-  program
-    .command("discover")
-    .description("Reminder shim: prints the correct `bash scripts/discover.sh` invocation.")
-    .action(() => {
-      process.stdout.write(
-        "discover is not a CLI entry point. Run: bash scripts/discover.sh <samples-dir> --url <confluence-url>\n",
-      );
-      process.exit(1);
-    });
-
-  program
-    .command("validate-output")
-    .description("Validate an agent output file against its schema.")
-    .argument("<file>", "JSON file to validate")
-    .argument("<schema>", "schema name: discovery | proposer | scout")
-    .action(notImplemented("validate-output"));
-
-  program
-    .command("finalize")
-    .description("Convert proposals.json → rules.json by promoting every rule with enabled=true.")
-    .argument("[proposals_file]", "path to proposals.json", "output/proposals.json")
-    .option("--out <path>", "output rules.json path", "output/rules.json")
-    .action(notImplemented("finalize"));
-
-  program
-    .command("convert")
-    .description("Convert XHTML pages to Notion blocks using finalized rules.")
-    .option("--rules <path>", "path to rules.json", "output/rules.json")
-    .option("--input <path>", "directory of XHTML files", "samples")
-    .requiredOption(
-      "--url <url>",
-      "Confluence source URL; converted JSON lands under output/runs/<slug>/converted/",
-    )
-    .action(notImplemented("convert"));
-
-  program
-    .command("migrate")
-    .description("Convert XHTML pages and publish to Notion (URL-dispatch or legacy batch).")
-    .argument("[confluence_url]", "Confluence source URL (preferred form)")
-    .addOption(
-      new Option("--to <target>", "Notion parent (page URL or page id)").env("NOTION_ROOT_PAGE_ID"),
-    )
-    .option("--name <slug>", "override run slug under output/runs/")
-    .option("--rediscover", "force re-running scripts/discover.sh", false)
-    .option("--dry-run", "fetch + convert only; skip every Notion write", false)
-    .option("--rules <path>", "path to rules.json", "output/rules.json")
-    .option("--input <path>", "directory of XHTML files", "samples")
-    .addOption(
-      new Option("--target <id>", "Notion parent page ID (legacy form)").env("NOTION_ROOT_PAGE_ID"),
-    )
-    .option("--url <url>", "Confluence source URL (required when the positional URL is omitted)")
-    .action(notImplemented("migrate"));
-
-  program
-    .command("migrate-tree")
-    .description("Create an empty Notion page hierarchy mirroring a Confluence tree.")
-    .option("--tree <path>", "path to page-tree.json", "output/page-tree.json")
-    .addOption(new Option("--target <id>", "Notion parent page ID").env("NOTION_ROOT_PAGE_ID"))
-    .requiredOption(
-      "--url <url>",
-      "Confluence source URL; resolution.json lands under output/runs/<slug>/",
-    )
-    .action(notImplemented("migrate-tree"));
-
-  program
-    .command("migrate-tree-pages")
-    .description("Multi-pass migration: tree → table-rule discovery → body upload.")
-    .requiredOption("--root-id <id>", "Confluence root page ID")
-    .addOption(new Option("--target <id>", "Notion parent page ID").env("NOTION_ROOT_PAGE_ID"))
-    .option("--rules <path>", "path to rules.json", "output/rules.json")
-    .requiredOption(
-      "--url <url>",
-      "Confluence source URL; every artifact lands under output/runs/<slug>/",
-    )
-    .action(notImplemented("migrate-tree-pages"));
+  registerFetchCommands(program);
+  registerNotionCommands(program);
+  registerDiscoverShim(program);
+  registerValidateCommands(program);
+  registerFinalizeCommands(program);
+  registerConvertCommands(program);
+  registerMigrateCommands(program);
 
   return program;
 }

--- a/src/cli/migrate.ts
+++ b/src/cli/migrate.ts
@@ -1,0 +1,46 @@
+import type { Command } from "commander";
+import { Option } from "commander";
+import { notImplemented } from "./stub.js";
+
+export function registerMigrateCommands(program: Command): void {
+  program
+    .command("migrate")
+    .description("Convert XHTML pages and publish to Notion (URL-dispatch or legacy batch).")
+    .argument("[confluence_url]", "Confluence source URL (preferred form)")
+    .addOption(
+      new Option("--to <target>", "Notion parent (page URL or page id)").env("NOTION_ROOT_PAGE_ID"),
+    )
+    .option("--name <slug>", "override run slug under output/runs/")
+    .option("--rediscover", "force re-running scripts/discover.sh", false)
+    .option("--dry-run", "fetch + convert only; skip every Notion write", false)
+    .option("--rules <path>", "path to rules.json", "output/rules.json")
+    .option("--input <path>", "directory of XHTML files", "samples")
+    .addOption(
+      new Option("--target <id>", "Notion parent page ID (legacy form)").env("NOTION_ROOT_PAGE_ID"),
+    )
+    .option("--url <url>", "Confluence source URL (required when the positional URL is omitted)")
+    .action(notImplemented("migrate"));
+
+  program
+    .command("migrate-tree")
+    .description("Create an empty Notion page hierarchy mirroring a Confluence tree.")
+    .option("--tree <path>", "path to page-tree.json", "output/page-tree.json")
+    .addOption(new Option("--target <id>", "Notion parent page ID").env("NOTION_ROOT_PAGE_ID"))
+    .requiredOption(
+      "--url <url>",
+      "Confluence source URL; resolution.json lands under output/runs/<slug>/",
+    )
+    .action(notImplemented("migrate-tree"));
+
+  program
+    .command("migrate-tree-pages")
+    .description("Multi-pass migration: tree → table-rule discovery → body upload.")
+    .requiredOption("--root-id <id>", "Confluence root page ID")
+    .addOption(new Option("--target <id>", "Notion parent page ID").env("NOTION_ROOT_PAGE_ID"))
+    .option("--rules <path>", "path to rules.json", "output/rules.json")
+    .requiredOption(
+      "--url <url>",
+      "Confluence source URL; every artifact lands under output/runs/<slug>/",
+    )
+    .action(notImplemented("migrate-tree-pages"));
+}

--- a/src/cli/notion.ts
+++ b/src/cli/notion.ts
@@ -1,0 +1,44 @@
+import { Client } from "@notionhq/client";
+import type { Command } from "commander";
+
+function readNotionToken(): string | undefined {
+  const a = process.env.NOTION_API_TOKEN;
+  const b = process.env.NOTION_TOKEN;
+  if (typeof a === "string" && a.length > 0) return a;
+  if (typeof b === "string" && b.length > 0) return b;
+  return undefined;
+}
+
+function readNotionRootPageId(): string | undefined {
+  const v = process.env.NOTION_ROOT_PAGE_ID;
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+export function registerNotionCommands(program: Command): void {
+  program
+    .command("notion-ping")
+    .description("Validate the Notion API token by fetching bot user info.")
+    .action(async () => {
+      const token = readNotionToken();
+      if (token === undefined) {
+        process.stderr.write(
+          "Missing NOTION_API_TOKEN (or legacy NOTION_TOKEN). See CONTRIBUTING.md and ADR-00M.\n",
+        );
+        process.exit(1);
+      }
+      if (readNotionRootPageId() === undefined) {
+        process.stderr.write(
+          "Missing NOTION_ROOT_PAGE_ID (required by the frozen CLI contract).\n",
+        );
+        process.exit(1);
+      }
+      try {
+        const client = new Client({ auth: token });
+        await client.users.me({});
+        process.stdout.write("notion-ping: ok\n");
+      } catch (e) {
+        process.stderr.write(`notion-ping: Notion API error: ${String(e)}\n`);
+        process.exit(1);
+      }
+    });
+}

--- a/src/cli/stub.ts
+++ b/src/cli/stub.ts
@@ -1,0 +1,6 @@
+/** Shared stub for subcommands that are not implemented yet (PR 4/5). */
+export function notImplemented(sub: string): () => never {
+  return () => {
+    throw new Error(`not implemented: ${sub}`);
+  };
+}

--- a/src/cli/validate.ts
+++ b/src/cli/validate.ts
@@ -1,0 +1,11 @@
+import type { Command } from "commander";
+import { notImplemented } from "./stub.js";
+
+export function registerValidateCommands(program: Command): void {
+  program
+    .command("validate-output")
+    .description("Validate an agent output file against its schema.")
+    .argument("<file>", "JSON file to validate")
+    .argument("<schema>", "schema name: discovery | proposer | scout")
+    .action(notImplemented("validate-output"));
+}


### PR DESCRIPTION
## Summary

Parallel track **A** for #140: per-issue-140-cli worktree.

- Split `src/cli/index.ts` into `fetch.ts`, `notion.ts`, `validate.ts`, `finalize.ts`, `convert.ts`, `migrate.ts`, `discover.ts`, and `stub.ts`; composition stays ADR-00M-compliant (surface tests unchanged).
- Wire `notion-ping` to `@notionhq/client` `users.me` with `NOTION_API_TOKEN` or `NOTION_TOKEN` plus `NOTION_ROOT_PAGE_ID`.
- Root `--help` description mentions loading `.env` via `node --env-file=.env`.

## Merge order

Land **before** the eval worktree PR so `scripts/run-eval.sh` keeps working until the tsx + eval scaffold merges.

## Test plan

- [x] `pnpm test` / `pnpm lint` / `pnpm typecheck`

Refs #140

Made with [Cursor](https://cursor.com)