### PR TITLE
feat: Align unsupportedMacro fallback so 29130800 (drawio) matches Python baseline

### DIFF
--- a/src/converter/converter.ts
+++ b/src/converter/converter.ts
@@ -568,8 +568,10 @@ function convertMacro(el: Element, ctx: ConversionContext): NotionBlock[] {
   }
 
   // 5. Info / note / warning / tip panels. Gated specific rule first, then
-  // an always-on fallback so info-family macros never appear as
-  // unsupportedMacro — their mapping to callout is semantic, not rule-driven.
+  // an always-on fallback so info-family macros are always routed through
+  // convertPanelMacro instead of falling through to the generic
+  // "[<macro>] <text>" paragraph — their mapping to callout is semantic,
+  // not rule-driven.
   if (PANEL_STYLES[macroName] !== undefined) {
     if (ctx.enabledIds.has(`rule:macro:${macroName}`)) {
       markRuleUsed(ctx, `rule:macro:${macroName}`);
@@ -594,9 +596,12 @@ function convertMacro(el: Element, ctx: ConversionContext): NotionBlock[] {
     }
   }
 
-  // 8. Fallback: typed unsupportedMacro block + unresolved entry. The block
-  // carries the macro name and source xhtml so a later AI pass can replace
-  // it in-place rather than guessing from surrounding context.
+  // 8. Fallback: render as a Python-baseline paragraph "[<macro_name>] <text>"
+  // (or just "[<macro_name>]" when the macro element has no text). Matches
+  // the Python converter's behaviour for unknown macros so equivalence
+  // fixtures stay byte-exact (e.g. drawio in 29130800.expected.json). An
+  // unresolved entry is still recorded so the resolver pass can replace the
+  // paragraph in-place once a mapping is learned.
   const contextXhtml = serialize(el);
   ctx.unresolved.push({
     kind: "macro",
@@ -604,15 +609,9 @@ function convertMacro(el: Element, ctx: ConversionContext): NotionBlock[] {
     sourcePageId: ctx.pageId,
     contextXhtml,
   });
-  return [
-    {
-      type: "unsupportedMacro",
-      unsupportedMacro: {
-        name: macroName,
-        xhtml: contextXhtml,
-      },
-    },
-  ];
+  const text = allText(el).trim();
+  const content = text ? `[${macroName}] ${text}` : `[${macroName}]`;
+  return [paragraph([textSeg(content)])];
 }
 
 function extractIncludePageTitle(el: Element): string {

--- a/tests/converter/converter.test.ts
+++ b/tests/converter/converter.test.ts
@@ -160,20 +160,15 @@ describe("convertXhtmlToNotionBlocks — CDATA preservation (issue #165)", () =>
 });
 
 describe("convertXhtmlToNotionBlocks — unknown macro fallback", () => {
-  it("emits a typed unsupportedMacro block for an unknown macro rather than dropping it silently", () => {
+  it("emits a Python-baseline paragraph '[<macro>] <text>' for an unknown macro rather than dropping it silently", () => {
     const xhtml =
       '<ac:structured-macro ac:name="totally-made-up"><ac:parameter ac:name="x">y</ac:parameter></ac:structured-macro>';
     const result = convert(xhtml);
     expect(result.blocks).toHaveLength(1);
-    const block = result.blocks[0] as {
-      type?: string;
-      unsupportedMacro?: { name?: string; xhtml?: string };
-    };
-    expect(block.type).toBe("unsupportedMacro");
-    expect(block.unsupportedMacro?.name).toBe("totally-made-up");
-    expect(typeof block.unsupportedMacro?.xhtml).toBe("string");
-    expect(block.unsupportedMacro?.xhtml?.length ?? 0).toBeGreaterThan(0);
-    // Matching unresolved entry is recorded so the resolver pass can pick it up.
+    expect(firstParagraphText(result.blocks as Array<Record<string, unknown>>)).toBe(
+      "[totally-made-up] y",
+    );
+    // Matching unresolved entry is still recorded so the resolver pass can replace the paragraph in-place.
     expect(
       result.unresolved.some(
         (item) => item.kind === "macro" && item.identifier === "totally-made-up",

--- a/tests/converter/equivalence.test.ts
+++ b/tests/converter/equivalence.test.ts
@@ -94,20 +94,12 @@ function discoverFixtures(): { id: string; xhtmlPath: string; expectedPath: stri
 
 const fixtures = discoverFixtures();
 
-// Fixture `29130800` still diverges from the Python baseline because the TS
-// port emits a typed `unsupportedMacro` block for unknown macros (e.g. the
-// `drawio` macro in this fixture), while the Python converter falls through
-// to a paragraph with `[macro_name] text`. That's a deliberate TS-port
-// design choice (see the `unsupportedMacro` fallback in
-// `src/converter/converter.ts`) — not a parser issue. Tracking the broader
-// fallback alignment as a separate follow-up; re-enable `29130800` once the
-// fallback behaviour is reconciled.
-//
-// The other three fixtures previously pinned (27821303, 90000001, 90000007)
-// were CDATA-handling divergences caused by parse5 running in HTML5 mode;
-// after the parser swap to `@xmldom/xmldom` in `text/xml` mode (issue #165)
-// they match the Python baseline and have been unpinned.
-const KNOWN_FAILING_IDS = new Set(["29130800"]);
+// No pinned divergences from the Python baseline. The previously pinned
+// fixtures (27821303, 90000001, 90000007) were CDATA-handling cases that
+// were resolved by the parser swap to `@xmldom/xmldom` in `text/xml` mode
+// (issue #165); 29130800 was the last holdout (drawio fallback) and was
+// reconciled by aligning the unknown-macro fallback to the Python
+// "[<macro_name>] <text>" paragraph shape (issue #167).
 
 describe("converter equivalence vs Python baseline", () => {
   let suiteStart = 0;
@@ -130,15 +122,6 @@ describe("converter equivalence vs Python baseline", () => {
       ruleset: BASELINE_RULESET,
       pageId: id,
     });
-    if (KNOWN_FAILING_IDS.has(id)) {
-      // Pin known divergence as a *failed equality* — if the converter
-      // ever starts matching Python on this fixture, this assertion will
-      // flip and prompt removing the id from KNOWN_FAILING_IDS.
-      expect(() => expect(result.blocks).toMatchNotionBlocks(expected)).toThrow(
-        /Notion blocks did not match/,
-      );
-      return;
-    }
     expect(result.blocks).toMatchNotionBlocks(expected);
   });
 });


### PR DESCRIPTION
## Summary

Automated implementation for #167.

Closes #167

## Pipeline

Generated by `scripts/develop.sh 167` — Plan, Implement, Test, Review, Fix, Verify, PR.

## Artifacts

- Plan: `output/dev/plan.json`
- Review: `output/dev/review.json`

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes
- [ ] Manual review of changes against issue requirements