### PR TITLE
fix(cli): resolve bin symlinks when gating direct invocation (0.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project are documented here. This project adheres
 to [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and, once
 published, [Semantic Versioning](https://semver.org/).
 
+## [0.1.2] - 2026-04-26
+
+### Fixed
+
+- `c2n` and `c2n-mcp` bins are no-ops when launched through the npm bin
+  symlink (`node_modules/.bin/<bin>`). The direct-invocation guard compared
+  `process.argv[1]` (symlink path) to `import.meta.url` (real path) without
+  resolving symlinks, so the guard was always false. Both entrypoints now
+  resolve `realpath` on each side before comparing. Affects every consumer
+  using `npm i -g`, `npx`, or any local install — 0.1.0 / 0.1.1 silently
+  exited 0 with no output. Adds a regression test that invokes the built
+  CLI through a symlink to catch this in the future.
+
 ## [0.1.1] - 2026-04-26
 
 First post-release patch. No user-visible behaviour changes; verifies the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "confluence-to-notion",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Auto-discover Confluence → Notion transformation rules using a multi-agent pipeline",
   "license": "MIT",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,12 +1,22 @@
+import { realpathSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createProgram } from "./cli/index.js";
 
 export { createProgram } from "./cli/index.js";
 
+function realpathOrSelf(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return p;
+  }
+}
+
 const entry = process.argv[1];
 const isDirectInvocation =
-  entry !== undefined && resolve(fileURLToPath(import.meta.url)) === resolve(entry);
+  entry !== undefined &&
+  realpathOrSelf(resolve(fileURLToPath(import.meta.url))) === realpathOrSelf(resolve(entry));
 
 if (isDirectInvocation) {
   createProgram().parse(process.argv);

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,8 +1,18 @@
 // c2n-mcp bin entry: connect createServer() to stdio with graceful shutdown.
 
+import { realpathSync } from "node:fs";
+import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createServer } from "./server.js";
+
+function realpathOrSelf(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return p;
+  }
+}
 
 export async function main(): Promise<void> {
   const server = createServer();
@@ -31,7 +41,9 @@ export async function main(): Promise<void> {
 }
 
 const invokedDirectly =
-  typeof process.argv[1] === "string" && fileURLToPath(import.meta.url) === process.argv[1];
+  typeof process.argv[1] === "string" &&
+  realpathOrSelf(resolve(fileURLToPath(import.meta.url))) ===
+    realpathOrSelf(resolve(process.argv[1]));
 if (invokedDirectly) {
   main().catch((error: unknown) => {
     const message = error instanceof Error ? (error.stack ?? error.message) : String(error);

--- a/tests/integration/cli-distribution.test.ts
+++ b/tests/integration/cli-distribution.test.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process";
-import { statSync } from "node:fs";
+import { mkdtempSync, rmSync, statSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
@@ -27,6 +28,22 @@ describe("CLI distribution (built dist/cli.js)", () => {
     expect(out).toContain("fetch");
     expect(out).toContain("convert");
     expect(out).toContain("validate-output");
+  });
+
+  it("runs through a bin-style symlink (npm installs the bin as a symlink to dist/cli.js)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "c2n-symlink-"));
+    const shim = join(dir, "c2n");
+    try {
+      symlinkSync(cliJs, shim);
+      const out = execFileSync(process.execPath, [shim, "--version"], {
+        cwd: dir,
+        encoding: "utf8",
+        env: { ...process.env, NO_COLOR: "1" },
+      }).trim();
+      expect(out).toMatch(/^\d+\.\d+\.\d+/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("keeps published CLI bundles under 2MB each", () => {


### PR DESCRIPTION
## Summary

- 0.1.0 / 0.1.1 are functionally broken on every install path. Both `c2n` and `c2n-mcp` silently exit 0 with no output when launched through the npm bin symlink (`npm i -g`, `npx`, local install).
- Root cause: the direct-invocation guards in `src/cli.ts` and `src/mcp/index.ts` compared `process.argv[1]` (symlink path = `node_modules/.bin/<bin>`) against `fileURLToPath(import.meta.url)` (real path = `node_modules/confluence-to-notion/dist/<bin>.js`) without `realpath`. The guard was always false → `parse(process.argv)` / `main()` never ran.
- Fix: wrap both sides in `realpathSync` before comparing. Adds a regression test that invokes `dist/cli.js` through a symlink in a temp dir.
- Bumps to **0.1.2**.

## Test plan

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm test` all green locally (395 tests pass).
- [x] Local symlink invocation (`node /tmp/c2n-shim --version`) prints `0.1.1` (pre-bump build).
- [ ] After merge + tag `v0.1.2`, verify `npx -p confluence-to-notion@0.1.2 c2n --version` prints a version on a fresh machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)