### PR TITLE
chore(release): switch Release workflow to tag-driven publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,15 +2,14 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    tags: ["v*.*.*"]
 
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
   id-token: write
 
 jobs:
@@ -33,14 +32,17 @@ jobs:
 
       - run: pnpm build
 
-      - name: Create release PR or publish to npm
-        uses: changesets/action@v1
-        with:
-          publish: pnpm changeset publish
-          version: pnpm changeset version
-          commit: "chore: release"
-          title: "chore: release"
+      - name: Verify tag matches package.json version
+        run: |
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "Tag $GITHUB_REF_NAME (= $TAG_VERSION) does not match package.json version $PKG_VERSION" >&2
+            exit 1
+          fi
+
+      - name: Publish to npm
+        run: pnpm publish --access public --provenance --no-git-checks
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
## Summary

Per #162 Step 2 — the manual 0.1.0 publish has claimed the npm package name (registry now serves `confluence-to-notion@0.1.0`), so the Release workflow can finally flip from "every-push-to-main" (which 404'd because the package name didn't exist yet) to **tag-driven** publishes.

- Trigger changed from `push: branches: [main]` to `push: tags: ['v*.*.*']`.
- The `changesets/action@v1` create-release-PR flow is removed; the workflow is now a straight `pnpm publish --access public --provenance` once the tag exists.
- A guard step fails the run if the tag does not match `package.json` version (`v0.1.1` against `0.1.0` exits 1) so a misnamed tag never publishes.
- Permissions tightened: `contents: read` (no PRs opened anymore); `id-token: write` retained for npm OIDC provenance.

Changesets stays installed and remains the bump tool — developers add a changeset alongside their PR, then `pnpm changeset version` produces the version-bump commit; pushing the resulting `vX.Y.Z` tag triggers this workflow.

Closes #162.

## Test plan

- [x] `npm view confluence-to-notion version` returns `0.1.0` (manual publish landed)
- [ ] Workflow does not run on this PR's merge (no tag) — verify the Release run goes from red to inert/skipped on `main`
- [ ] Pushing a future `v0.1.1` tag triggers the workflow and publishes (verified on the next changeset cycle)