### PR TITLE
feat(cli): wire fetch, fetch-tree, convert, and TS eval harness

### DIFF
--- a/src/cli/confluenceEnv.ts
+++ b/src/cli/confluenceEnv.ts
@@ -1,0 +1,21 @@
+/** Read Confluence REST settings from the environment (ADR-00M / CONTRIBUTING). */
+
+export function readConfluenceBaseUrl(): string {
+  const raw = process.env.CONFLUENCE_BASE_URL?.trim();
+  if (raw !== undefined && raw.length > 0) {
+    return raw.endsWith("/") ? raw.slice(0, -1) : raw;
+  }
+  return "https://cwiki.apache.org/confluence";
+}
+
+export function readConfluenceAuth(): { email: string; token: string } {
+  const email = process.env.CONFLUENCE_EMAIL?.trim();
+  const token = process.env.CONFLUENCE_API_TOKEN?.trim() ?? process.env.CONFLUENCE_TOKEN?.trim();
+  if (email === undefined || email.length === 0) {
+    throw new Error("Missing CONFLUENCE_EMAIL (required for Confluence basic auth).");
+  }
+  if (token === undefined || token.length === 0) {
+    throw new Error("Missing CONFLUENCE_API_TOKEN (or legacy CONFLUENCE_TOKEN).");
+  }
+  return { email, token };
+}

--- a/src/cli/convert.ts
+++ b/src/cli/convert.ts
@@ -1,5 +1,62 @@
+import { readFile, readdir } from "node:fs/promises";
+import { extname, join } from "node:path";
 import type { Command } from "commander";
-import { notImplemented } from "./stub.js";
+import { FinalRulesetSchema } from "../agentOutput/finalRuleset.js";
+import { convertXhtmlToConversionResult } from "../converter/convertPage.js";
+import { finalizeRun, startRun, updateStep, writeConvertedPage } from "../runs/index.js";
+
+export interface ConvertCliOptions {
+  rules: string;
+  input: string;
+  url: string;
+}
+
+function outputRootDir(): string {
+  return join(process.cwd(), "output");
+}
+
+export async function runConvertCommand(opts: ConvertCliOptions): Promise<void> {
+  const rulesPath = join(process.cwd(), opts.rules);
+  const inputDir = join(process.cwd(), opts.input);
+  const rulesJson = JSON.parse(await readFile(rulesPath, "utf8")) as unknown;
+  const ruleset = FinalRulesetSchema.parse(rulesJson);
+
+  const entries = await readdir(inputDir, { withFileTypes: true });
+  const xhtmlFiles = entries.filter(
+    (e) => e.isFile() && extname(e.name).toLowerCase() === ".xhtml",
+  );
+
+  if (xhtmlFiles.length === 0) {
+    process.stderr.write(`convert: no .xhtml files in ${inputDir}\n`);
+    process.exit(1);
+  }
+
+  const { context } = await startRun({
+    outputRoot: outputRootDir(),
+    url: opts.url,
+    sourceType: "page",
+  });
+  await updateStep(context, "convert", "running");
+  try {
+    let n = 0;
+    for (const ent of xhtmlFiles) {
+      const pageId = ent.name.replace(/\.xhtml$/i, "");
+      const xhtml = await readFile(join(inputDir, ent.name), "utf8");
+      const result = convertXhtmlToConversionResult(ruleset, xhtml, pageId);
+      await writeConvertedPage(context, pageId, result);
+      n += 1;
+    }
+    await updateStep(context, "convert", "done", { count: n });
+    await finalizeRun(context);
+    process.stdout.write(
+      `convert: wrote ${String(n)} conversion(s) under ${context.paths.convertedDir}\n`,
+    );
+  } catch (e) {
+    await updateStep(context, "convert", "failed");
+    await finalizeRun(context);
+    throw e;
+  }
+}
 
 export function registerConvertCommands(program: Command): void {
   program
@@ -11,5 +68,13 @@ export function registerConvertCommands(program: Command): void {
       "--url <url>",
       "Confluence source URL; converted JSON lands under output/runs/<slug>/converted/",
     )
-    .action(notImplemented("convert"));
+    .action(async function (this: Command) {
+      const o = this.opts<ConvertCliOptions>();
+      try {
+        await runConvertCommand(o);
+      } catch (e) {
+        process.stderr.write(`convert: ${String(e)}\n`);
+        process.exit(1);
+      }
+    });
 }

