### PR TITLE
feat(eval): c2n eval, schema validation, Anthropic judge, MSW fetch

### DIFF
--- a/.claude/docs/ADR-00M-cli-surface-freeze.md
+++ b/.claude/docs/ADR-00M-cli-surface-freeze.md
@@ -26,7 +26,7 @@ Captured from `src/confluence_to_notion/cli.py` and
 | `CONFLUENCE_API_PATH` | `/rest/api` | Always (has default) | Must start with `/`. Override for self-hosted Confluence. |
 | `NOTION_API_TOKEN` | _unset_ | `notion-ping` + every `migrate*` command | Must start with `ntn_` or `secret_`. |
 | `NOTION_ROOT_PAGE_ID` | _unset_ | Fallback for `--target` / `--to` | Every `migrate*` command falls back to this when the flag is omitted. |
-| `ANTHROPIC_API_KEY` | _unset_ | Only `scripts/run-eval.sh --llm-judge` | Never required by the CLI itself. |
+| `ANTHROPIC_API_KEY` | _unset_ | Only `c2n eval --llm-judge` (or `scripts/run-eval.sh --llm-judge`) | Never required by the CLI itself. |
 
 ## Subcommands
 
@@ -63,6 +63,18 @@ No flags. Requires `NOTION_API_TOKEN` and `NOTION_ROOT_PAGE_ID`.
 > Reminder shim: prints the correct `bash scripts/discover.sh` invocation and exits 1. Not a real pipeline entry point.
 
 No flags.
+
+### `c2n eval`
+
+> Semantic coverage over sample XHTML, optional LLM-as-judge, and baseline diff vs the latest prior snapshot under `eval_results/`.
+
+| Arg / Flag | Type | Default | Env fallback | Required | Semantics |
+|---|---|---|---|---|---|
+| `OUTPUT_DIR` (positional) | PATH | `output` | — | No | Directory containing `patterns.json` and `proposals.json` (validated before coverage). |
+| `EVAL_RESULTS_DIR` (positional) | PATH | `eval_results` | — | No | Directory where `eval_results/<timestamp>.json` snapshots are written and read for baseline diff. |
+| `SAMPLES_DIR` (positional) | PATH | _none_ | — | No | Sample XHTML directory; **required** when `--llm-judge` is set (semantic coverage also uses it when provided). |
+| `--llm-judge` | FLAG | `false` | — | No | When set, runs the Anthropic judge pass if `ANTHROPIC_API_KEY` is present; otherwise judge output stays null. |
+| `--fail-on-regression` | FLAG | `false` | — | No | Exit non-zero when baseline comparison marks a regression. |
 
 ### `c2n validate-output`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Derived rules are applied by a deterministic converter to migrate wiki pages whi
 - HTTP: undici / global `fetch` (lands in PR 3)
 - Notion SDK: `@notionhq/client` (lands in PR 3)
 - MCP SDK: `@modelcontextprotocol/sdk` (lands in PR 3)
-- Anthropic SDK: `@anthropic-ai/sdk` (lands in PR 3 for eval `--llm-judge`)
+- Anthropic: `c2n eval --llm-judge` calls the Messages HTTP API directly (no `@anthropic-ai/sdk` in the CLI bundle; keeps `dist/cli.js` small).
 - Bundler: tsup
 - Test runner: vitest (+ `@vitest/coverage-v8`)
 - Lint + format: biome
@@ -70,7 +70,7 @@ Load rules from `.claude/rules/*.md`:
 pnpm exec c2n --version
 pnpm exec c2n --help
 # Planned subcommands (frozen in ADR-00M): fetch, fetch-tree, notion-ping, validate-output,
-# finalize, convert, migrate, migrate-tree, migrate-tree-pages
+# finalize, convert, eval, migrate, migrate-tree, migrate-tree-pages
 
 # Agent pipeline (bash script orchestration) — retargeted to `pnpm exec c2n` in PR 4
 bash scripts/discover.sh samples/ --url <url>             # Run full pipeline (4 steps)

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint": "biome check",
     "format": "biome format --write",
     "typecheck": "tsc --noEmit",
