### PR TITLE
feat: converter: replace parse5 HTML5 mode with true XML parser (CDATA + namespaces)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   },
   "dependencies": {
     "@notionhq/client": "5.20.0",
+    "@xmldom/xmldom": "^0.9.10",
     "commander": "^12.1.0",
-    "parse5": "^7.2.1",
     "undici": "7.25.0",
     "zod": "^3.23.8"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,12 +11,12 @@ importers:
       '@notionhq/client':
         specifier: 5.20.0
         version: 5.20.0
+      '@xmldom/xmldom':
+        specifier: ^0.9.10
+        version: 0.9.10
       commander:
         specifier: ^12.1.0
         version: 12.1.0
-      parse5:
-        specifier: ^7.2.1
-        version: 7.3.0
       undici:
         specifier: 7.25.0
         version: 7.25.0
@@ -786,6 +786,10 @@ packages:
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
+  '@xmldom/xmldom@0.9.10':
+    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
+    engines: {node: '>=14.6'}
+
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
@@ -946,10 +950,6 @@ packages:
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
-
-  entities@6.0.1:
-    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
-    engines: {node: '>=0.12'}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -1270,9 +1270,6 @@ packages:
 
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
-
-  parse5@7.3.0:
-    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -2294,6 +2291,8 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
+  '@xmldom/xmldom@0.9.10': {}
+
   acorn@8.16.0: {}
 
   ansi-colors@4.1.3: {}
@@ -2415,8 +2414,6 @@ snapshots:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
-
-  entities@6.0.1: {}
 
   es-module-lexer@1.7.0: {}
 
@@ -2779,10 +2776,6 @@ snapshots:
   package-manager-detector@0.2.11:
     dependencies:
       quansync: 0.2.11
-
-  parse5@7.3.0:
-    dependencies:
-      entities: 6.0.1
 
   path-exists@4.0.0: {}
 

--- a/src/converter/converter.ts
+++ b/src/converter/converter.ts
@@ -5,16 +5,16 @@
 // Confluence XHTML and produces Notion API block dicts. No LLM calls — pure
 // transformation logic.
 //
-// Parser choice: parse5 in its standard (HTML5) mode preserves the `ac:` and
-// `ri:` prefixes inside tagName (e.g. `ac:structured-macro`) and decodes
-// named / numeric HTML entities automatically, so we get namespace-aware
-// behaviour without needing XML-mode parsing. The documented fallback, if we
-// ever hit a case where entity handling fights us, is linkedom's DOMParser in
-// XML mode — we deliberately avoid cheerio because it strips unknown
-// namespaces.
+// Parser choice: @xmldom/xmldom DOMParser in `text/xml` mode. The Python
+// baseline used ElementTree in XML mode, so the TS port matches that
+// behaviour: CDATA sections decode into normal text nodes, `ac:` / `ri:`
+// namespace prefixes are preserved on `tagName`, and the parser is strict
+// about well-formedness. parse5 (HTML5) was the previous choice but treated
+// `<![CDATA[ ... ]]>` as a bogus comment, dropping any text inside — see
+// issue #165. The synthetic root wrapper declares the `ac:` / `ri:`
+// namespaces so undeclared-prefix errors don't fire.
 
-import * as parse5 from "parse5";
-import type { DefaultTreeAdapterTypes } from "parse5";
+import { DOMParser, XMLSerializer } from "@xmldom/xmldom";
 import type { FinalRuleset } from "../agentOutput/finalRuleset.js";
 import type { TableRuleSet } from "./schemas.js";
 import {
@@ -24,10 +24,36 @@ import {
   type UnresolvedItem,
 } from "./schemas.js";
 
-type Element = DefaultTreeAdapterTypes.Element;
-type ChildNode = DefaultTreeAdapterTypes.ChildNode;
-type ParentNode = DefaultTreeAdapterTypes.ParentNode;
-type TextNode = DefaultTreeAdapterTypes.TextNode;
+// Minimal structural DOM aliases that match xmldom's runtime nodes. We avoid
+// importing xmldom's exported `Element` / `Node` types because they're class
+// types and constructing them in tests would require xmldom internals.
+interface Attr {
+  readonly name: string;
+  readonly localName: string | null;
+  readonly prefix: string | null;
+  readonly value: string;
+}
+interface DomNode {
+  readonly nodeType: number;
+  readonly nodeName: string;
+  readonly nodeValue: string | null;
+  readonly childNodes: { length: number; item(i: number): DomNode | null } & Iterable<DomNode>;
+  readonly firstChild: DomNode | null;
+  readonly parentNode: DomNode | null;
+}
+interface Element extends DomNode {
+  readonly tagName: string;
+  readonly localName: string;
+  readonly prefix: string | null;
+  readonly attributes: { length: number; item(i: number): Attr | null } & Iterable<Attr>;
+}
+interface TextNode extends DomNode {}
+type ChildNode = DomNode;
+type ParentNode = DomNode;
+
+const ELEMENT_NODE = 1;
+const TEXT_NODE = 3;
+const CDATA_SECTION_NODE = 4;
 
 const LARGE_PAGE_BLOCK_THRESHOLD = 100;
 const LARGE_PAGE_SIZE_THRESHOLD = 102_400;
@@ -118,7 +144,7 @@ export function convertXhtmlToNotionBlocks(
     tableIndex: 0,
   };
 
-  const root = parse5.parseFragment(trimmed);
+  const root = parseXhtmlFragment(trimmed);
   const blocks = convertChildren(root, ctx);
 
   const sizeBytes = Buffer.byteLength(trimmed, "utf8");
@@ -152,34 +178,140 @@ function markRuleUsed(ctx: ConversionContext, ruleId: string): void {
 
 // --- DOM helpers ---
 
+// Common HTML named entities that aren't in XML's built-in set. xmldom's
+// strict XML parser treats unknown named entities as errors and leaves them
+// undecoded. parse5 used to decode these natively; we restore that behaviour
+// with a pre-pass that runs only outside CDATA sections.
+const HTML_NAMED_ENTITIES: Record<string, string> = {
+  nbsp: " ",
+  ensp: " ",
+  emsp: " ",
+  thinsp: " ",
+  ndash: "–",
+  mdash: "—",
+  hellip: "…",
+  copy: "©",
+  reg: "®",
+  trade: "™",
+  laquo: "«",
+  raquo: "»",
+  lsquo: "‘",
+  rsquo: "’",
+  ldquo: "“",
+  rdquo: "”",
+  sbquo: "‚",
+  bdquo: "„",
+  middot: "·",
+  bull: "•",
+  deg: "°",
+  plusmn: "±",
+  times: "×",
+  divide: "÷",
+  cent: "¢",
+  pound: "£",
+  euro: "€",
+  yen: "¥",
+  sect: "§",
+  para: "¶",
+  larr: "←",
+  uarr: "↑",
+  rarr: "→",
+  darr: "↓",
+  harr: "↔",
+  hArr: "⇔",
+  rArr: "⇒",
+  lArr: "⇐",
+  iexcl: "¡",
+  iquest: "¿",
+  shy: "­",
+};
+
+function decodeNamedHtmlEntities(input: string): string {
+  // Split on CDATA boundaries; only decode in the non-CDATA segments so
+  // verbatim source code inside `<![CDATA[ ... ]]>` is left alone.
+  const parts = input.split(/(<!\[CDATA\[[\s\S]*?\]\]>)/);
+  for (let i = 0; i < parts.length; i += 1) {
+    const part = parts[i];
+    if (part === undefined || part.startsWith("<![CDATA[")) continue;
+    parts[i] = part.replace(/&([a-zA-Z][a-zA-Z0-9]*);/g, (match, name: string) => {
+      const ch = HTML_NAMED_ENTITIES[name];
+      return ch !== undefined ? ch : match;
+    });
+  }
+  return parts.join("");
+}
+
+const NAMESPACE_WRAPPER_OPEN =
+  '<root xmlns:ac="http://atlassian.com/content" xmlns:ri="http://atlassian.com/resource/identifier">';
+const NAMESPACE_WRAPPER_CLOSE = "</root>";
+
+function parseXhtmlFragment(xhtml: string): ParentNode {
+  const wrapped = NAMESPACE_WRAPPER_OPEN + decodeNamedHtmlEntities(xhtml) + NAMESPACE_WRAPPER_CLOSE;
+  const parser = new DOMParser({
+    onError: () => {
+      /* swallow xmldom's noisy stderr for non-fatal issues */
+    },
+  });
+  const doc = parser.parseFromString(wrapped, "text/xml");
+  const documentElement = doc.documentElement as unknown as ParentNode | null;
+  if (documentElement === null) {
+    return { childNodes: emptyChildNodes() } as unknown as ParentNode;
+  }
+  return documentElement;
+}
+
+const EMPTY_ITERATOR: Iterable<DomNode> = {
+  [Symbol.iterator]: () =>
+    ({ next: () => ({ done: true, value: undefined }) }) as Iterator<DomNode>,
+};
+function emptyChildNodes() {
+  return { length: 0, item: () => null, ...EMPTY_ITERATOR };
+}
+
 function isElement(node: ChildNode | ParentNode): node is Element {
-  return "tagName" in node;
+  return node.nodeType === ELEMENT_NODE;
 }
 
 function isText(node: ChildNode): node is TextNode {
-  return node.nodeName === "#text";
+  return node.nodeType === TEXT_NODE || node.nodeType === CDATA_SECTION_NODE;
+}
+
+function textValue(node: TextNode): string {
+  return node.nodeValue ?? "";
 }
 
 function localTag(el: Element): string {
-  const tag = el.tagName;
-  const colon = tag.indexOf(":");
-  return colon >= 0 ? tag.slice(colon + 1) : tag;
+  // xmldom keeps the `ac:` prefix in tagName; localName is the suffix.
+  return el.localName ?? el.tagName;
 }
 
 function getAttr(el: Element, name: string, prefix?: string): string {
-  for (const attr of el.attrs) {
+  const attrs = el.attributes;
+  for (let i = 0; i < attrs.length; i += 1) {
+    const attr = attrs.item(i);
+    if (!attr) continue;
     if (prefix !== undefined) {
-      if (attr.prefix === prefix && attr.name === name) return attr.value;
-    } else if (!attr.prefix && attr.name === name) {
-      return attr.value;
+      if (attr.prefix === prefix && attr.localName === name) return attr.value;
+    } else {
+      const attrPrefix = attr.prefix;
+      const attrLocal = attr.localName ?? attr.name;
+      if ((attrPrefix === null || attrPrefix === "") && attrLocal === name) return attr.value;
     }
   }
   return "";
 }
 
+function* childNodesOf(node: ParentNode): Generator<DomNode> {
+  const children = node.childNodes;
+  for (let i = 0; i < children.length; i += 1) {
+    const child = children.item(i);
+    if (child !== null) yield child;
+  }
+}
+
 function elementChildren(node: ParentNode): Element[] {
   const out: Element[] = [];
-  for (const child of node.childNodes) {
+  for (const child of childNodesOf(node)) {
     if (isElement(child)) out.push(child);
   }
   return out;
@@ -187,31 +319,29 @@ function elementChildren(node: ParentNode): Element[] {
 
 function allText(node: ParentNode): string {
   let acc = "";
-  for (const child of node.childNodes) {
+  for (const child of childNodesOf(node)) {
     if (isElement(child)) {
       acc += allText(child);
     } else if (isText(child)) {
-      acc += child.value;
+      acc += textValue(child);
     }
   }
   return acc;
 }
 
 function serialize(node: Element): string {
-  // parse5's tree adapter serializer is unexposed; wrap in a fragment for
-  // serializer compatibility. Falls back to a minimal reconstruction when
-  // serialization fails.
   try {
-    const fragment: DefaultTreeAdapterTypes.DocumentFragment = {
-      nodeName: "#document-fragment",
-      childNodes: [node],
-    } as unknown as DefaultTreeAdapterTypes.DocumentFragment;
-    return parse5.serialize(fragment);
+    return new XMLSerializer().serializeToString(
+      node as unknown as Parameters<XMLSerializer["serializeToString"]>[0],
+    );
   } catch {
-    const attrs = node.attrs
-      .map((a) => `${a.prefix ? `${a.prefix}:` : ""}${a.name}="${a.value}"`)
-      .join(" ");
-    return `<${node.tagName}${attrs ? ` ${attrs}` : ""} />`;
+    const attrs: string[] = [];
+    const list = node.attributes;
+    for (let i = 0; i < list.length; i += 1) {
+      const a = list.item(i);
+      if (a) attrs.push(`${a.name}="${a.value}"`);
+    }
+    return `<${node.tagName}${attrs.length > 0 ? ` ${attrs.join(" ")}` : ""} />`;
   }
 }
 
@@ -219,11 +349,11 @@ function serialize(node: Element): string {
 
 function convertChildren(parent: ParentNode, ctx: ConversionContext): NotionBlock[] {
   const blocks: NotionBlock[] = [];
-  for (const child of parent.childNodes) {
+  for (const child of childNodesOf(parent)) {
     if (isElement(child)) {
       blocks.push(...convertElement(child, ctx));
     } else if (isText(child)) {
-      const text = child.value;
+      const text = textValue(child);
       if (text.trim().length > 0) {
         blocks.push(paragraph([textSeg(text.trim())]));
       }
@@ -283,9 +413,10 @@ function convertElement(el: Element, ctx: ConversionContext): NotionBlock[] {
 
 function extractRichText(el: ParentNode, ctx: ConversionContext): RichTextSeg[] {
   const segments: RichTextSeg[] = [];
-  for (const child of el.childNodes) {
+  for (const child of childNodesOf(el)) {
     if (isText(child)) {
-      if (child.value.length > 0) segments.push(textSeg(child.value));
+      const value = textValue(child);
+      if (value.length > 0) segments.push(textSeg(value));
       continue;
     }
     if (!isElement(child)) continue;
@@ -371,9 +502,9 @@ function extractInlineMacro(el: Element, ctx: ConversionContext): RichTextSeg[] 
 // --- Block converters ---
 
 function tryPromoteBlockMacro(pEl: Element, ctx: ConversionContext): NotionBlock[] | null {
-  const firstChild = pEl.childNodes[0];
+  const firstChild = pEl.childNodes.item(0);
   const hasLeadingText =
-    firstChild !== undefined && isText(firstChild) && firstChild.value.trim().length > 0;
+    firstChild !== null && isText(firstChild) && textValue(firstChild).trim().length > 0;
   const children = elementChildren(pEl);
   if (hasLeadingText || children.length !== 1) return null;
 
@@ -382,12 +513,12 @@ function tryPromoteBlockMacro(pEl: Element, ctx: ConversionContext): NotionBlock
 
   // Reject if there's trailing text after the macro.
   let seenTarget = false;
-  for (const node of pEl.childNodes) {
+  for (const node of childNodesOf(pEl)) {
     if (!seenTarget) {
       if (node === only) seenTarget = true;
       continue;
     }
-    if (isText(node) && node.value.trim().length > 0) return null;
+    if (isText(node) && textValue(node).trim().length > 0) return null;
   }
 
   const macroName = getMacroName(only);
@@ -620,9 +751,9 @@ function convertAcImage(el: Element, ctx: ConversionContext): NotionBlock[] {
 
 function convertPre(el: Element): NotionBlock[] {
   const parts: string[] = [];
-  for (const child of el.childNodes) {
+  for (const child of childNodesOf(el)) {
     if (isText(child)) {
-      parts.push(child.value);
+      parts.push(textValue(child));
     } else if (isElement(child)) {
       if (localTag(child) === "br") {
         parts.push("\n");
@@ -767,9 +898,10 @@ function convertList(el: Element, listTag: "ul" | "ol", ctx: ConversionContext):
 
 function extractRichTextFromLi(li: Element, ctx: ConversionContext): RichTextSeg[] {
   const segments: RichTextSeg[] = [];
-  for (const child of li.childNodes) {
+  for (const child of childNodesOf(li)) {
     if (isText(child)) {
-      if (child.value.length > 0) segments.push(textSeg(child.value));
+      const value = textValue(child);
+      if (value.length > 0) segments.push(textSeg(value));
       continue;
     }
     if (!isElement(child)) continue;

--- a/src/converter/converter.ts
+++ b/src/converter/converter.ts
@@ -248,24 +248,23 @@ const NAMESPACE_WRAPPER_CLOSE = "</root>";
 function parseXhtmlFragment(xhtml: string): ParentNode {
   const wrapped = NAMESPACE_WRAPPER_OPEN + decodeNamedHtmlEntities(xhtml) + NAMESPACE_WRAPPER_CLOSE;
   const parser = new DOMParser({
-    onError: () => {
-      /* swallow xmldom's noisy stderr for non-fatal issues */
+    onError: (level: string, message: string) => {
+      if (level === "error" || level === "fatalError") {
+        console.warn(`converter: xhtml parse ${level}: ${message}`);
+      }
     },
   });
   const doc = parser.parseFromString(wrapped, "text/xml");
   const documentElement = doc.documentElement as unknown as ParentNode | null;
   if (documentElement === null) {
+    console.warn("converter: parser returned no documentElement; producing zero blocks");
     return { childNodes: emptyChildNodes() } as unknown as ParentNode;
   }
   return documentElement;
 }
 
-const EMPTY_ITERATOR: Iterable<DomNode> = {
-  [Symbol.iterator]: () =>
-    ({ next: () => ({ done: true, value: undefined }) }) as Iterator<DomNode>,
-};
 function emptyChildNodes() {
-  return { length: 0, item: () => null, ...EMPTY_ITERATOR };
+  return { length: 0, item: () => null };
 }
 
 function isElement(node: ChildNode | ParentNode): node is Element {
@@ -329,10 +328,23 @@ function allText(node: ParentNode): string {
   return acc;
 }
 
+// Strip auto-injected wrapper namespaces. xmldom's XMLSerializer re-emits the
+// inherited xmlns:ac/xmlns:ri declarations from the synthetic <root> wrapper
+// onto the outermost serialized element; the original Confluence input never
+// declares these on inner elements, so removing them keeps contextXhtml
+// byte-equivalent with the Python ElementTree baseline.
+function stripWrapperNamespaces(serialized: string): string {
+  return serialized
+    .replace(/\s+xmlns:ac="http:\/\/atlassian\.com\/content"/g, "")
+    .replace(/\s+xmlns:ri="http:\/\/atlassian\.com\/resource\/identifier"/g, "");
+}
+
 function serialize(node: Element): string {
   try {
-    return new XMLSerializer().serializeToString(
-      node as unknown as Parameters<XMLSerializer["serializeToString"]>[0],
+    return stripWrapperNamespaces(
+      new XMLSerializer().serializeToString(
+        node as unknown as Parameters<XMLSerializer["serializeToString"]>[0],
+      ),
     );
   } catch {
     const attrs: string[] = [];

--- a/src/converter/tableRules.ts
+++ b/src/converter/tableRules.ts
@@ -7,13 +7,63 @@
 
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
-import * as parse5 from "parse5";
-import type { DefaultTreeAdapterTypes } from "parse5";
+import { DOMParser } from "@xmldom/xmldom";
 import { type NotionPropertyType, type TableRuleSet, TableRuleSetSchema } from "./schemas.js";
 
-type Element = DefaultTreeAdapterTypes.Element;
-type ChildNode = DefaultTreeAdapterTypes.ChildNode;
-type ParentNode = DefaultTreeAdapterTypes.ParentNode;
+interface DomNode {
+  readonly nodeType: number;
+  readonly nodeName: string;
+  readonly nodeValue: string | null;
+  readonly childNodes: { length: number; item(i: number): DomNode | null };
+}
+interface Element extends DomNode {
+  readonly tagName: string;
+  readonly localName: string;
+}
+type ParentNode = DomNode;
+type ChildNode = DomNode;
+
+const ELEMENT_NODE = 1;
+const TEXT_NODE = 3;
+const CDATA_SECTION_NODE = 4;
+
+const NAMESPACE_WRAPPER_OPEN =
+  '<root xmlns:ac="http://atlassian.com/content" xmlns:ri="http://atlassian.com/resource/identifier">';
+const NAMESPACE_WRAPPER_CLOSE = "</root>";
+
+const HTML_NAMED_ENTITIES: Record<string, string> = {
+  nbsp: " ",
+  ensp: " ",
+  emsp: " ",
+  thinsp: " ",
+  ndash: "–",
+  mdash: "—",
+  hellip: "…",
+  copy: "©",
+  reg: "®",
+  trade: "™",
+  laquo: "«",
+  raquo: "»",
+  lsquo: "‘",
+  rsquo: "’",
+  ldquo: "“",
+  rdquo: "”",
+  middot: "·",
+  bull: "•",
+};
+
+function decodeNamedHtmlEntities(input: string): string {
+  const parts = input.split(/(<!\[CDATA\[[\s\S]*?\]\]>)/);
+  for (let i = 0; i < parts.length; i += 1) {
+    const part = parts[i];
+    if (part === undefined || part.startsWith("<![CDATA[")) continue;
+    parts[i] = part.replace(/&([a-zA-Z][a-zA-Z0-9]*);/g, (match, name: string) => {
+      const ch = HTML_NAMED_ENTITIES[name];
+      return ch !== undefined ? ch : match;
+    });
+  }
+  return parts.join("");
+}
 
 const DATE_RE = /^(?:\d{4}[-/.]\d{1,2}[-/.]\d{1,2}|\d{1,2}[-/.]\d{1,2}[-/.]\d{4})$/;
 const SELECT_MAX_DISTINCT = 5;
@@ -27,15 +77,27 @@ export function normalizeHeaderSignature(headers: string[]): string {
 }
 
 function isElement(node: ChildNode | ParentNode): node is Element {
-  return "tagName" in node;
+  return node.nodeType === ELEMENT_NODE;
+}
+
+function* childNodesOf(node: ParentNode): Generator<ChildNode> {
+  const list = node.childNodes;
+  for (let i = 0; i < list.length; i += 1) {
+    const child = list.item(i);
+    if (child !== null) yield child;
+  }
 }
 
 function elementChildren(node: ParentNode): Element[] {
-  return node.childNodes.filter(isElement);
+  const out: Element[] = [];
+  for (const child of childNodesOf(node)) {
+    if (isElement(child)) out.push(child);
+  }
+  return out;
 }
 
 function* walkElements(node: ParentNode): Generator<Element> {
-  for (const child of node.childNodes) {
+  for (const child of childNodesOf(node)) {
     if (isElement(child)) {
       yield child;
       yield* walkElements(child);
@@ -45,11 +107,11 @@ function* walkElements(node: ParentNode): Generator<Element> {
 
 function textOf(node: ParentNode): string {
   let acc = "";
-  for (const child of node.childNodes) {
+  for (const child of childNodesOf(node)) {
     if (isElement(child)) {
       acc += textOf(child);
-    } else if (child.nodeName === "#text") {
-      acc += child.value;
+    } else if (child.nodeType === TEXT_NODE || child.nodeType === CDATA_SECTION_NODE) {
+      acc += child.nodeValue ?? "";
     }
   }
   return acc;
@@ -61,7 +123,12 @@ function collapseWhitespace(text: string): string {
 
 function parseFragmentSafe(xhtml: string): ParentNode | null {
   try {
-    return parse5.parseFragment(xhtml);
+    const wrapped =
+      NAMESPACE_WRAPPER_OPEN + decodeNamedHtmlEntities(xhtml) + NAMESPACE_WRAPPER_CLOSE;
+    const parser = new DOMParser({ onError: () => {} });
+    const doc = parser.parseFromString(wrapped, "text/xml");
+    const root = doc.documentElement as unknown as ParentNode | null;
+    return root;
   } catch {
     return null;
   }

--- a/src/converter/tableRules.ts
+++ b/src/converter/tableRules.ts
@@ -31,6 +31,11 @@ const NAMESPACE_WRAPPER_OPEN =
   '<root xmlns:ac="http://atlassian.com/content" xmlns:ri="http://atlassian.com/resource/identifier">';
 const NAMESPACE_WRAPPER_CLOSE = "</root>";
 
+// Mirror of converter.ts's HTML_NAMED_ENTITIES — kept in sync deliberately
+// (per ADR allowance to duplicate small helpers across these two files).
+// A divergent map would cause rule inference to see literal `&deg;` while
+// converter rendering decodes it to `°`, producing different column-type
+// guesses than the rendered output.
 const HTML_NAMED_ENTITIES: Record<string, string> = {
   nbsp: " ",
   ensp: " ",
@@ -48,8 +53,31 @@ const HTML_NAMED_ENTITIES: Record<string, string> = {
   rsquo: "’",
   ldquo: "“",
   rdquo: "”",
+  sbquo: "‚",
+  bdquo: "„",
   middot: "·",
   bull: "•",
+  deg: "°",
+  plusmn: "±",
+  times: "×",
+  divide: "÷",
+  cent: "¢",
+  pound: "£",
+  euro: "€",
+  yen: "¥",
+  sect: "§",
+  para: "¶",
+  larr: "←",
+  uarr: "↑",
+  rarr: "→",
+  darr: "↓",
+  harr: "↔",
+  hArr: "⇔",
+  rArr: "⇒",
+  lArr: "⇐",
+  iexcl: "¡",
+  iquest: "¿",
+  shy: "­",
 };
 
 function decodeNamedHtmlEntities(input: string): string {
@@ -125,9 +153,18 @@ function parseFragmentSafe(xhtml: string): ParentNode | null {
   try {
     const wrapped =
       NAMESPACE_WRAPPER_OPEN + decodeNamedHtmlEntities(xhtml) + NAMESPACE_WRAPPER_CLOSE;
-    const parser = new DOMParser({ onError: () => {} });
+    const parser = new DOMParser({
+      onError: (level: string, message: string) => {
+        if (level === "error" || level === "fatalError") {
+          console.warn(`tableRules: xhtml parse ${level}: ${message}`);
+        }
+      },
+    });
     const doc = parser.parseFromString(wrapped, "text/xml");
     const root = doc.documentElement as unknown as ParentNode | null;
+    if (root === null) {
+      console.warn("tableRules: parser returned no documentElement; skipping table");
+    }
     return root;
   } catch {
     return null;

--- a/tests/converter/converter.test.ts
+++ b/tests/converter/converter.test.ts
@@ -1,15 +1,35 @@
 // Failing unit tests for src/converter/converter.ts (issue item 5). The
 // tests in this file are the Red phase for the main converter port; task:4
 // makes them Green. They cover parse5 XML-mode namespace handling, entity
-// decoding, macro dispatch specificity, and the unsupportedMacro fallback.
+// decoding, macro dispatch specificity, the unsupportedMacro fallback, and
+// CDATA preservation (issue #165).
 
 import { describe, expect, it } from "vitest";
+import type { FinalRuleset } from "../../src/agentOutput/finalRuleset.js";
 import { convertXhtmlToNotionBlocks } from "../../src/converter/converter.js";
 import { createMockResolver } from "../fixtures/mockResolver.js";
 
-function convert(xhtml: string) {
+function convert(xhtml: string, ruleset?: FinalRuleset) {
   const resolver = createMockResolver();
-  return convertXhtmlToNotionBlocks(xhtml, { resolver, pageId: "1" });
+  const options = ruleset ? { resolver, pageId: "1", ruleset } : { resolver, pageId: "1" };
+  return convertXhtmlToNotionBlocks(xhtml, options);
+}
+
+function rulesetWith(ids: string[]): FinalRuleset {
+  return {
+    source: "tests/converter/converter.test.ts",
+    rules: ids.map((rule_id) => ({
+      rule_id,
+      source_pattern_id: rule_id.replace(/^rule:/, ""),
+      source_description: "test rule",
+      notion_block_type: "paragraph",
+      mapping_description: "test rule",
+      example_input: "<x/>",
+      example_output: { type: "paragraph", paragraph: { rich_text: [] } },
+      confidence: "high",
+      enabled: true,
+    })),
+  };
 }
 
 function firstParagraphText(blocks: Array<Record<string, unknown>>): string {
@@ -98,6 +118,44 @@ describe("convertXhtmlToNotionBlocks — macro handler dispatch order", () => {
     expect(
       result.unresolved.find((item) => item.kind === "macro" && item.identifier === "info"),
     ).toBeUndefined();
+  });
+});
+
+describe("convertXhtmlToNotionBlocks — CDATA preservation (issue #165)", () => {
+  it("preserves CDATA-wrapped text inside ac:plain-text-link-body as the link display text", () => {
+    const xhtml =
+      '<p><ac:link><ri:page ri:content-title="Real Page Title" /><ac:plain-text-link-body><![CDATA[Display Override]]></ac:plain-text-link-body></ac:link></p>';
+    const result = convert(xhtml);
+    const block = result.blocks[0] as {
+      type?: string;
+      paragraph?: { rich_text?: Array<{ text?: { content?: string } }> };
+    };
+    expect(block.type).toBe("paragraph");
+    const segments = block.paragraph?.rich_text ?? [];
+    const joined = segments.map((s) => s.text?.content ?? "").join("");
+    expect(joined).toBe("Display Override");
+    expect(joined).not.toBe("Real Page Title");
+  });
+
+  it("preserves CDATA-wrapped source inside ac:plain-text-body of a code macro verbatim", () => {
+    const xhtml =
+      '<ac:structured-macro ac:name="code"><ac:parameter ac:name="language">javascript</ac:parameter><ac:plain-text-body><![CDATA[const greet = (name) => `Hello, ${name}!`;\nconsole.log(greet("world"));]]></ac:plain-text-body></ac:structured-macro>';
+    const result = convert(xhtml, rulesetWith(["rule:macro:code"]));
+    expect(result.blocks).toHaveLength(1);
+    const block = result.blocks[0] as {
+      type?: string;
+      code?: {
+        language?: string;
+        rich_text?: Array<{ text?: { content?: string } }>;
+      };
+    };
+    expect(block.type).toBe("code");
+    expect(block.code?.language).toBe("javascript");
+    const content = block.code?.rich_text?.[0]?.text?.content ?? "";
+    expect(content).toBe(
+      'const greet = (name) => `Hello, ${name}!`;\nconsole.log(greet("world"));',
+    );
+    expect(content).not.toContain("]]>");
   });
 });
 

--- a/tests/converter/equivalence.test.ts
+++ b/tests/converter/equivalence.test.ts
@@ -94,15 +94,20 @@ function discoverFixtures(): { id: string; xhtmlPath: string; expectedPath: stri
 
 const fixtures = discoverFixtures();
 
-// Fixtures where the TS port is known to diverge from the Python baseline.
-// All four are caused by parse5 running in HTML5 (not XML) mode: HTML5
-// treats `<![CDATA[ ... ]]>` as a bogus comment, so any text inside CDATA
-// is dropped or misread. The Python converter uses ElementTree XML mode
-// which decodes CDATA into a normal text node. Tracked alongside the
-// converter parse-mode follow-up — see `output/dev/preflight-drift.md` →
-// "Known TS port divergences". Re-enable each id by removing it from this
-// set once the underlying converter behaviour matches Python.
-const KNOWN_FAILING_IDS = new Set(["27821303", "29130800", "90000001", "90000007"]);
+// Fixture `29130800` still diverges from the Python baseline because the TS
+// port emits a typed `unsupportedMacro` block for unknown macros (e.g. the
+// `drawio` macro in this fixture), while the Python converter falls through
+// to a paragraph with `[macro_name] text`. That's a deliberate TS-port
+// design choice (see the `unsupportedMacro` fallback in
+// `src/converter/converter.ts`) — not a parser issue. Tracking the broader
+// fallback alignment as a separate follow-up; re-enable `29130800` once the
+// fallback behaviour is reconciled.
+//
+// The other three fixtures previously pinned (27821303, 90000001, 90000007)
+// were CDATA-handling divergences caused by parse5 running in HTML5 mode;
+// after the parser swap to `@xmldom/xmldom` in `text/xml` mode (issue #165)
+// they match the Python baseline and have been unpinned.
+const KNOWN_FAILING_IDS = new Set(["29130800"]);
 
 describe("converter equivalence vs Python baseline", () => {
   let suiteStart = 0;


### PR DESCRIPTION
## Summary

Automated implementation for #165.

Closes #165

## Pipeline

Generated by `scripts/develop.sh 165` — Plan, Implement, Test, Review, Fix, Verify, PR.

## Artifacts

- Plan: `output/dev/plan.json`
- Review: `output/dev/review.json`

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes
- [ ] Manual review of changes against issue requirements