--- a/src/cli/fetch.ts
+++ b/src/cli/fetch.ts
@@ -1,5 +1,153 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import type { Command } from "commander";
-import { notImplemented } from "./stub.js";
+import { createConfluenceClient } from "../confluence/client.js";
+import { type RunContext, finalizeRun, startRun, updateStep } from "../runs/index.js";
+import { readConfluenceAuth, readConfluenceBaseUrl } from "./confluenceEnv.js";
+
+export interface FetchCliOptions {
+  space?: string;
+  pages?: string;
+  limit: string;
+  outDir: string;
+  url?: string;
+}
+
+function outputRootDir(): string {
+  return join(process.cwd(), "output");
+}
+
+async function writePageXhtml(targetDir: string, pageId: string, xhtml: string): Promise<void> {
+  await mkdir(targetDir, { recursive: true });
+  const path = join(targetDir, `${pageId}.xhtml`);
+  await writeFile(path, xhtml, "utf8");
+}
+
+async function runFetchWithClient(
+  client: ReturnType<typeof createConfluenceClient>,
+  opts: FetchCliOptions,
+  runContext: RunContext | null,
+): Promise<number> {
+  const limit = Number.parseInt(opts.limit, 10) || 25;
+  let count = 0;
+  const samplesDir = runContext
+    ? join(runContext.runDir, "samples")
+    : join(process.cwd(), opts.outDir);
+
+  if (opts.pages !== undefined && opts.pages.length > 0) {
+    const ids = opts.pages
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    for (const id of ids) {
+      const page = await client.getPage(id);
+      const body = page.body.storage.value;
+      await writePageXhtml(samplesDir, page.id, body);
+      count += 1;
+    }
+    return count;
+  }
+
+  if (opts.space !== undefined && opts.space.length > 0) {
+    let cursor = 0;
+    while (true) {
+      const batch = await client.listSpacePages(opts.space, { limit, cursor });
+      for (const page of batch.results) {
+        const body = page.body.storage.value;
+        await writePageXhtml(samplesDir, page.id, body);
+        count += 1;
+      }
+      if (batch.size < limit) break;
+      cursor = batch.start + batch.size;
+    }
+    return count;
+  }
+
+  throw new Error("internal: neither pages nor space");
+}
+
+export async function runFetchCommand(opts: FetchCliOptions): Promise<void> {
+  if (
+    (opts.pages === undefined || opts.pages.trim() === "") &&
+    (opts.space === undefined || opts.space.trim() === "")
+  ) {
+    process.stderr.write("fetch: provide --space <key> or --pages <comma-separated-ids>.\n");
+    process.exit(1);
+  }
+
+  const { email, token } = readConfluenceAuth();
+  const baseUrl = readConfluenceBaseUrl();
+  const client = createConfluenceClient({ email, token, baseUrl });
+
+  let runContext: RunContext | null = null;
+  if (opts.url !== undefined && opts.url.length > 0) {
+    const sourceType = opts.space !== undefined && opts.space.length > 0 ? "space" : "page";
+    const started = await startRun({
+      outputRoot: outputRootDir(),
+      url: opts.url,
+      sourceType,
+    });
+    runContext = started.context;
+    await updateStep(runContext, "fetch", "running");
+    try {
+      const count = await runFetchWithClient(client, opts, runContext);
+      await updateStep(runContext, "fetch", "done", { count });
+      await finalizeRun(runContext);
+      process.stdout.write(`fetch: wrote ${String(count)} page(s) under ${runContext.runDir}\n`);
+    } catch (e) {
+      await updateStep(runContext, "fetch", "failed");
+      await finalizeRun(runContext);
+      throw e;
+    }
+    return;
+  }
+
+  const count = await runFetchWithClient(client, opts, null);
+  process.stdout.write(
+    `fetch: wrote ${String(count)} page(s) to ${join(process.cwd(), opts.outDir)}\n`,
+  );
+}
+
+export interface FetchTreeCliOptions {
+  rootId: string;
+  output: string;
+  url?: string;
+}
+
+export async function runFetchTreeCommand(opts: FetchTreeCliOptions): Promise<void> {
+  const { email, token } = readConfluenceAuth();
+  const baseUrl = readConfluenceBaseUrl();
+  const client = createConfluenceClient({ email, token, baseUrl });
+  const tree = await client.getPageTree(opts.rootId, { maxDepth: 25 });
+  const json = `${JSON.stringify(tree, null, 2)}\n`;
+
+  if (opts.url !== undefined && opts.url.length > 0) {
+    const { context } = await startRun({
+      outputRoot: outputRootDir(),
+      url: opts.url,
+      sourceType: "tree",
+      rootId: opts.rootId,
+    });
+    await updateStep(context, "fetch", "running");
+    try {
+      const path = join(context.runDir, "page-tree.json");
+      await writeFile(path, json, "utf8");
+      await updateStep(context, "fetch", "done", { count: 1 });
+      await finalizeRun(context);
+      process.stdout.write(`fetch-tree: wrote ${path}\n`);
+    } catch (e) {
+      await updateStep(context, "fetch", "failed");
+      await finalizeRun(context);
+      throw e;
+    }
+    return;
+  }
+
+  const outPath = join(process.cwd(), opts.output);
+  await mkdir(dirname(outPath), { recursive: true });
+  await writeFile(outPath, json, "utf8");
+  process.stdout.write(`fetch-tree: wrote ${outPath}\n`);
+}
 
 export function registerFetchCommands(program: Command): void {
   program
@@ -10,7 +158,15 @@ export function registerFetchCommands(program: Command): void {
     .option("--limit <n>", "max pages when using --space", "25")
     .option("--out-dir <path>", "output directory for XHTML", "samples")
     .option("--url <url>", "Confluence source URL; writes artifacts under output/runs/<slug>/")
-    .action(notImplemented("fetch"));
+    .action(async function (this: Command) {
+      const o = this.opts<FetchCliOptions>();
+      try {
+        await runFetchCommand(o);
+      } catch (e) {
+        process.stderr.write(`fetch: ${String(e)}\n`);
+        process.exit(1);
+      }
+    });
 
   program
     .command("fetch-tree")
@@ -18,5 +174,13 @@ export function registerFetchCommands(program: Command): void {
     .requiredOption("--root-id <id>", "Confluence root page ID")
     .option("--output <path>", "output JSON path", "output/page-tree.json")
     .option("--url <url>", "Confluence source URL (overrides --output placement)")
-    .action(notImplemented("fetch-tree"));
+    .action(async function (this: Command) {
+      const o = this.opts<FetchTreeCliOptions>();
+      try {
+        await runFetchTreeCommand(o);
+      } catch (e) {
+        process.stderr.write(`fetch-tree: ${String(e)}\n`);
+        process.exit(1);
+      }
+    });
 }

--- a/src/converter/convertPage.ts
+++ b/src/converter/convertPage.ts
@@ -1,0 +1,27 @@
+import type { FinalRuleset } from "../agentOutput/finalRuleset.js";
+import { type ConversionResult, ConversionResultSchema } from "./schemas.js";
+
+/**
+ * Minimal XHTML → Notion conversion for the CLI until the full deterministic
+ * converter from PR 2/5 lands. Produces a single paragraph block from visible text.
+ */
+export function convertXhtmlToConversionResult(
+  _rules: FinalRuleset,
+  xhtml: string,
+  pageId: string,
+): ConversionResult {
+  const plain = xhtml
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  const content = (plain.length > 0 ? plain : `page ${pageId}`).slice(0, 1990);
+  const block = {
+    type: "paragraph",
+    paragraph: {
+      rich_text: [{ type: "text", text: { content: content } }],
+    },
+  };
+  return ConversionResultSchema.parse({ blocks: [block], unresolved: [], usedRules: {} });
+}

--- a/src/eval/baseline.ts
+++ b/src/eval/baseline.ts
@@ -1,0 +1,98 @@
+import { readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { type BaselineComparison, type EvalReport, EvalReportSchema } from "./report.js";
+
+const DEFAULT_COVERAGE_THRESHOLD = 0.05;
+const DEFAULT_LLM_JUDGE_THRESHOLD = 0.3;
+
+/** Newest valid snapshot in `resultsDir`, or null. Skips corrupt files. */
+export async function loadPreviousEvalReport(resultsDir: string): Promise<EvalReport | null> {
+  let names: string[];
+  try {
+    names = await readdir(resultsDir);
+  } catch {
+    return null;
+  }
+  const snapshots = names.filter((n) => n.endsWith(".json")).sort((a, b) => a.localeCompare(b));
+  for (let i = snapshots.length - 1; i >= 0; i -= 1) {
+    const name = snapshots[i];
+    if (name === undefined) continue;
+    try {
+      const raw = await readFile(join(resultsDir, name), "utf8");
+      const parsed = EvalReportSchema.safeParse(JSON.parse(raw) as unknown);
+      if (parsed.success) return parsed.data;
+    } catch {}
+  }
+  return null;
+}
+
+function llmJudgeGrandMean(judge: unknown): number | null {
+  if (!Array.isArray(judge) || judge.length === 0) return null;
+  const values: number[] = [];
+  for (const row of judge) {
+    if (row && typeof row === "object" && "scores" in row) {
+      const scores = (row as { scores?: Record<string, unknown> }).scores;
+      if (scores && typeof scores === "object") {
+        for (const v of Object.values(scores)) {
+          if (typeof v === "number") values.push(v);
+        }
+      }
+    }
+  }
+  if (values.length === 0) return null;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+export function compareToBaseline(
+  current: EvalReport,
+  previous: EvalReport | null,
+  coverageThreshold = DEFAULT_COVERAGE_THRESHOLD,
+  llmJudgeThreshold = DEFAULT_LLM_JUDGE_THRESHOLD,
+): BaselineComparison {
+  const thresholds_used: Record<string, number> = {
+    semantic_coverage: coverageThreshold,
+    llm_judge: llmJudgeThreshold,
+  };
+
+  if (previous === null) {
+    return {
+      previous_timestamp: null,
+      coverage_delta: 0.0,
+      llm_judge_mean_delta: null,
+      regressions: [],
+      thresholds_used,
+      is_regression: false,
+    };
+  }
+
+  const regressions: string[] = [];
+
+  const curCov = current.semantic_coverage?.coverage_ratio ?? null;
+  const prevCov = previous.semantic_coverage?.coverage_ratio ?? null;
+  let coverage_delta = 0.0;
+  if (curCov !== null && prevCov !== null) {
+    coverage_delta = curCov - prevCov;
+    if (coverage_delta <= -coverageThreshold) {
+      regressions.push("semantic_coverage");
+    }
+  }
+
+  const curJ = llmJudgeGrandMean(current.llm_judge);
+  const prevJ = llmJudgeGrandMean(previous.llm_judge);
+  let llm_judge_mean_delta: number | null = null;
+  if (curJ !== null && prevJ !== null) {
+    llm_judge_mean_delta = curJ - prevJ;
+    if (llm_judge_mean_delta <= -llmJudgeThreshold) {
+      regressions.push("llm_judge");
+    }
+  }
+
+  return {
+    previous_timestamp: previous.timestamp,
+    coverage_delta,
+    llm_judge_mean_delta,
+    regressions,
+    thresholds_used,
+    is_regression: regressions.length > 0,
+  };
+}

--- a/src/eval/comparator.ts
+++ b/src/eval/comparator.ts
@@ -1,0 +1,36 @@
+import { execSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { DiscoveryOutputSchema } from "../agentOutput/schemas.js";
+import type { EvalReport } from "./report.js";
+import { analyzeCoverage } from "./semanticCoverage.js";
+
+export function detectPromptChanges(): boolean {
+  try {
+    const out = execSync("git diff --name-only HEAD~1 -- .claude/agents/", {
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "ignore"],
+    });
+    return out.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+export async function runEvalCore(
+  outputDir: string,
+  samplesDir?: string,
+): Promise<Pick<EvalReport, "timestamp" | "prompt_changed" | "semantic_coverage" | "llm_judge">> {
+  const outAbs = resolve(outputDir);
+  const patternsPath = join(outAbs, "patterns.json");
+  const raw = await readFile(patternsPath, "utf8");
+  const patterns = DiscoveryOutputSchema.parse(JSON.parse(raw) as unknown);
+  const semantic_coverage =
+    samplesDir !== undefined ? await analyzeCoverage(resolve(samplesDir), patterns) : null;
+  return {
+    timestamp: new Date().toISOString(),
+    prompt_changed: detectPromptChanges(),
+    semantic_coverage,
+    llm_judge: null,
+  };
+}

--- a/src/eval/index.ts
+++ b/src/eval/index.ts
@@ -1,15 +1,18 @@
 /**
- * TypeScript eval pipeline entry (PR 4/5 — replaces `python -m confluence_to_notion.eval`).
- * This scaffold keeps `scripts/run-eval.sh` on a Node-only path; semantic coverage,
- * baseline diff, and LLM-as-judge ports land in follow-up commits on the same branch.
+ * TypeScript eval pipeline (PR 4/5). Produces `EvalReport`-shaped JSON under
+ * `eval_results/<timestamp>.json`, matching the historical Python comparator path.
  */
 import { mkdir, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
+import { compareToBaseline, loadPreviousEvalReport } from "./baseline.js";
+import { runEvalCore } from "./comparator.js";
+import { runLlmJudgeIfConfigured } from "./llmJudge.js";
+import type { EvalReport } from "./report.js";
 
 interface EvalCliArgs {
   outputDir: string;
   evalResultsDir: string;
-  samplesDir: string;
+  samplesDir?: string;
   llmJudge: boolean;
   failOnRegression: boolean;
 }
@@ -30,29 +33,51 @@ function parseArgs(argv: string[]): EvalCliArgs {
     }
     positional.push(a);
   }
-  const [outputDir = "output", evalResultsDir = "eval_results", samplesDir = "samples"] =
-    positional;
-  return { outputDir, evalResultsDir, samplesDir, llmJudge, failOnRegression };
+  const [outputDir = "output", evalResultsDir = "eval_results", samplesDir] = positional;
+  const base = { outputDir, evalResultsDir, llmJudge, failOnRegression };
+  return samplesDir !== undefined ? { ...base, samplesDir } : base;
 }
 
 async function main(): Promise<void> {
   const args = parseArgs(process.argv);
-  await mkdir(args.evalResultsDir, { recursive: true });
-  const stamp = new Date().toISOString().replaceAll(":", "-");
-  const outFile = join(args.evalResultsDir, `${stamp}.json`);
-  const payload = {
-    generatedAt: new Date().toISOString(),
-    outputDir: args.outputDir,
-    samplesDir: args.samplesDir,
-    flags: { llmJudge: args.llmJudge, failOnRegression: args.failOnRegression },
-    summary: {
-      status: "scaffold",
-      message:
-        "TS eval harness scaffold — schema validation runs via c2n validate-output in run-eval.sh; semantic coverage, baseline, and LLM judge are not ported in this commit.",
-    },
+  const resultsDir = resolve(args.evalResultsDir);
+  const previous = await loadPreviousEvalReport(resultsDir);
+
+  if (args.llmJudge && args.samplesDir === undefined) {
+    process.stderr.write("--llm-judge requires <samples_dir> as the third positional argument.\n");
+    process.exit(1);
+  }
+
+  const core = await runEvalCore(args.outputDir, args.samplesDir);
+
+  let llm_judge: unknown = null;
+  if (args.llmJudge && args.samplesDir !== undefined) {
+    llm_judge = await runLlmJudgeIfConfigured({
+      outputDir: resolve(args.outputDir),
+      samplesDir: resolve(args.samplesDir),
+    });
+  }
+
+  const beforeBaseline: EvalReport = {
+    ...core,
+    llm_judge,
+    baseline_comparison: null,
   };
-  await writeFile(outFile, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  const report: EvalReport = {
+    ...beforeBaseline,
+    baseline_comparison: compareToBaseline(beforeBaseline, previous),
+  };
+
+  await mkdir(resultsDir, { recursive: true });
+  const stamp = report.timestamp.replaceAll(":", "-").replaceAll("+", "_");
+  const outFile = join(resultsDir, `${stamp}.json`);
+  await writeFile(outFile, `${JSON.stringify(report, null, 2)}\n`, "utf8");
   process.stdout.write(`eval: wrote ${outFile}\n`);
+
+  if (args.failOnRegression && report.baseline_comparison?.is_regression) {
+    process.stderr.write("eval: regression detected (--fail-on-regression).\n");
+    process.exit(1);
+  }
 }
 
 main().catch((err: unknown) => {

--- a/src/eval/llmJudge.ts
+++ b/src/eval/llmJudge.ts
@@ -1,0 +1,13 @@
+/**
+ * LLM-as-judge pass (ADR-004 signal-only). Full Anthropic integration is deferred;
+ * the harness leaves `llm_judge` null unless a future commit wires `@anthropic-ai/sdk`.
+ */
+export async function runLlmJudgeIfConfigured(_args: {
+  outputDir: string;
+  samplesDir: string;
+}): Promise<unknown | null> {
+  if (!process.env.ANTHROPIC_API_KEY?.trim()) {
+    return null;
+  }
+  return null;
+}

--- a/src/eval/report.ts
+++ b/src/eval/report.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+/** Matches `SemanticCoverage` in historical `agents/schemas.py`. */
+export const SemanticCoverageSchema = z.object({
+  pages_analyzed: z.number().int().positive(),
+  sample_elements: z.array(z.string()),
+  covered_elements: z.array(z.string()),
+  coverage_ratio: z.number().min(0).max(1),
+});
+export type SemanticCoverage = z.infer<typeof SemanticCoverageSchema>;
+
+/** Matches `BaselineComparison` in historical `agents/schemas.py`. */
+export const BaselineComparisonSchema = z.object({
+  previous_timestamp: z.string().nullable(),
+  coverage_delta: z.number(),
+  llm_judge_mean_delta: z.number().nullable(),
+  regressions: z.array(z.string()),
+  thresholds_used: z.record(z.string(), z.number()),
+  is_regression: z.boolean(),
+});
+export type BaselineComparison = z.infer<typeof BaselineComparisonSchema>;
+
+/** Matches `EvalReport` in historical `agents/schemas.py` (JSON field names). */
+export const EvalReportSchema = z.object({
+  timestamp: z.string(),
+  prompt_changed: z.boolean(),
+  semantic_coverage: SemanticCoverageSchema.nullable(),
+  llm_judge: z.unknown().nullable().optional(),
+  baseline_comparison: BaselineComparisonSchema.nullable(),
+});
+export type EvalReport = z.infer<typeof EvalReportSchema>;

--- a/src/eval/semanticCoverage.ts
+++ b/src/eval/semanticCoverage.ts
@@ -1,0 +1,75 @@
+import { readFile, readdir } from "node:fs/promises";
+import { extname, join } from "node:path";
+import type { DiscoveryOutput } from "../agentOutput/schemas.js";
+import type { SemanticCoverage } from "./report.js";
+
+function collectKeysFromXhtml(xhtml: string): Set<string> {
+  const keys = new Set<string>();
+  const macroRe = /<ac:structured-macro\b[^>]*\bac:name\s*=\s*"([^"]+)"/gi;
+  for (const m of xhtml.matchAll(macroRe)) {
+    const name = m[1];
+    if (name) keys.add(`macro:${name}`);
+  }
+  const macroRe2 = /<ac:structured-macro\b[^>]*\bac:name\s*=\s*'([^']+)'/gi;
+  for (const m of xhtml.matchAll(macroRe2)) {
+    const name = m[1];
+    if (name) keys.add(`macro:${name}`);
+  }
+  if (/<ac:link\b/i.test(xhtml)) keys.add("element:ac-link");
+  if (/<ac:image\b/i.test(xhtml)) keys.add("element:ac-image");
+  if (/<h[1-6]\b/i.test(xhtml)) keys.add("element:heading");
+  if (/<\/?(ul|ol)\b/i.test(xhtml)) keys.add("element:list");
+  if (/<(code|pre)\b/i.test(xhtml)) keys.add("element:code");
+  if (/<table\b/i.test(xhtml)) keys.add("element:table");
+  if (/<a\b/i.test(xhtml)) keys.add("element:link");
+  return keys;
+}
+
+function patternKeys(patterns: DiscoveryOutput): Set<string> {
+  const covered = new Set<string>();
+  for (const pattern of patterns.patterns) {
+    for (const snippet of pattern.example_snippets) {
+      for (const k of collectKeysFromXhtml(snippet)) {
+        covered.add(k);
+      }
+    }
+  }
+  return covered;
+}
+
+export async function analyzeCoverage(
+  samplesDir: string,
+  patterns: DiscoveryOutput,
+): Promise<SemanticCoverage> {
+  const entries = await readdir(samplesDir, { withFileTypes: true });
+  const sampleFiles = entries
+    .filter((e) => e.isFile() && extname(e.name).toLowerCase() === ".xhtml")
+    .map((e) => e.name)
+    .sort();
+  if (sampleFiles.length === 0) {
+    throw new Error(`no .xhtml files found in ${samplesDir}`);
+  }
+
+  const sampleKeys = new Set<string>();
+  for (const name of sampleFiles) {
+    const text = await readFile(join(samplesDir, name), "utf8");
+    for (const k of collectKeysFromXhtml(text)) {
+      sampleKeys.add(k);
+    }
+  }
+
+  const pKeys = patternKeys(patterns);
+  const covered = new Set<string>();
+  for (const k of sampleKeys) {
+    if (pKeys.has(k)) covered.add(k);
+  }
+
+  const ratio = sampleKeys.size > 0 ? covered.size / sampleKeys.size : 1.0;
+
+  return {
+    pages_analyzed: sampleFiles.length,
+    sample_elements: [...sampleKeys].sort((a, b) => a.localeCompare(b)),
+    covered_elements: [...covered].sort((a, b) => a.localeCompare(b)),
+    coverage_ratio: ratio,
+  };
+}

--- a/tests/converter/convertPage.test.ts
+++ b/tests/converter/convertPage.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { FinalRuleset } from "../../src/agentOutput/finalRuleset.js";
+import { convertXhtmlToConversionResult } from "../../src/converter/convertPage.js";
+
+const emptyRuleset: FinalRuleset = { source: "test", rules: [] };
+
+describe("convertXhtmlToConversionResult", () => {
+  it("strips markup into a single paragraph block", () => {
+    const result = convertXhtmlToConversionResult(emptyRuleset, "<p>Hello <b>world</b></p>", "42");
+    expect(result.blocks).toHaveLength(1);
+    expect(result.blocks[0]).toMatchObject({
+      type: "paragraph",
+      paragraph: {
+        rich_text: [{ type: "text", text: { content: "Hello world" } }],
+      },
+    });
+  });
+
+  it("drops script and style bodies", () => {
+    const result = convertXhtmlToConversionResult(
+      emptyRuleset,
+      "<p>a</p><script>evil()</script><style>.x{}</style><p>b</p>",
+      "1",
+    );
+    expect(result.blocks[0]).toMatchObject({
+      type: "paragraph",
+      paragraph: {
+        rich_text: [{ type: "text", text: { content: "a b" } }],
+      },
+    });
+  });
+
+  it("uses page id when there is no visible text", () => {
+    const result = convertXhtmlToConversionResult(emptyRuleset, "   \n\t  ", "99");
+    expect(result.blocks[0]).toMatchObject({
+      type: "paragraph",
+      paragraph: {
+        rich_text: [{ type: "text", text: { content: "page 99" } }],
+      },
+    });
+  });
+
+  it("returns empty usedRules and unresolved", () => {
+    const result = convertXhtmlToConversionResult(emptyRuleset, "<p>x</p>", "1");
+    expect(result.unresolved).toEqual([]);
+    expect(result.usedRules).toEqual({});
+  });
+});

--- a/tests/eval/baseline.test.ts
+++ b/tests/eval/baseline.test.ts
@@ -1,0 +1,71 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compareToBaseline, loadPreviousEvalReport } from "../../src/eval/baseline.js";
+import type { EvalReport, SemanticCoverage } from "../../src/eval/report.js";
+
+function coverage(ratio: number): SemanticCoverage {
+  return {
+    pages_analyzed: 1,
+    sample_elements: ["macro:x"],
+    covered_elements: ratio >= 0.5 ? ["macro:x"] : [],
+    coverage_ratio: ratio,
+  };
+}
+
+function report(partial: Omit<EvalReport, "baseline_comparison">): EvalReport {
+  return { ...partial, baseline_comparison: null };
+}
+
+describe("compareToBaseline", () => {
+  it("treats missing previous snapshot as no regression", () => {
+    const current = report({
+      timestamp: "t1",
+      prompt_changed: false,
+      semantic_coverage: coverage(1),
+      llm_judge: null,
+    });
+    const cmp = compareToBaseline(current, null);
+    expect(cmp.is_regression).toBe(false);
+    expect(cmp.previous_timestamp).toBeNull();
+    expect(cmp.regressions).toEqual([]);
+  });
+
+  it("detects semantic coverage regression beyond the default threshold", () => {
+    const previous = report({
+      timestamp: "t0",
+      prompt_changed: false,
+      semantic_coverage: coverage(1),
+      llm_judge: null,
+    });
+    const current = report({
+      timestamp: "t1",
+      prompt_changed: false,
+      semantic_coverage: coverage(0.89),
+      llm_judge: null,
+    });
+    const cmp = compareToBaseline(current, previous);
+    expect(cmp.is_regression).toBe(true);
+    expect(cmp.regressions).toContain("semantic_coverage");
+    expect(cmp.coverage_delta).toBeCloseTo(-0.11, 5);
+  });
+});
+
+describe("loadPreviousEvalReport", () => {
+  it("returns the newest parseable snapshot and skips corrupt files", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "c2n-eval-"));
+    await writeFile(join(dir, "old.json"), "not json", "utf8");
+    const good: EvalReport = {
+      timestamp: "2026-01-02T00:00:00.000Z",
+      prompt_changed: false,
+      semantic_coverage: null,
+      llm_judge: null,
+      baseline_comparison: null,
+    };
+    await writeFile(join(dir, "2026-01-02.json"), JSON.stringify(good), "utf8");
+    await writeFile(join(dir, "newer-bad.json"), "{", "utf8");
+    const loaded = await loadPreviousEvalReport(dir);
+    expect(loaded?.timestamp).toBe(good.timestamp);
+  });
+});

--- a/tests/eval/semanticCoverage.test.ts
+++ b/tests/eval/semanticCoverage.test.ts
@@ -1,0 +1,51 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import type { DiscoveryOutput } from "../../src/agentOutput/schemas.js";
+import { analyzeCoverage } from "../../src/eval/semanticCoverage.js";
+
+function minimalPatterns(snippets: string[]): DiscoveryOutput {
+  return {
+    sample_dir: "samples",
+    pages_analyzed: 1,
+    patterns: [
+      {
+        pattern_id: "p1",
+        pattern_type: "macro",
+        description: "test",
+        example_snippets: snippets,
+        source_pages: ["1"],
+        frequency: 1,
+      },
+    ],
+  };
+}
+
+describe("analyzeCoverage", () => {
+  it("reports full coverage when sample keys appear in pattern snippets", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "c2n-semcov-"));
+    await writeFile(join(dir, "a.xhtml"), '<ac:structured-macro ac:name="info" />', "utf8");
+    const patterns = minimalPatterns(['<ac:structured-macro ac:name="info" />']);
+    const report = await analyzeCoverage(dir, patterns);
+    expect(report.pages_analyzed).toBe(1);
+    expect(report.sample_elements).toContain("macro:info");
+    expect(report.covered_elements).toContain("macro:info");
+    expect(report.coverage_ratio).toBe(1);
+  });
+
+  it("reports partial coverage when samples use macros missing from patterns", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "c2n-semcov-"));
+    await writeFile(join(dir, "a.xhtml"), '<ac:structured-macro ac:name="panel" />', "utf8");
+    const patterns = minimalPatterns(['<ac:structured-macro ac:name="info" />']);
+    const report = await analyzeCoverage(dir, patterns);
+    expect(report.sample_elements).toContain("macro:panel");
+    expect(report.covered_elements).not.toContain("macro:panel");
+    expect(report.coverage_ratio).toBe(0);
+  });
+
+  it("throws when the samples directory has no .xhtml files", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "c2n-semcov-"));
+    await expect(analyzeCoverage(dir, minimalPatterns([]))).rejects.toThrow(/no \.xhtml files/);
+  });
+});

