### PR TITLE
chore(release): drop NPM_TOKEN, use npm OIDC trusted publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,4 @@ jobs:
           fi
 
       - name: Publish to npm
-        run: pnpm publish --access public --provenance --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_PROVENANCE: "true"
+        run: npm publish --access public --provenance


### PR DESCRIPTION
## Summary

Switch the auth method only — match the design-readiness-checker setup: trusted publishing via the workflow's OIDC id-token instead of an NPM_TOKEN secret. Install / build / tag-version guard steps unchanged from #181.

- Remove `NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}` (the secret was never configured; trusted publishing makes it unnecessary).
- `pnpm publish --no-git-checks` → `npm publish --access public --provenance`. The npm CLI honours the OIDC id-token automatically; the trusted publisher record on npmjs.com matches it against the workflow.

## Trusted publisher prerequisite

Must be configured at **npmjs.com → confluence-to-notion → Settings → Trusted publishers**:

- Repository owner: `let-sunny`
- Repository: `confluence-to-notion`
- Workflow filename: `release.yml`
- Environment: (empty)

## Test plan

- [ ] PR merge does not trigger Release (no tag) — workflow stays inert on `main`
- [ ] First post-publish tag (e.g. `v0.1.1`) triggers the workflow → publishes via OIDC