### PR TITLE
feat(cli): validate-output + finalize (agent JSON → rules) (#140)

### DIFF
--- a/src/agentOutput/finalRuleset.ts
+++ b/src/agentOutput/finalRuleset.ts
@@ -1,0 +1,39 @@
+/**
+ * `output/rules.json` contract produced by `c2n finalize` from `output/proposals.json`.
+ * Mirrors the historical `FinalRuleset` / `FinalRule` Pydantic models.
+ */
+import { z } from "zod";
+import type { ProposedRule, ProposerOutput } from "./schemas.js";
+
+export const FinalRuleSchema = z.object({
+  rule_id: z.string().min(1),
+  source_pattern_id: z.string().min(1),
+  source_description: z.string().min(1),
+  notion_block_type: z.string().min(1),
+  mapping_description: z.string().min(1),
+  example_input: z.string(),
+  example_output: z.record(z.string(), z.unknown()),
+  confidence: z.enum(["high", "medium", "low"]),
+  enabled: z.boolean(),
+});
+export type FinalRule = z.infer<typeof FinalRuleSchema>;
+
+export const FinalRulesetSchema = z.object({
+  source: z.string().min(1),
+  rules: z.array(FinalRuleSchema).default([]),
+});
+export type FinalRuleset = z.infer<typeof FinalRulesetSchema>;
+
+function proposedToFinal(proposed: ProposedRule): FinalRule {
+  return {
+    ...proposed,
+    enabled: true,
+  };
+}
+
+export function finalRulesetFromProposerOutput(output: ProposerOutput): FinalRuleset {
+  return {
+    source: output.source_patterns_file,
+    rules: output.rules.map(proposedToFinal),
+  };
+}

--- a/src/agentOutput/schemas.ts
+++ b/src/agentOutput/schemas.ts
@@ -1,0 +1,75 @@
+/**
+ * Zod contracts for discover-pipeline agent JSON files (patterns, proposals, scout sources).
+ * Aligned with `.claude/agents/discover/*.md` embedded schemas and the historical Python
+ * `agents/schemas.py` models.
+ */
+import { z } from "zod";
+
+export const DiscoveryPatternSchema = z.object({
+  pattern_id: z.string().min(1),
+  pattern_type: z.string().min(1),
+  description: z.string().min(1),
+  example_snippets: z.array(z.string()).min(1),
+  source_pages: z.array(z.string()).min(1),
+  frequency: z.number().int().positive(),
+});
+export type DiscoveryPattern = z.infer<typeof DiscoveryPatternSchema>;
+
+export const DiscoveryOutputSchema = z.object({
+  sample_dir: z.string().min(1),
+  pages_analyzed: z.number().int().positive(),
+  patterns: z.array(DiscoveryPatternSchema).default([]),
+});
+export type DiscoveryOutput = z.infer<typeof DiscoveryOutputSchema>;
+
+export const ProposedRuleSchema = z.object({
+  rule_id: z.string().min(1),
+  source_pattern_id: z.string().min(1),
+  source_description: z.string().min(1),
+  notion_block_type: z.string().min(1),
+  mapping_description: z.string().min(1),
+  example_input: z.string(),
+  example_output: z.record(z.string(), z.unknown()),
+  confidence: z.enum(["high", "medium", "low"]),
+});
+export type ProposedRule = z.infer<typeof ProposedRuleSchema>;
+
+export const ProposerOutputSchema = z.object({
+  source_patterns_file: z.string().min(1),
+  rules: z.array(ProposedRuleSchema).default([]),
+});
+export type ProposerOutput = z.infer<typeof ProposerOutputSchema>;
+
+export const ScoutSourceSchema = z.object({
+  wiki_url: z.string().min(1),
+  space_key: z.string().min(1),
+  macro_density: z.number().min(0).max(1),
+  sample_macros: z.array(z.string()),
+  page_count: z.number().int().min(0),
+  accessible: z.boolean(),
+  fetched_at: z.string().nullable().optional(),
+});
+export type ScoutSource = z.infer<typeof ScoutSourceSchema>;
+
+export const ScoutOutputSchema = z.object({
+  sources: z.array(ScoutSourceSchema).default([]),
+});
+export type ScoutOutput = z.infer<typeof ScoutOutputSchema>;
+
+export const AgentOutputSchemaNameSchema = z.enum(["discovery", "proposer", "scout"]);
+export type AgentOutputSchemaName = z.infer<typeof AgentOutputSchemaNameSchema>;
+
+export function parseAgentOutput(schema: AgentOutputSchemaName, data: unknown): unknown {
+  switch (schema) {
+    case "discovery":
+      return DiscoveryOutputSchema.parse(data);
+    case "proposer":
+      return ProposerOutputSchema.parse(data);
+    case "scout":
+      return ScoutOutputSchema.parse(data);
+    default: {
+      const _exhaustive: never = schema;
+      return _exhaustive;
+    }
+  }
+}

--- a/src/cli/finalize.ts
+++ b/src/cli/finalize.ts
@@ -1,5 +1,31 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
 import type { Command } from "commander";
-import { notImplemented } from "./stub.js";
+import { finalRulesetFromProposerOutput } from "../agentOutput/finalRuleset.js";
+import { ProposerOutputSchema } from "../agentOutput/schemas.js";
+
+export async function finalizeProposalsToRules(
+  proposalsPath: string,
+  rulesOutPath: string,
+): Promise<{ ruleCount: number }> {
+  let raw: string;
+  try {
+    raw = await readFile(proposalsPath, "utf8");
+  } catch (e) {
+    throw new Error(`Cannot read proposals file: ${proposalsPath}: ${String(e)}`);
+  }
+  let json: unknown;
+  try {
+    json = JSON.parse(raw) as unknown;
+  } catch (e) {
+    throw new SyntaxError(`Invalid JSON in ${proposalsPath}: ${String(e)}`);
+  }
+  const proposer = ProposerOutputSchema.parse(json);
+  const ruleset = finalRulesetFromProposerOutput(proposer);
+  await mkdir(dirname(rulesOutPath), { recursive: true });
+  await writeFile(rulesOutPath, `${JSON.stringify(ruleset, null, 2)}\n`, "utf8");
+  return { ruleCount: ruleset.rules.length };
+}
 
 export function registerFinalizeCommands(program: Command): void {
   program
@@ -7,5 +33,14 @@ export function registerFinalizeCommands(program: Command): void {
     .description("Convert proposals.json → rules.json by promoting every rule with enabled=true.")
     .argument("[proposals_file]", "path to proposals.json", "output/proposals.json")
     .option("--out <path>", "output rules.json path", "output/rules.json")
-    .action(notImplemented("finalize"));
+    .action(async function (this: Command, proposalsFile: string) {
+      const opts = this.opts<{ out: string }>();
+      try {
+        const { ruleCount } = await finalizeProposalsToRules(proposalsFile, opts.out);
+        process.stdout.write(`Finalized ${String(ruleCount)} rules → ${opts.out}\n`);
+      } catch (e) {
+        process.stderr.write(`finalize: ${String(e)}\n`);
+        process.exit(1);
+      }
+    });
 }

--- a/src/cli/validate.ts
+++ b/src/cli/validate.ts
@@ -1,5 +1,46 @@
+import { readFile } from "node:fs/promises";
 import type { Command } from "commander";
-import { notImplemented } from "./stub.js";
+import {
+  type AgentOutputSchemaName,
+  AgentOutputSchemaNameSchema,
+  parseAgentOutput,
+} from "../agentOutput/schemas.js";
+
+export async function validateOutputFile(
+  filePath: string,
+  schemaName: AgentOutputSchemaName,
+): Promise<void> {
+  let rawText: string;
+  try {
+    rawText = await readFile(filePath, "utf8");
+  } catch (e) {
+    throw new Error(`Cannot read file: ${filePath}: ${String(e)}`);
+  }
+  let json: unknown;
+  try {
+    json = JSON.parse(rawText) as unknown;
+  } catch (e) {
+    throw new SyntaxError(`Invalid JSON in ${filePath}: ${String(e)}`);
+  }
+  parseAgentOutput(schemaName, json);
+}
+
+function printZodError(err: unknown, filePath: string): void {
+  if (
+    err &&
+    typeof err === "object" &&
+    "issues" in err &&
+    Array.isArray((err as { issues: unknown }).issues)
+  ) {
+    const zerr = err as { issues: Array<{ path: (string | number)[]; message: string }> };
+    for (const issue of zerr.issues) {
+      const path = issue.path.length > 0 ? issue.path.join(".") : "(root)";
+      process.stderr.write(`${filePath}: ${path}: ${issue.message}\n`);
+    }
+    return;
+  }
+  process.stderr.write(`${filePath}: ${String(err)}\n`);
+}
 
 export function registerValidateCommands(program: Command): void {
   program
@@ -7,5 +48,19 @@ export function registerValidateCommands(program: Command): void {
     .description("Validate an agent output file against its schema.")
     .argument("<file>", "JSON file to validate")
     .argument("<schema>", "schema name: discovery | proposer | scout")
-    .action(notImplemented("validate-output"));
+    .action(async (file: string, schema: string) => {
+      const parsed = AgentOutputSchemaNameSchema.safeParse(schema);
+      if (!parsed.success) {
+        process.stderr.write(
+          `Invalid schema name "${schema}". Use discovery, proposer, or scout.\n`,
+        );
+        process.exit(1);
+      }
+      try {
+        await validateOutputFile(file, parsed.data);
+      } catch (e) {
+        printZodError(e, file);
+        process.exit(1);
+      }
+    });
 }

--- a/tests/cli/finalize.test.ts
+++ b/tests/cli/finalize.test.ts
@@ -1,0 +1,49 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { FinalRulesetSchema } from "../../src/agentOutput/finalRuleset.js";
+import { finalizeProposalsToRules } from "../../src/cli/finalize.js";
+
+let tmp: string | null = null;
+
+afterEach(async () => {
+  if (tmp) {
+    await rm(tmp, { recursive: true, force: true });
+    tmp = null;
+  }
+});
+
+describe("finalizeProposalsToRules", () => {
+  it("writes rules.json with enabled rules from proposals", async () => {
+    tmp = await mkdtemp(join(tmpdir(), "c2n-fin-"));
+    const proposalsPath = join(tmp, "proposals.json");
+    const rulesPath = join(tmp, "rules.json");
+    const proposals = {
+      source_patterns_file: "output/patterns.json",
+      rules: [
+        {
+          rule_id: "rule:macro:toc",
+          source_pattern_id: "macro:toc",
+          source_description: "TOC macro",
+          notion_block_type: "table_of_contents",
+          mapping_description: "Map to TOC block",
+          example_input: '<ac:structured-macro ac:name="toc"/>',
+          example_output: { type: "table_of_contents", table_of_contents: { color: "default" } },
+          confidence: "high" as const,
+        },
+      ],
+    };
+    await writeFile(proposalsPath, JSON.stringify(proposals), "utf8");
+
+    const { ruleCount } = await finalizeProposalsToRules(proposalsPath, rulesPath);
+    expect(ruleCount).toBe(1);
+
+    const raw = await readFile(rulesPath, "utf8");
+    const parsed = FinalRulesetSchema.parse(JSON.parse(raw));
+    expect(parsed.source).toBe("output/patterns.json");
+    expect(parsed.rules).toHaveLength(1);
+    expect(parsed.rules[0]?.enabled).toBe(true);
+    expect(parsed.rules[0]?.rule_id).toBe("rule:macro:toc");
+  });
+});

--- a/tests/cli/validate-output.test.ts
+++ b/tests/cli/validate-output.test.ts
@@ -1,0 +1,74 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { validateOutputFile } from "../../src/cli/validate.js";
+
+let tmp: string | null = null;
+
+afterEach(async () => {
+  if (tmp) {
+    await rm(tmp, { recursive: true, force: true });
+    tmp = null;
+  }
+});
+
+describe("validateOutputFile", () => {
+  it("accepts a valid discovery document", async () => {
+    tmp = await mkdtemp(join(tmpdir(), "c2n-val-"));
+    const path = join(tmp, "patterns.json");
+    const doc = {
+      sample_dir: "samples/",
+      pages_analyzed: 1,
+      patterns: [
+        {
+          pattern_id: "macro:toc",
+          pattern_type: "macro",
+          description: "TOC",
+          example_snippets: ['<ac:structured-macro ac:name="toc"></ac:structured-macro>'],
+          source_pages: ["1"],
+          frequency: 1,
+        },
+      ],
+    };
+    await writeFile(path, JSON.stringify(doc), "utf8");
+    await expect(validateOutputFile(path, "discovery")).resolves.toBeUndefined();
+  });
+
+  it("rejects invalid discovery JSON shape", async () => {
+    tmp = await mkdtemp(join(tmpdir(), "c2n-val-"));
+    const path = join(tmp, "bad.json");
+    await writeFile(
+      path,
+      JSON.stringify({ sample_dir: "x", pages_analyzed: 0, patterns: [] }),
+      "utf8",
+    );
+    await expect(validateOutputFile(path, "discovery")).rejects.toThrow();
+  });
+
+  it("accepts scout sources.json", async () => {
+    tmp = await mkdtemp(join(tmpdir(), "c2n-val-"));
+    const path = join(tmp, "sources.json");
+    const doc = {
+      sources: [
+        {
+          wiki_url: "https://example.com/wiki",
+          space_key: "S",
+          macro_density: 0.5,
+          sample_macros: ["toc"],
+          page_count: 10,
+          accessible: true,
+        },
+      ],
+    };
+    await writeFile(path, JSON.stringify(doc), "utf8");
+    await expect(validateOutputFile(path, "scout")).resolves.toBeUndefined();
+  });
+
+  it("reads file from disk for integration-style check", async () => {
+    tmp = await mkdtemp(join(tmpdir(), "c2n-val-"));
+    const path = join(tmp, "p.json");
+    await writeFile(path, "not json", "utf8");
+    await expect(validateOutputFile(path, "discovery")).rejects.toThrow(/Invalid JSON/);
+  });
+});


### PR DESCRIPTION
## Summary

Continues #140 after #146/#147:

- **`src/agentOutput/`** — zod schemas for `patterns.json` (discovery), `proposals.json` (proposer), and `sources.json` (scout), aligned with the discover agent markdown contracts.
- **`c2n validate-output`** — reads JSON from disk and validates against the selected schema; prints zod issues to stderr and exits `1` on failure.
- **`c2n finalize`** — reads `proposals.json`, validates as proposer output, writes `rules.json` in the `FinalRuleset` shape (every rule `enabled: true`).

## Not in this PR

Remaining #140 items: fetch/convert/migrate wiring, full eval port + Python-compatible JSON, integration smoke, bundle-size CI assertion.

## Test plan

- [x] `pnpm test`
- [x] `pnpm lint`
- [x] `pnpm typecheck`

Refs #140

Made with [Cursor](https://cursor.com)