--- a/tests/integration/cli-distribution.test.ts
+++ b/tests/integration/cli-distribution.test.ts
@@ -1,0 +1,42 @@
+import { execFileSync } from "node:child_process";
+import { statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const maxBytes = 2 * 1024 * 1024;
+const cliJs = join(repoRoot, "dist/cli.js");
+
+function runBuiltCli(args: string[]): string {
+  return execFileSync(process.execPath, [cliJs, ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: { ...process.env, NO_COLOR: "1" },
+  });
+}
+
+describe("CLI distribution (built dist/cli.js)", () => {
+  beforeAll(() => {
+    execFileSync("pnpm", ["build"], { cwd: repoRoot, stdio: "inherit" });
+  });
+
+  it("prints a semver version", () => {
+    const out = runBuiltCli(["--version"]).trim();
+    expect(out).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it("help output mentions primary workflow commands", () => {
+    const out = runBuiltCli(["--help"]);
+    expect(out).toContain("fetch");
+    expect(out).toContain("convert");
+    expect(out).toContain("validate-output");
+  });
+
+  it("keeps published CLI bundles under 2MB each", () => {
+    for (const rel of ["dist/cli.js", "dist/mcp.js"] as const) {
+      const bytes = statSync(join(repoRoot, rel)).size;
+      expect(bytes, rel).toBeLessThan(maxBytes);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add `readConfluenceBaseUrl` / `readConfluenceAuth` for Confluence CLI commands.
- Implement `fetch` and `fetch-tree` with optional `--url` run lifecycle under `output/runs/`, plus legacy `--out-dir` paths.
- Implement `convert`: load `rules.json`, scan `*.xhtml`, write converted JSON via minimal `convertXhtmlToConversionResult` stub.
- Port eval harness pieces: `report`, `semanticCoverage`, `baseline`, `comparator`, `llmJudge` stub, and a single `src/eval/index.ts` entrypoint aligned with `scripts/run-eval.sh`.
- Tests: `convertPage`, eval baseline/semantic coverage, integration test for built CLI (`--version`, `--help`) and bundle size under 2MB.

## Test plan
- [x] `pnpm test`
- [x] `pnpm lint`
- [x] `pnpm typecheck`

Refs #140

Made with [Cursor](https://cursor.com)