### PR TITLE
chore(eval): tsx scaffold + run-eval.sh without uv (#140)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test:watch": "vitest",
     "lint": "biome check",
     "format": "biome format --write",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "eval:pipeline": "tsx src/eval/index.ts output/ eval_results/ samples/"
   },
   "dependencies": {
     "@notionhq/client": "5.20.0",
@@ -36,6 +37,7 @@
     "@vitest/coverage-v8": "^2.1.8",
     "msw": "2.13.5",
     "tsup": "^8.3.5",
+    "tsx": "^4.19.4",
     "typescript": "^5.7.2",
     "vitest": "^2.1.8"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,7 +38,10 @@ importers:
         version: 2.13.5(@types/node@20.19.39)(typescript@5.9.3)
       tsup:
         specifier: ^8.3.5
-        version: 8.5.1(postcss@8.5.10)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.19.4
+        version: 4.21.0
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -877,6 +880,9 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
@@ -1078,6 +1084,9 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   rettime@0.11.8:
     resolution: {integrity: sha512-0fERGXktJTyJ+h8fBEiPxHPEFOu0h15JY7JtwrOVqR5K+vb99ho6IyOo7ekLS3h4sJCzIDy4VWKIbZUfe9njmg==}
 
@@ -1228,6 +1237,11 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-fest@5.6.0:
     resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
@@ -1960,6 +1974,10 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   glob@10.5.0:
     dependencies:
       foreground-child: 3.3.1
@@ -2130,11 +2148,12 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(postcss@8.5.10):
+  postcss-load-config@6.0.1(postcss@8.5.10)(tsx@4.21.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       postcss: 8.5.10
+      tsx: 4.21.0
 
   postcss@8.5.10:
     dependencies:
@@ -2147,6 +2166,8 @@ snapshots:
   require-directory@2.1.1: {}
 
   resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
 
   rettime@0.11.8: {}
 
@@ -2286,7 +2307,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tsup@8.5.1(postcss@8.5.10)(typescript@5.9.3):
+  tsup@8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -2297,7 +2318,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.10)
+      postcss-load-config: 6.0.1(postcss@8.5.10)(tsx@4.21.0)
       resolve-from: 5.0.0
       rollup: 4.60.2
       source-map: 0.7.6
@@ -2313,6 +2334,13 @@ snapshots:
       - supports-color
       - tsx
       - yaml
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   type-fest@5.6.0:
     dependencies:

--- a/scripts/run-eval.sh
+++ b/scripts/run-eval.sh
@@ -41,5 +41,5 @@ pnpm exec c2n validate-output output/patterns.json discovery
 pnpm exec c2n validate-output output/proposals.json proposer
 
 # Step 3: Semantic coverage + baseline diff (+ optional LLM-as-judge)
-echo "--- Semantic coverage + baseline ---"
-uv run python -m confluence_to_notion.eval output/ eval_results/ samples/ ${EVAL_FLAGS[@]+"${EVAL_FLAGS[@]}"}
+echo "--- Semantic coverage + baseline (TS eval harness) ---"
+pnpm exec tsx src/eval/index.ts output/ eval_results/ samples/ ${EVAL_FLAGS[@]+"${EVAL_FLAGS[@]}"}

--- a/src/eval/index.ts
+++ b/src/eval/index.ts
@@ -1,0 +1,61 @@
+/**
+ * TypeScript eval pipeline entry (PR 4/5 — replaces `python -m confluence_to_notion.eval`).
+ * This scaffold keeps `scripts/run-eval.sh` on a Node-only path; semantic coverage,
+ * baseline diff, and LLM-as-judge ports land in follow-up commits on the same branch.
+ */
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+interface EvalCliArgs {
+  outputDir: string;
+  evalResultsDir: string;
+  samplesDir: string;
+  llmJudge: boolean;
+  failOnRegression: boolean;
+}
+
+function parseArgs(argv: string[]): EvalCliArgs {
+  const rest = argv.slice(2);
+  let llmJudge = false;
+  let failOnRegression = false;
+  const positional: string[] = [];
+  for (const a of rest) {
+    if (a === "--llm-judge") {
+      llmJudge = true;
+      continue;
+    }
+    if (a === "--fail-on-regression") {
+      failOnRegression = true;
+      continue;
+    }
+    positional.push(a);
+  }
+  const [outputDir = "output", evalResultsDir = "eval_results", samplesDir = "samples"] =
+    positional;
+  return { outputDir, evalResultsDir, samplesDir, llmJudge, failOnRegression };
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv);
+  await mkdir(args.evalResultsDir, { recursive: true });
+  const stamp = new Date().toISOString().replaceAll(":", "-");
+  const outFile = join(args.evalResultsDir, `${stamp}.json`);
+  const payload = {
+    generatedAt: new Date().toISOString(),
+    outputDir: args.outputDir,
+    samplesDir: args.samplesDir,
+    flags: { llmJudge: args.llmJudge, failOnRegression: args.failOnRegression },
+    summary: {
+      status: "scaffold",
+      message:
+        "TS eval harness scaffold — schema validation runs via c2n validate-output in run-eval.sh; semantic coverage, baseline, and LLM judge are not ported in this commit.",
+    },
+  };
+  await writeFile(outFile, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  process.stdout.write(`eval: wrote ${outFile}\n`);
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(`eval: ${String(err)}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Parallel track **B** for #140: per-issue-140-eval worktree.

- Add `src/eval/index.ts` (placeholder JSON under `eval_results/`; semantic coverage / baseline / LLM judge to follow).
- Add `tsx` devDependency and `pnpm run eval:pipeline` script.
- Retarget `scripts/run-eval.sh` step 3 from `uv run python -m …` to `pnpm exec tsx src/eval/index.ts` (forwards `--llm-judge` / `--fail-on-regression`).

## Merge order

Land **after** the CLI split PR if you want two smaller reviews; otherwise rebase this branch onto main once the other PR merges (expect trivial conflicts only in `package.json` / lockfile).

## Test plan

- [x] `pnpm test` / `pnpm lint` / `pnpm typecheck`

Refs #140

Made with [Cursor](https://cursor.com)