### PR TITLE
feat(mcp): read-only handlers (fetch_page, list_runs, get_run_report)

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -7,6 +7,8 @@
 // their CallToolRequestSchema branches throw "not implemented" and are
 // carved out into the follow-up issues described in plan.json.
 
+import { readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import {
   CallToolRequestSchema,
@@ -17,7 +19,9 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import type { FinalRuleset } from "../agentOutput/finalRuleset.js";
+import type { ConfluenceAdapter } from "../confluence/client.js";
 import { convertXhtmlToConversionResult } from "../converter/convertPage.js";
+import { parseConfluenceUrl } from "../url.js";
 
 interface ToolDefinition {
   name: string;
@@ -180,6 +184,13 @@ export interface CreateServerOptions {
    * same fallback the CLI uses when no finalized ruleset is available.
    */
   ruleset?: FinalRuleset;
+  /**
+   * Builds a Confluence adapter for read-only tool handlers (c2n_fetch_page).
+   * Tests inject a fake adapter; the production stdio entry wires this from
+   * src/config.ts + src/cli/confluenceEnv.ts. When undefined, c2n_fetch_page
+   * throws InvalidRequest naming the missing env vars.
+   */
+  confluenceFactory?: (overrides?: { baseUrl?: string }) => ConfluenceAdapter;
 }
 
 const ConvertPageInputSchema = z.object({
@@ -188,6 +199,43 @@ const ConvertPageInputSchema = z.object({
   title: z.string().optional(),
 });
 
+const FetchPageInputSchema = z.object({
+  pageIdOrUrl: z.string().min(1),
+  baseUrl: z.string().optional(),
+});
+
+// Both run-read handlers accept an optional `rootDir` so tests can target a tmp
+// directory. The public tools/list schema only documents `slug` for
+// c2n_get_run_report (and `rootDir` on c2n_list_runs); the parity gate is
+// unaffected because the handler tolerates the extra field rather than
+// advertising it.
+const ListRunsInputSchema = z.object({
+  rootDir: z.string().optional(),
+});
+
+const GetRunReportInputSchema = z.object({
+  slug: z.string().min(1),
+  rootDir: z.string().optional(),
+});
+
+function resolveRunsRoot(rootDir: string | undefined): string {
+  return rootDir ?? join(process.cwd(), "output", "runs");
+}
+
+function resolvePageId(pageIdOrUrl: string): string {
+  if (/^\d+$/.test(pageIdOrUrl)) {
+    return pageIdOrUrl;
+  }
+  const parsed = parseConfluenceUrl(pageIdOrUrl);
+  if (parsed.kind === "page" || parsed.kind === "pageId") {
+    return parsed.pageId;
+  }
+  throw new McpError(
+    ErrorCode.InvalidParams,
+    `c2n_fetch_page requires a page ID or a /spaces/<KEY>/pages/<ID>/... URL; got a ${parsed.kind} link.`,
+  );
+}
+
 const EMPTY_RULESET: FinalRuleset = { source: "mcp", rules: [] };
 
 const WRITE_TOOLS = new Set(["c2n_migrate_page"]);
@@ -195,6 +243,7 @@ const WRITE_TOOLS = new Set(["c2n_migrate_page"]);
 export function createServer(options: CreateServerOptions = {}): Server {
   const ruleset = options.ruleset ?? EMPTY_RULESET;
   const allowWrite = options.allowWrite === true;
+  const confluenceFactory = options.confluenceFactory;
   const server = new Server(
     { name: "c2n-mcp", version: "0.1.0" },
     {
@@ -226,6 +275,74 @@ export function createServer(options: CreateServerOptions = {}): Server {
           {
             type: "text",
             text: JSON.stringify(result),
+          },
+        ],
+      };
+    }
+    if (name === "c2n_list_runs") {
+      const parsed = ListRunsInputSchema.parse(args ?? {});
+      const root = resolveRunsRoot(parsed.rootDir);
+      let entries: Array<{ name: string; isDirectory: () => boolean }>;
+      try {
+        entries = await readdir(root, { withFileTypes: true });
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+          return { content: [{ type: "text", text: JSON.stringify([]) }] };
+        }
+        throw err;
+      }
+      const slugs = entries
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name)
+        .sort();
+      return { content: [{ type: "text", text: JSON.stringify(slugs) }] };
+    }
+    if (name === "c2n_get_run_report") {
+      const parsed = GetRunReportInputSchema.parse(args ?? {});
+      const root = resolveRunsRoot(parsed.rootDir);
+      const reportPath = join(root, parsed.slug, "report.md");
+      let body: string;
+      try {
+        body = await readFile(reportPath, "utf8");
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+          throw new McpError(
+            ErrorCode.InvalidParams,
+            `No report.md found for run slug "${parsed.slug}" under ${root}.`,
+          );
+        }
+        throw err;
+      }
+      return { content: [{ type: "text", text: body }] };
+    }
+    if (name === "c2n_fetch_page") {
+      if (!confluenceFactory) {
+        throw new McpError(
+          ErrorCode.InvalidRequest,
+          "c2n_fetch_page requires CONFLUENCE_BASE_URL, CONFLUENCE_EMAIL, and CONFLUENCE_API_TOKEN to be set in the server environment.",
+        );
+      }
+      const parsed = FetchPageInputSchema.parse(args ?? {});
+      const pageId = resolvePageId(parsed.pageIdOrUrl);
+      const adapter = confluenceFactory(parsed.baseUrl ? { baseUrl: parsed.baseUrl } : undefined);
+      const page = await adapter.getPage(pageId);
+      const payload = {
+        pageId: page.id,
+        title: page.title,
+        spaceKey: page.space.key,
+        version: page.version.number,
+        body: {
+          storage: {
+            value: page.body.storage.value,
+            representation: page.body.storage.representation,
+          },
+        },
+      };
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(payload),
           },
         ],
       };

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,11 +1,14 @@
 // MCP server contract for c2n.
 //
-// Registers the tools/list and resources/list handlers that constitute the
-// "parity gate" for issue #133: the listing must match
-// tests/fixtures/mcp/{tools-list,resources-list}.json byte-for-byte. The 4
-// resources beyond c2n_convert_page are listed as part of the contract but
-// their CallToolRequestSchema branches throw "not implemented" and are
-// carved out into the follow-up issues described in plan.json.
+// Registers the tools/list and resources/templates/list handlers that
+// constitute the "parity gate" for issue #133: the listings must match
+// tests/fixtures/mcp/{tools-list,resource-templates-list}.json byte-for-byte.
+// Read-only tool handlers (c2n_fetch_page, c2n_convert_page, c2n_list_runs,
+// c2n_get_run_report) are implemented in this file. The write handler
+// c2n_migrate_page is listed for parity but rejected with InvalidRequest
+// unless allowWrite is true; its implementation and the four
+// resource-content (ReadResourceRequestSchema) branches are carved out to
+// follow-up issue #174 (A2).
 
 import { readFile, readdir } from "node:fs/promises";
 import { join } from "node:path";

--- a/tests/mcp/convertPage.test.ts
+++ b/tests/mcp/convertPage.test.ts
@@ -58,18 +58,6 @@ describe("c2n_convert_page tool handler", () => {
     }
   });
 
