### PR TITLE
fix(release): drop ./ prefix from bin paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "type": "module",
   "private": false,
   "bin": {
-    "c2n": "./dist/cli.js",
-    "c2n-mcp": "./dist/mcp.js"
+    "c2n": "dist/cli.js",
+    "c2n-mcp": "dist/mcp.js"
   },
   "files": ["dist", "README.md", "CHANGELOG.md", "LICENSE"],
   "engines": {


### PR DESCRIPTION
## Summary

`npm publish --dry-run` was silently dropping both bin entries:

\`\`\`
npm warn publish "bin[c2n]" script name dist/cli.js was invalid and removed
npm warn publish "bin[c2n-mcp]" script name dist/mcp.js was invalid and removed
\`\`\`

If we shipped 0.1.0 like that, users running \`npm i -g confluence-to-notion\` would receive a package with **no executables** — \`c2n\` and \`c2n-mcp\` would not be on PATH. Discovered while running the #162 cutover dry-run sweep.

Removing the leading \`./\` from each bin path makes npm 11 accept them. The dry-run now reports the tarball with both bins intact.

## Test plan

- [x] \`pnpm test\` (394 / 395)
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`npm publish --dry-run\` no longer prints the bin warnings; \`dist/cli.js\` + \`dist/mcp.js\` are present and the bin section is preserved