-    "eval:pipeline": "tsx src/eval/index.ts output/ eval_results/ samples/"
+    "eval:pipeline": "pnpm exec c2n eval output/ eval_results/ samples/"
   },
   "dependencies": {
     "@notionhq/client": "5.20.0",

--- a/scripts/run-eval.sh
+++ b/scripts/run-eval.sh
@@ -42,4 +42,4 @@ pnpm exec c2n validate-output output/proposals.json proposer
 
 # Step 3: Semantic coverage + baseline diff (+ optional LLM-as-judge)
 echo "--- Semantic coverage + baseline (TS eval harness) ---"
-pnpm exec tsx src/eval/index.ts output/ eval_results/ samples/ ${EVAL_FLAGS[@]+"${EVAL_FLAGS[@]}"}
+pnpm exec c2n eval output/ eval_results/ samples/ ${EVAL_FLAGS[@]+"${EVAL_FLAGS[@]}"}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,10 +1,12 @@
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { createProgram } from "./cli/index.js";
 
 export { createProgram } from "./cli/index.js";
 
+const entry = process.argv[1];
 const isDirectInvocation =
-  import.meta.url === `file://${process.argv[1]}` ||
-  process.argv[1]?.endsWith("/dist/cli.js") === true;
+  entry !== undefined && resolve(fileURLToPath(import.meta.url)) === resolve(entry);
 
 if (isDirectInvocation) {
   createProgram().parse(process.argv);

--- a/src/cli/evalHarness.ts
+++ b/src/cli/evalHarness.ts
@@ -1,0 +1,40 @@
+import type { Command } from "commander";
+import { type EvalCliArgs, runEvalWithArgs } from "../eval/run.js";
+
+export function registerEvalHarness(program: Command): void {
+  program
+    .command("eval")
+    .description(
+      "Run semantic coverage, optional LLM-as-judge, and baseline comparison; writes eval_results/<timestamp>.json.",
+    )
+    .argument("[output_dir]", "discovery output root (patterns.json, proposals.json)", "output")
+    .argument("[eval_results_dir]", "directory for JSON snapshots", "eval_results")
+    .argument("[samples_dir]", "sample XHTML directory (required when using --llm-judge)")
+    .option("--fail-on-regression", "exit 1 when baseline comparison reports a regression", false)
+    .option("--llm-judge", "run Anthropic judge when ANTHROPIC_API_KEY is set", false)
+    .action(async function (
+      this: Command,
+      output_dir: string,
+      eval_results_dir: string,
+      samples_dir: string | undefined,
+    ) {
+      const o = this.opts<{ llmJudge?: boolean; failOnRegression?: boolean }>();
+      const baseArgs = {
+        outputDir: output_dir,
+        evalResultsDir: eval_results_dir,
+        llmJudge: Boolean(o.llmJudge),
+        failOnRegression: Boolean(o.failOnRegression),
+      };
+      const args: EvalCliArgs =
+        samples_dir !== undefined && samples_dir.length > 0
+          ? { ...baseArgs, samplesDir: samples_dir }
+          : baseArgs;
+      try {
+        const code = await runEvalWithArgs(args);
+        process.exit(code);
+      } catch (e) {
+        process.stderr.write(`eval: ${String(e)}\n`);
+        process.exit(1);
+      }
+    });
+}

--- a/src/cli/fetch.ts
+++ b/src/cli/fetch.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import type { Command } from "commander";
-import { createConfluenceClient } from "../confluence/client.js";
+import { type FetchLike, createConfluenceClient } from "../confluence/client.js";
 import { type RunContext, finalizeRun, startRun, updateStep } from "../runs/index.js";
 import { readConfluenceAuth, readConfluenceBaseUrl } from "./confluenceEnv.js";
 
@@ -15,6 +15,20 @@ export interface FetchCliOptions {
 
 function outputRootDir(): string {
   return join(process.cwd(), "output");
+}
+
+/** When `C2N_USE_GLOBAL_FETCH=1`, use `globalThis.fetch` so MSW can intercept in tests. */
+function createCliConfluenceClient(): ReturnType<typeof createConfluenceClient> {
+  const { email, token } = readConfluenceAuth();
+  const baseUrl = readConfluenceBaseUrl();
+  const useGlobal = process.env.C2N_USE_GLOBAL_FETCH === "1";
+  const g = globalThis as { fetch?: FetchLike };
+  return createConfluenceClient({
+    email,
+    token,
+    baseUrl,
+    ...(useGlobal && typeof g.fetch === "function" ? { fetchImpl: g.fetch } : {}),
+  });
 }
 
 async function writePageXhtml(targetDir: string, pageId: string, xhtml: string): Promise<void> {
@@ -75,9 +89,7 @@ export async function runFetchCommand(opts: FetchCliOptions): Promise<void> {
     process.exit(1);
   }
 
-  const { email, token } = readConfluenceAuth();
-  const baseUrl = readConfluenceBaseUrl();
-  const client = createConfluenceClient({ email, token, baseUrl });
+  const client = createCliConfluenceClient();
 
   let runContext: RunContext | null = null;
   if (opts.url !== undefined && opts.url.length > 0) {
@@ -115,9 +127,7 @@ export interface FetchTreeCliOptions {
 }
 
 export async function runFetchTreeCommand(opts: FetchTreeCliOptions): Promise<void> {
-  const { email, token } = readConfluenceAuth();
-  const baseUrl = readConfluenceBaseUrl();
-  const client = createConfluenceClient({ email, token, baseUrl });
+  const client = createCliConfluenceClient();
   const tree = await client.getPageTree(opts.rootId, { maxDepth: 25 });
   const json = `${JSON.stringify(tree, null, 2)}\n`;
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import pkg from "../../package.json" with { type: "json" };
 import { registerConvertCommands } from "./convert.js";
 import { registerDiscoverShim } from "./discover.js";
+import { registerEvalHarness } from "./evalHarness.js";
 import { registerFetchCommands } from "./fetch.js";
 import { registerFinalizeCommands } from "./finalize.js";
 import { registerMigrateCommands } from "./migrate.js";
@@ -26,6 +27,7 @@ export function createProgram(): Command {
   registerFetchCommands(program);
   registerNotionCommands(program);
   registerDiscoverShim(program);
+  registerEvalHarness(program);
   registerValidateCommands(program);
   registerFinalizeCommands(program);
   registerConvertCommands(program);

--- a/src/eval/index.ts
+++ b/src/eval/index.ts
@@ -1,83 +1,11 @@
 /**
- * TypeScript eval pipeline (PR 4/5). Produces `EvalReport`-shaped JSON under
- * `eval_results/<timestamp>.json`, matching the historical Python comparator path.
+ * TypeScript eval pipeline entry (non-CLI). Prefer `pnpm exec c2n eval …` in scripts.
  */
-import { mkdir, writeFile } from "node:fs/promises";
-import { join, resolve } from "node:path";
-import { compareToBaseline, loadPreviousEvalReport } from "./baseline.js";
-import { runEvalCore } from "./comparator.js";
-import { runLlmJudgeIfConfigured } from "./llmJudge.js";
-import type { EvalReport } from "./report.js";
-
-interface EvalCliArgs {
-  outputDir: string;
-  evalResultsDir: string;
-  samplesDir?: string;
-  llmJudge: boolean;
-  failOnRegression: boolean;
-}
-
-function parseArgs(argv: string[]): EvalCliArgs {
-  const rest = argv.slice(2);
-  let llmJudge = false;
-  let failOnRegression = false;
-  const positional: string[] = [];
-  for (const a of rest) {
-    if (a === "--llm-judge") {
-      llmJudge = true;
-      continue;
-    }
-    if (a === "--fail-on-regression") {
-      failOnRegression = true;
-      continue;
-    }
-    positional.push(a);
-  }
-  const [outputDir = "output", evalResultsDir = "eval_results", samplesDir] = positional;
-  const base = { outputDir, evalResultsDir, llmJudge, failOnRegression };
-  return samplesDir !== undefined ? { ...base, samplesDir } : base;
-}
+import { parseEvalArgvTail, runEvalWithArgs } from "./run.js";
 
 async function main(): Promise<void> {
-  const args = parseArgs(process.argv);
-  const resultsDir = resolve(args.evalResultsDir);
-  const previous = await loadPreviousEvalReport(resultsDir);
-
-  if (args.llmJudge && args.samplesDir === undefined) {
-    process.stderr.write("--llm-judge requires <samples_dir> as the third positional argument.\n");
-    process.exit(1);
-  }
-
-  const core = await runEvalCore(args.outputDir, args.samplesDir);
-
-  let llm_judge: unknown = null;
-  if (args.llmJudge && args.samplesDir !== undefined) {
-    llm_judge = await runLlmJudgeIfConfigured({
-      outputDir: resolve(args.outputDir),
-      samplesDir: resolve(args.samplesDir),
-    });
-  }
-
-  const beforeBaseline: EvalReport = {
-    ...core,
-    llm_judge,
-    baseline_comparison: null,
-  };
-  const report: EvalReport = {
-    ...beforeBaseline,
-    baseline_comparison: compareToBaseline(beforeBaseline, previous),
-  };
-
-  await mkdir(resultsDir, { recursive: true });
-  const stamp = report.timestamp.replaceAll(":", "-").replaceAll("+", "_");
-  const outFile = join(resultsDir, `${stamp}.json`);
-  await writeFile(outFile, `${JSON.stringify(report, null, 2)}\n`, "utf8");
-  process.stdout.write(`eval: wrote ${outFile}\n`);
-
-  if (args.failOnRegression && report.baseline_comparison?.is_regression) {
-    process.stderr.write("eval: regression detected (--fail-on-regression).\n");
-    process.exit(1);
-  }
+  const code = await runEvalWithArgs(parseEvalArgvTail(process.argv));
+  process.exit(code);
 }
 
 main().catch((err: unknown) => {

--- a/src/eval/llmJudge.ts
+++ b/src/eval/llmJudge.ts
@@ -1,13 +1,103 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { z } from "zod";
+import { DiscoveryOutputSchema } from "../agentOutput/schemas.js";
+
+const ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages";
+const ANTHROPIC_VERSION = "2023-06-01";
+/** Small, cost-effective model for batch eval; swap only via intentional ADR change. */
+const JUDGE_MODEL = "claude-3-5-haiku-20241022";
+
+const JudgeRowSchema = z.object({
+  scores: z.record(z.number()),
+  rationale: z.string().optional(),
+});
+
+const JudgeResponseSchema = z.array(JudgeRowSchema);
+
 /**
- * LLM-as-judge pass (ADR-004 signal-only). Full Anthropic integration is deferred;
- * the harness leaves `llm_judge` null unless a future commit wires `@anthropic-ai/sdk`.
+ * LLM-as-judge pass (ADR-004). Uses the Anthropic Messages HTTP API (no SDK) to
+ * keep the published CLI bundle small; requires `ANTHROPIC_API_KEY` when enabled.
  */
-export async function runLlmJudgeIfConfigured(_args: {
+export async function runLlmJudgeIfConfigured(args: {
   outputDir: string;
   samplesDir: string;
 }): Promise<unknown | null> {
-  if (!process.env.ANTHROPIC_API_KEY?.trim()) {
-    return null;
+  const key = process.env.ANTHROPIC_API_KEY?.trim();
+  if (!key) return null;
+
+  const patternsPath = join(args.outputDir, "patterns.json");
+  const raw = await readFile(patternsPath, "utf8");
+  const patterns = DiscoveryOutputSchema.parse(JSON.parse(raw) as unknown);
+
+  const prompt = [
+    "You evaluate discovery output for a Confluence → Notion migration pipeline.",
+    "Return ONLY a JSON array (no markdown fences) with 1 to 3 objects of this exact shape:",
+    '{"scores":{"relevance":0,"specificity":0,"actionability":0},"rationale":"short text"}',
+    "Each score must be a number from 0 (worst) to 1 (best), judging whether patterns are specific and actionable for engineers.",
+    "",
+    `Pattern count: ${String(patterns.patterns.length)}`,
+    `First patterns (truncated JSON): ${JSON.stringify(patterns.patterns.slice(0, 8)).slice(0, 12_000)}`,
+    `Sample XHTML directory (for context only): ${args.samplesDir}`,
+  ].join("\n");
+
+  const res = await fetch(ANTHROPIC_MESSAGES_URL, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": key,
+      "anthropic-version": ANTHROPIC_VERSION,
+    },
+    body: JSON.stringify({
+      model: JUDGE_MODEL,
+      max_tokens: 2048,
+      messages: [{ role: "user", content: prompt }],
+    }),
+  });
+
+  const responseText = await res.text();
+  if (!res.ok) {
+    throw new Error(`Anthropic API error: ${String(res.status)} ${responseText.slice(0, 500)}`);
   }
-  return null;
+
+  const body = JSON.parse(responseText) as {
+    content?: Array<{ type: string; text?: string }>;
+  };
+  const textBlock = body.content?.find((c) => c.type === "text")?.text?.trim() ?? "";
+  const parsed = extractJsonArray(textBlock);
+  const safe = JudgeResponseSchema.safeParse(parsed);
+  if (!safe.success) {
+    return [
+      {
+        scores: { parse_error: 0 },
+        rationale: `Judge JSON did not match schema: ${safe.error.message}`,
+      },
+    ];
+  }
+  return safe.data;
+}
+
+function extractJsonArray(text: string): unknown {
+  const fence = /^```(?:json)?\s*([\s\S]*?)```$/m.exec(text);
+  if (fence?.[1]) {
+    try {
+      return JSON.parse(fence[1].trim()) as unknown;
+    } catch {
+      /* fall through */
+    }
+  }
+  const start = text.indexOf("[");
+  const end = text.lastIndexOf("]");
+  if (start >= 0 && end > start) {
+    try {
+      return JSON.parse(text.slice(start, end + 1)) as unknown;
+    } catch {
+      /* fall through */
+    }
+  }
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return [];
+  }
 }

--- a/src/eval/run.ts
+++ b/src/eval/run.ts
@@ -1,0 +1,81 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { compareToBaseline, loadPreviousEvalReport } from "./baseline.js";
+import { runEvalCore } from "./comparator.js";
+import { runLlmJudgeIfConfigured } from "./llmJudge.js";
+import type { EvalReport } from "./report.js";
+import { validateEvalAgentOutputs } from "./schemaValidation.js";
+
+export interface EvalCliArgs {
+  outputDir: string;
+  evalResultsDir: string;
+  samplesDir?: string;
+  llmJudge: boolean;
+  failOnRegression: boolean;
+}
+
+/** Parse argv shaped like `[node, <script>, ...tail]` (no `eval` subcommand token). */
+export function parseEvalArgvTail(argv: string[]): EvalCliArgs {
+  const rest = argv.slice(2);
+  let llmJudge = false;
+  let failOnRegression = false;
+  const positional: string[] = [];
+  for (const a of rest) {
+    if (a === "--llm-judge") {
+      llmJudge = true;
+      continue;
+    }
+    if (a === "--fail-on-regression") {
+      failOnRegression = true;
+      continue;
+    }
+    positional.push(a);
+  }
+  const [outputDir = "output", evalResultsDir = "eval_results", samplesDir] = positional;
+  const base = { outputDir, evalResultsDir, llmJudge, failOnRegression };
+  return samplesDir !== undefined ? { ...base, samplesDir } : base;
+}
+
+export async function runEvalWithArgs(args: EvalCliArgs): Promise<number> {
+  const resultsDir = resolve(args.evalResultsDir);
+  const previous = await loadPreviousEvalReport(resultsDir);
+
+  if (args.llmJudge && args.samplesDir === undefined) {
+    process.stderr.write("--llm-judge requires <samples_dir> as the third positional argument.\n");
+    return 1;
+  }
+
+  await validateEvalAgentOutputs(args.outputDir);
+
+  const core = await runEvalCore(args.outputDir, args.samplesDir);
+
+  let llm_judge: unknown = null;
+  if (args.llmJudge && args.samplesDir !== undefined) {
+    llm_judge = await runLlmJudgeIfConfigured({
+      outputDir: resolve(args.outputDir),
+      samplesDir: resolve(args.samplesDir),
+    });
+  }
+
+  const beforeBaseline: EvalReport = {
+    ...core,
+    llm_judge,
+    baseline_comparison: null,
+  };
+  const report: EvalReport = {
+    ...beforeBaseline,
+    baseline_comparison: compareToBaseline(beforeBaseline, previous),
+  };
+
+  await mkdir(resultsDir, { recursive: true });
+  const stamp = report.timestamp.replaceAll(":", "-").replaceAll("+", "_");
+  const outFile = join(resultsDir, `${stamp}.json`);
+  await writeFile(outFile, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  process.stdout.write(`eval: wrote ${outFile}\n`);
+
+  if (args.failOnRegression && report.baseline_comparison?.is_regression) {
+    process.stderr.write("eval: regression detected (--fail-on-regression).\n");
+    return 1;
+  }
+  return 0;
+}

--- a/src/eval/schemaValidation.ts
+++ b/src/eval/schemaValidation.ts
@@ -1,0 +1,18 @@
+import { join } from "node:path";
+import type { AgentOutputSchemaName } from "../agentOutput/schemas.js";
+import { validateOutputFile } from "../cli/validate.js";
+
+const EVAL_AGENT_FILES: Array<[string, AgentOutputSchemaName]> = [
+  ["patterns.json", "discovery"],
+  ["proposals.json", "proposer"],
+];
+
+/**
+ * Validates agent JSON artifacts under `outputDir` that the eval harness depends on.
+ * Delegates to the same zod paths as `c2n validate-output` (single source of truth).
+ */
+export async function validateEvalAgentOutputs(outputDir: string): Promise<void> {
+  for (const [name, schema] of EVAL_AGENT_FILES) {
+    await validateOutputFile(join(outputDir, name), schema);
+  }
+}

--- a/tests/cli/surface.test.ts
+++ b/tests/cli/surface.test.ts
@@ -128,6 +128,7 @@ const EXPECTED_SUBCOMMANDS = [
   "fetch-tree",
   "notion-ping",
   "discover",
+  "eval",
   "validate-output",
   "finalize",
   "convert",

--- a/tests/eval/llmJudge.test.ts
+++ b/tests/eval/llmJudge.test.ts
@@ -1,0 +1,71 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runLlmJudgeIfConfigured } from "../../src/eval/llmJudge.js";
+
+describe("runLlmJudgeIfConfigured", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    process.env.ANTHROPIC_API_KEY = undefined;
+  });
+
+  it("returns null when ANTHROPIC_API_KEY is unset", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "c2n-llm-"));
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, "patterns.json"),
+      '{"sample_dir":"s","pages_analyzed":1,"patterns":[]}',
+      "utf8",
+    );
+    const out = await runLlmJudgeIfConfigured({ outputDir: dir, samplesDir: join(dir, "s") });
+    expect(out).toBeNull();
+  });
+
+  it("parses judge JSON from the Anthropic response shape", async () => {
+    process.env.ANTHROPIC_API_KEY = "test-key";
+    const dir = await mkdtemp(join(tmpdir(), "c2n-llm-"));
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, "patterns.json"),
+      JSON.stringify({
+        sample_dir: "samples",
+        pages_analyzed: 1,
+        patterns: [
+          {
+            pattern_id: "p1",
+            pattern_type: "macro",
+            description: "d",
+            example_snippets: ['<ac:structured-macro ac:name="info"/>'],
+            source_pages: ["1"],
+            frequency: 1,
+          },
+        ],
+      }),
+      "utf8",
+    );
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        text: async () =>
+          JSON.stringify({
+            content: [
+              {
+                type: "text",
+                text: '[{"scores":{"relevance":0.8,"specificity":0.7,"actionability":0.9},"rationale":"ok"}]',
+              },
+            ],
+          }),
+      })) as unknown as typeof fetch,
+    );
+
+    const out = await runLlmJudgeIfConfigured({ outputDir: dir, samplesDir: join(dir, "samples") });
+    expect(Array.isArray(out)).toBe(true);
+    const row = (out as Array<{ scores: Record<string, number> }>)[0];
+    expect(row?.scores?.relevance).toBeCloseTo(0.8, 5);
+  });
+});