-  it("rejects an unimplemented tool with an MCP error", async () => {
-    const { client, server } = await connectClient();
-    try {
-      await expect(
-        client.callTool({ name: "c2n_fetch_page", arguments: { pageIdOrUrl: "1" } }),
-      ).rejects.toThrow(/not implemented/i);
-    } finally {
-      await client.close();
-      await server.close();
-    }
-  });
-
   it("rejects write tools when allowWrite is not enabled", async () => {
     const { client, server } = await connectClient();
     try {

--- a/tests/mcp/fetchPage.test.ts
+++ b/tests/mcp/fetchPage.test.ts
@@ -126,6 +126,24 @@ describe("c2n_fetch_page tool handler", () => {
     }
   });
 
+  it("rejects display-style URLs with InvalidParams without calling the adapter", async () => {
+    const { client, server, state } = await connect();
+    try {
+      await expect(
+        client.callTool({
+          name: "c2n_fetch_page",
+          arguments: {
+            pageIdOrUrl: "https://example.atlassian.net/wiki/display/DOCS/Some+Title",
+          },
+        }),
+      ).rejects.toThrow(/display link/i);
+      expect(state.getPageCalls).toEqual([]);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
   it("throws InvalidRequest when no Confluence factory is wired", async () => {
     const { client, server } = await connect({ withFactory: false });
     try {

--- a/tests/mcp/fetchPage.test.ts
+++ b/tests/mcp/fetchPage.test.ts
@@ -1,0 +1,145 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { describe, expect, it } from "vitest";
+import type {
+  ConfluenceAdapter,
+  GetPageTreeOptions,
+  ListSpacePagesOptions,
+  ListSpacePagesResult,
+} from "../../src/confluence/client.js";
+import type { ConfluencePage, PageTreeNode } from "../../src/confluence/schemas.js";
+import { createServer } from "../../src/mcp/server.js";
+
+interface FactoryCall {
+  overrides: { baseUrl?: string } | undefined;
+}
+
+interface FakeAdapterState {
+  factoryCalls: FactoryCall[];
+  getPageCalls: string[];
+}
+
+function buildPage(overrides: Partial<ConfluencePage> = {}): ConfluencePage {
+  return {
+    id: "12345",
+    title: "Sample page",
+    type: "page",
+    space: { key: "DOCS", name: "Docs" },
+    body: { storage: { value: "<p>Hello</p>", representation: "storage" } },
+    version: { number: 7 },
+    ...overrides,
+  } as ConfluencePage;
+}
+
+function fakeAdapter(state: FakeAdapterState, page: ConfluencePage): ConfluenceAdapter {
+  return {
+    async getPage(pageId: string): Promise<ConfluencePage> {
+      state.getPageCalls.push(pageId);
+      return page;
+    },
+    async getPageTree(_rootPageId: string, _options: GetPageTreeOptions): Promise<PageTreeNode> {
+      throw new Error("not used");
+    },
+    async listSpacePages(
+      _spaceKey: string,
+      _options: ListSpacePagesOptions,
+    ): Promise<ListSpacePagesResult> {
+      throw new Error("not used");
+    },
+    async getAttachment(_pageId: string, _filename: string): Promise<Uint8Array> {
+      throw new Error("not used");
+    },
+  };
+}
+
+interface ConnectOptions {
+  page?: ConfluencePage;
+  withFactory?: boolean;
+}
+
+async function connect(opts: ConnectOptions = {}) {
+  const state: FakeAdapterState = { factoryCalls: [], getPageCalls: [] };
+  const page = opts.page ?? buildPage();
+  const server = createServer(
+    opts.withFactory === false
+      ? {}
+      : {
+          confluenceFactory: (overrides) => {
+            state.factoryCalls.push({ overrides });
+            return fakeAdapter(state, page);
+          },
+        },
+  );
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "fetch-page-test-client", version: "0.0.0" });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return { client, server, state };
+}
+
+describe("c2n_fetch_page tool handler", () => {
+  it("calls adapter.getPage with a raw page ID and serialises the response", async () => {
+    const page = buildPage({
+      id: "9001",
+      title: "Direct ID page",
+      space: { key: "TEAM", name: "Team space" },
+      version: { number: 3 },
+      body: { storage: { value: "<p>direct</p>", representation: "storage" } },
+    });
+    const { client, server, state } = await connect({ page });
+    try {
+      const response = await client.callTool({
+        name: "c2n_fetch_page",
+        arguments: { pageIdOrUrl: "9001" },
+      });
+      expect(response.isError).toBeFalsy();
+      expect(state.getPageCalls).toEqual(["9001"]);
+      const content = response.content as Array<{ type: string; text: string }>;
+      expect(content[0]?.type).toBe("text");
+      const parsed = JSON.parse(content[0]?.text ?? "");
+      expect(parsed).toEqual({
+        pageId: "9001",
+        title: "Direct ID page",
+        spaceKey: "TEAM",
+        version: 3,
+        body: { storage: { value: "<p>direct</p>", representation: "storage" } },
+      });
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it("resolves a Confluence URL through src/url.ts before calling adapter.getPage", async () => {
+    const page = buildPage({ id: "555", title: "URL page" });
+    const { client, server, state } = await connect({ page });
+    try {
+      const url = "https://example.atlassian.net/wiki/spaces/DOCS/pages/555/Some+Title";
+      const response = await client.callTool({
+        name: "c2n_fetch_page",
+        arguments: { pageIdOrUrl: url },
+      });
+      expect(response.isError).toBeFalsy();
+      expect(state.getPageCalls).toEqual(["555"]);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it("throws InvalidRequest when no Confluence factory is wired", async () => {
+    const { client, server } = await connect({ withFactory: false });
+    try {
+      await expect(
+        client.callTool({
+          name: "c2n_fetch_page",
+          arguments: { pageIdOrUrl: "1" },
+        }),
+      ).rejects.toThrow(
+        /CONFLUENCE_BASE_URL.*CONFLUENCE_EMAIL.*CONFLUENCE_API_TOKEN|CONFLUENCE_EMAIL.*CONFLUENCE_API_TOKEN/,
+      );
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});

--- a/tests/mcp/runReadHandlers.test.ts
+++ b/tests/mcp/runReadHandlers.test.ts
@@ -1,0 +1,136 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createServer } from "../../src/mcp/server.js";
+
+async function connect() {
+  const server = createServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "run-read-test-client", version: "0.0.0" });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return { client, server };
+}
+
+async function seedRun(rootDir: string, slug: string, reportBody?: string): Promise<void> {
+  const runDir = join(rootDir, slug);
+  await mkdir(runDir, { recursive: true });
+  await writeFile(join(runDir, "source.json"), "{}", "utf8");
+  await writeFile(join(runDir, "status.json"), "{}", "utf8");
+  if (reportBody !== undefined) {
+    await writeFile(join(runDir, "report.md"), reportBody, "utf8");
+  }
+}
+
+describe("c2n_list_runs and c2n_get_run_report handlers", () => {
+  let workspace: string;
+  let runsRoot: string;
+  let originalCwd: string;
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(join(tmpdir(), "c2n-mcp-runs-"));
+    runsRoot = join(workspace, "output", "runs");
+    await mkdir(runsRoot, { recursive: true });
+    originalCwd = process.cwd();
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await rm(workspace, { recursive: true, force: true });
+  });
+
+  describe("c2n_list_runs", () => {
+    it("returns directory names sorted lexicographically when rootDir is provided", async () => {
+      await seedRun(runsRoot, "2025-12-01-alpha", "# alpha\n");
+      await seedRun(runsRoot, "2025-11-15-beta", "# beta\n");
+      const { client, server } = await connect();
+      try {
+        const response = await client.callTool({
+          name: "c2n_list_runs",
+          arguments: { rootDir: runsRoot },
+        });
+        expect(response.isError).toBeFalsy();
+        const content = response.content as Array<{ type: string; text: string }>;
+        expect(content[0]?.type).toBe("text");
+        const parsed = JSON.parse(content[0]?.text ?? "");
+        expect(parsed).toEqual(["2025-11-15-beta", "2025-12-01-alpha"]);
+      } finally {
+        await client.close();
+        await server.close();
+      }
+    });
+
+    it("defaults to ./output/runs relative to process.cwd() when rootDir is omitted", async () => {
+      await seedRun(runsRoot, "default-slug", "# default\n");
+      process.chdir(workspace);
+      const { client, server } = await connect();
+      try {
+        const response = await client.callTool({
+          name: "c2n_list_runs",
+          arguments: {},
+        });
+        const content = response.content as Array<{ type: string; text: string }>;
+        const parsed = JSON.parse(content[0]?.text ?? "");
+        expect(parsed).toEqual(["default-slug"]);
+      } finally {
+        await client.close();
+        await server.close();
+      }
+    });
+
+    it("returns [] when the runs directory does not exist", async () => {
+      const missing = join(workspace, "does-not-exist");
+      const { client, server } = await connect();
+      try {
+        const response = await client.callTool({
+          name: "c2n_list_runs",
+          arguments: { rootDir: missing },
+        });
+        const content = response.content as Array<{ type: string; text: string }>;
+        const parsed = JSON.parse(content[0]?.text ?? "");
+        expect(parsed).toEqual([]);
+      } finally {
+        await client.close();
+        await server.close();
+      }
+    });
+  });
+
+  describe("c2n_get_run_report", () => {
+    it("returns report.md contents for a known slug", async () => {
+      const body = "# Run report\n\nAll pages migrated.\n";
+      await seedRun(runsRoot, "2025-12-01-alpha", body);
+      const { client, server } = await connect();
+      try {
+        const response = await client.callTool({
+          name: "c2n_get_run_report",
+          arguments: { slug: "2025-12-01-alpha", rootDir: runsRoot },
+        });
+        expect(response.isError).toBeFalsy();
+        const content = response.content as Array<{ type: string; text: string }>;
+        expect(content[0]?.type).toBe("text");
+        expect(content[0]?.text).toBe(body);
+      } finally {
+        await client.close();
+        await server.close();
+      }
+    });
+
+    it("throws InvalidParams naming the slug for an unknown run", async () => {
+      const { client, server } = await connect();
+      try {
+        await expect(
+          client.callTool({
+            name: "c2n_get_run_report",
+            arguments: { slug: "missing-run", rootDir: runsRoot },
+          }),
+        ).rejects.toThrow(/missing-run/);
+      } finally {
+        await client.close();
+        await server.close();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Automated implementation for #172.

Closes #172

## Pipeline

Generated by `scripts/develop.sh 172` — Plan, Implement, Test, Review, Fix, Verify, PR.

## Artifacts

- Plan: `output/dev/plan.json`
- Review: `output/dev/review.json`

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes
- [ ] Manual review of changes against issue requirements