### PR TITLE
chore(release): bump Node to 24 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
           registry-url: https://registry.npmjs.org
 


### PR DESCRIPTION
## Summary

- Bumps `actions/setup-node` to Node 24 in `.github/workflows/release.yml`.
- Node 24 = current Active LTS (Oct 2025 → Oct 2026) and ships npm 11 with the improved trusted-publisher OIDC token-exchange flow.
- Suspect that Node 20's bundled npm 10 is why the v0.1.1 release run hit `404 Not Found - PUT` despite the OIDC id-token + provenance signature being issued.

## Test plan

- [ ] After merge, retag v0.1.1 to retest the release workflow against npm trusted publisher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)