--- a/tests/eval/schemaValidation.test.ts
+++ b/tests/eval/schemaValidation.test.ts
@@ -1,0 +1,37 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { validateEvalAgentOutputs } from "../../src/eval/schemaValidation.js";
+
+describe("validateEvalAgentOutputs", () => {
+  it("rejects when patterns.json is missing", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "c2n-schema-"));
+    await expect(validateEvalAgentOutputs(dir)).rejects.toThrow(/Cannot read file/);
+  });
+
+  it("passes when patterns and proposals validate", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "c2n-schema-"));
+    const patterns = {
+      sample_dir: "samples",
+      pages_analyzed: 1,
+      patterns: [
+        {
+          pattern_id: "p1",
+          pattern_type: "t",
+          description: "d",
+          example_snippets: ["<p>x</p>"],
+          source_pages: ["1"],
+          frequency: 1,
+        },
+      ],
+    };
+    const proposals = {
+      source_patterns_file: "output/patterns.json",
+      rules: [],
+    };
+    await writeFile(join(dir, "patterns.json"), JSON.stringify(patterns), "utf8");
+    await writeFile(join(dir, "proposals.json"), JSON.stringify(proposals), "utf8");
+    await expect(validateEvalAgentOutputs(dir)).resolves.toBeUndefined();
+  });
+});

--- a/tests/integration/cli-distribution.test.ts
+++ b/tests/integration/cli-distribution.test.ts
@@ -7,6 +7,7 @@ import { beforeAll, describe, expect, it } from "vitest";
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const maxBytes = 2 * 1024 * 1024;
 const cliJs = join(repoRoot, "dist/cli.js");
+const tsupCli = join(repoRoot, "node_modules", "tsup", "dist", "cli-default.js");
 
 function runBuiltCli(args: string[]): string {
   return execFileSync(process.execPath, [cliJs, ...args], {
@@ -18,7 +19,8 @@ function runBuiltCli(args: string[]): string {
 
 describe("CLI distribution (built dist/cli.js)", () => {
   beforeAll(() => {
-    execFileSync("pnpm", ["build"], { cwd: repoRoot, stdio: "inherit" });
+    // Run tsup via Node so Windows CI does not require `pnpm` on PATH for spawnSync.
+    execFileSync(process.execPath, [tsupCli], { cwd: repoRoot, stdio: "inherit" });
   });
 
   it("prints a semver version", () => {

--- a/tests/integration/fetch-url-msw.test.ts
+++ b/tests/integration/fetch-url-msw.test.ts
@@ -1,0 +1,78 @@
+import { mkdir, mkdtemp, readFile, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { runFetchCommand } from "../../src/cli/fetch.js";
+
+const BASE = "https://eval-msw.example.test/wiki";
+const EMAIL = "judge@example.com";
+const TOKEN = "token";
+
+const server = setupServer();
+
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: "error" });
+});
+
+afterEach(() => {
+  server.resetHandlers();
+  vi.restoreAllMocks();
+  process.env.CONFLUENCE_BASE_URL = undefined;
+  process.env.CONFLUENCE_EMAIL = undefined;
+  process.env.CONFLUENCE_API_TOKEN = undefined;
+  process.env.C2N_USE_GLOBAL_FETCH = undefined;
+});
+
+afterAll(() => {
+  server.close();
+});
+
+const validPage = (id: string) => ({
+  id,
+  title: "T",
+  type: "page",
+  space: { key: "S", name: "S" },
+  body: { storage: { value: "<p>mocked</p>", representation: "storage" } },
+  version: { number: 1 },
+});
+
+describe("fetch --url with MSW (global fetch)", () => {
+  it("writes XHTML under output/runs/<slug>/samples/", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "c2n-fetch-msw-"));
+    await mkdir(join(tmp, "output"), { recursive: true });
+    const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(tmp);
+
+    process.env.CONFLUENCE_BASE_URL = BASE;
+    process.env.CONFLUENCE_EMAIL = EMAIL;
+    process.env.CONFLUENCE_API_TOKEN = TOKEN;
+    process.env.C2N_USE_GLOBAL_FETCH = "1";
+
+    server.use(
+      http.get(`${BASE}/rest/api/content/77`, ({ request }) => {
+        const u = new URL(request.url);
+        expect(u.searchParams.get("expand")).toContain("body.storage");
+        return HttpResponse.json(validPage("77"));
+      }),
+    );
+
+    await runFetchCommand({
+      pages: "77",
+      limit: "25",
+      outDir: "samples",
+      url: "https://cwiki.apache.org/confluence/display/FOO/Bar",
+    });
+
+    const runsDir = join(tmp, "output", "runs");
+    const slugs = await readdir(runsDir);
+    expect(slugs.length).toBe(1);
+    const slug = slugs[0];
+    expect(slug).toBeDefined();
+    const xhtmlPath = join(runsDir, slug ?? "", "samples", "77.xhtml");
+    const body = await readFile(xhtmlPath, "utf8");
+    expect(body).toContain("mocked");
+
+    cwdSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- Add **`c2n eval`** (`src/cli/evalHarness.ts`) with ADR-00M table + surface test updates.
- Extract **`runEvalWithArgs`** / **`parseEvalArgvTail`** to `src/eval/run.ts`; `src/eval/index.ts` remains a thin `tsx` entry for local runs.
- Add **`validateEvalAgentOutputs`** (`src/eval/schemaValidation.ts`) reusing `c2n validate-output` zod parsing before semantic coverage.
- Implement **`llmJudge`** via Anthropic Messages **HTTP API** (`fetch`) to avoid bloating `dist/cli.js`; unit test mocks `fetch`.
- **`scripts/run-eval.sh`** step 3 and **`pnpm eval:pipeline`** use `pnpm exec c2n eval …`.
- **`C2N_USE_GLOBAL_FETCH=1`**: `fetch` / `fetch-tree` use `globalThis.fetch` so MSW can intercept; integration test covers **`fetch --url`** (not `convert`, which is still FS-only).

## Test plan
- [x] `pnpm test`
- [x] `pnpm lint`
- [x] `pnpm typecheck`

Refs #150

Made with [Cursor](https://cursor.com)