### PR TITLE
feat: develop pipeline: implementer self-applies protected-paths.patch, orchestrator then conflicts

### DIFF
--- a/.claude/agents/develop/dev-fixer.md
+++ b/.claude/agents/develop/dev-fixer.md
@@ -40,15 +40,16 @@ You are a code fixer agent. Your job is to resolve the issues identified in the 
 
 ### Editing protected paths under `.claude/` — patch handoff
 
-Claude Code blocks writes to most paths under `.claude/` in every permission mode; this guard applies to the Edit/Write tools AND to `Bash` subprocesses in non-interactive (`-p`) sessions. Exempt subtrees: `.claude/commands/**`, `.claude/agents/**`, `.claude/skills/**`, `.claude/worktrees/**`.
+Claude Code blocks Edit/Write to most paths under `.claude/`. Exempt subtrees that the Edit tool can write directly: `.claude/commands/**`, `.claude/agents/**`, `.claude/skills/**`, `.claude/worktrees/**`.
 
-For a non-exempt target (e.g. `.claude/rules/*.md`, `.claude/docs/**`), do NOT attempt a direct write — emit a unified-diff patch to `output/dev/protected-paths.patch` instead. `scripts/develop.sh` applies it with `git apply` after your session exits.
+For a non-exempt target (e.g. `.claude/rules/*.md`, `.claude/docs/**`), the orchestrator (`scripts/develop.sh`) owns the apply step — emit a unified-diff patch and stop. **Do NOT run `git apply` (or any other command that mutates the target file) on this patch yourself, even if Bash appears to allow it.** Only `scripts/develop.sh` applies the patch — between Step 5 and Step 6 (fixer). Self-applying creates a re-apply conflict that breaks the orchestrator (issue #191).
 
 Workflow:
-1. Read the target file (the guard is write-only; reads work fine).
+1. Read the target file (reads are not blocked).
 2. Build a unified diff with `--- a/<path>`, `+++ b/<path>`, `@@ ... @@` hunk headers. Paths are relative to the repo root.
 3. Write the diff to `output/dev/protected-paths.patch` via the Write tool (`output/` is not protected). Multiple protected files go in one patch.
 4. Note the handoff in `fix-log.json` so the reviewer can trace the change.
+5. **Stop.** Do not invoke `git apply`, `patch`, redirected `cat`/`tee`/`sed` writes, or any other path that would modify the target file. The orchestrator runs the apply.
 
 Example `output/dev/protected-paths.patch`:
 

--- a/.claude/agents/develop/dev-implementer.md
+++ b/.claude/agents/develop/dev-implementer.md
@@ -53,15 +53,16 @@ You are a development implementer agent. Your job is to execute each task in the
 
 ### Editing protected paths under `.claude/` — patch handoff
 
-Claude Code blocks writes to most paths under `.claude/` in every permission mode; this guard applies to the Edit/Write tools AND to `Bash` subprocesses in non-interactive (`-p`) sessions. Exempt subtrees: `.claude/commands/**`, `.claude/agents/**`, `.claude/skills/**`, `.claude/worktrees/**`.
+Claude Code blocks Edit/Write to most paths under `.claude/`. Exempt subtrees that the Edit tool can write directly: `.claude/commands/**`, `.claude/agents/**`, `.claude/skills/**`, `.claude/worktrees/**`.
 
-For a non-exempt target (e.g. `.claude/rules/*.md`, `.claude/docs/**`), do NOT attempt a direct write — emit a unified-diff patch to `output/dev/protected-paths.patch` instead. `scripts/develop.sh` applies it with `git apply` after your session exits.
+For a non-exempt target (e.g. `.claude/rules/*.md`, `.claude/docs/**`), the orchestrator (`scripts/develop.sh`) owns the apply step — emit a unified-diff patch and stop. **Do NOT run `git apply` (or any other command that mutates the target file) on this patch yourself, even if Bash appears to allow it.** Only `scripts/develop.sh` applies the patch — between Step 2 and Step 3 (implementer). Self-applying creates a re-apply conflict that breaks the orchestrator (issue #191).
 
 Workflow:
-1. Read the target file (the guard is write-only; reads work fine).
+1. Read the target file (reads are not blocked).
 2. Build a unified diff with `--- a/<path>`, `+++ b/<path>`, `@@ ... @@` hunk headers. Paths are relative to the repo root.
 3. Write the diff to `output/dev/protected-paths.patch` via the Write tool (`output/` is not protected). Multiple protected files go in one patch.
 4. Note the handoff in `implement-log.json` so the reviewer can trace the change.
+5. **Stop.** Do not invoke `git apply`, `patch`, redirected `cat`/`tee`/`sed` writes, or any other path that would modify the target file. The orchestrator runs the apply.
 
 Example `output/dev/protected-paths.patch`:
 

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -102,13 +102,22 @@ run_agent() {
 
 # --- Helper: apply protected-paths.patch emitted by an agent ---
 #
-# Subagents cannot write to most paths under `.claude/` — the write guard applies to
-# Edit/Write tools AND to Bash subprocesses in non-interactive (`-p`) sessions (local
-# smoke tests for #76 confirmed Bash is also blocked). The dev-implementer/dev-fixer
-# prompts instruct agents to emit a unified diff to $OUTPUT_DIR/protected-paths.patch
-# instead; this helper runs `git apply` from the script context (no guard here), then
-# deletes the patch so the next step starts clean. Fails loud — silent skip would let
-# the pipeline produce a PR that omits intended protected-path changes.
+# Subagents emit a unified diff to $OUTPUT_DIR/protected-paths.patch when they
+# need to edit `.claude/` paths that are write-protected from their session.
+# The orchestrator owns the apply step — agents are instructed not to run
+# `git apply` themselves.
+#
+# Idempotency: in practice an agent may still reason its way around the prompt
+# and self-apply the patch (issue #191 — implementer ran `git apply` in its own
+# session, then this helper failed re-applying the same diff). To survive that
+# slip, the helper now:
+#   1. `git apply --check` — if clean, apply (the normal path).
+#   2. Else `git apply --reverse --check` — if clean, the patch is already in
+#      the tree (likely self-applied by the agent). Log it, drop the patch
+#      file, return 0 so the pipeline continues.
+#   3. Else fail loud (preserve patch file, dump first 50 lines) — a genuinely
+#      broken patch must not be silently skipped, or the PR ends up missing
+#      intended protected-path changes.
 apply_protected_patch() {
     local step_num="$1"
     local source_label="$2"
@@ -128,11 +137,24 @@ apply_protected_patch() {
     fi
 
     echo "==> Applying protected-paths.patch (emitted by $source_label)"
-    if git apply --verbose "$patch_file"; then
-        echo "    [protected-patch] applied successfully"
+    if git apply --check "$patch_file" >/dev/null 2>&1; then
+        if git apply --verbose "$patch_file"; then
+            echo "    [protected-patch] applied successfully"
+            rm -f "$patch_file"
+            return 0
+        fi
+        echo "[ERROR] git apply failed on $patch_file (after --check passed)"
+        echo "    Patch preserved for manual inspection. First 50 lines:"
+        head -50 "$patch_file"
+        return 1
+    fi
+
+    if git apply --reverse --check "$patch_file" >/dev/null 2>&1; then
+        echo "    [protected-patch] already applied (likely self-applied by agent) — skipping"
         rm -f "$patch_file"
         return 0
     fi
+
     echo "[ERROR] git apply failed on $patch_file"
     echo "    Patch preserved for manual inspection. First 50 lines:"
     head -50 "$patch_file"

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -151,6 +151,7 @@ apply_protected_patch() {
 
     if git apply --reverse --check "$patch_file" >/dev/null 2>&1; then
         echo "    [protected-patch] already applied (likely self-applied by agent) — skipping"
+        echo "    [protected-patch] handoff artifact was: $patch_file (removed)"
         rm -f "$patch_file"
         return 0
     fi
@@ -484,7 +485,9 @@ Read the plan, then implement each task in order following TDD.
 After implementation, write your decisions and known risks to ${OUTPUT_DIR}/implement-log.json"
 
 # Apply any patch the implementer emitted for protected `.claude/**` paths (see
-# apply_protected_patch docstring). Runs before Step 3 so test/lint sees the changes.
+# apply_protected_patch docstring). Runs after Step 2 returns and before Step 3
+# (test/lint): a plan task that only touched non-exempt `.claude/**` is finalized
+# here via output/dev/protected-paths.patch — not during the agent session.
 apply_protected_patch 2 "dev-implementer" || { echo "[ERROR] Step 2: protected patch apply failed"; exit 1; }
 
 # --- Step 3: Test ---

--- a/tests/cli/applyProtectedPatch.test.ts
+++ b/tests/cli/applyProtectedPatch.test.ts
@@ -10,15 +10,28 @@ const __dirname = dirname(__filename);
 const REPO_ROOT = join(__dirname, "..", "..");
 const SCRIPT_PATH = join(REPO_ROOT, "scripts", "develop.sh");
 
-// Extract the apply_protected_patch function from scripts/develop.sh so we
-// can exercise it without running the whole orchestration. Sourcing the full
-// script would trigger argv parsing, branch creation, and preflight checks.
-function extractApplyProtectedPatch(): string {
-  const content = readFileSync(SCRIPT_PATH, "utf8");
-  const match = content.match(/^apply_protected_patch\(\) \{[\s\S]*?^\}/m);
-  if (!match) throw new Error("apply_protected_patch function not found in scripts/develop.sh");
+const APPLY_PROTECTED_PATCH_FN = "apply_protected_patch";
+
+/** Escape a literal for use inside a RegExp constructor. */
+function escapeRegExpLiteral(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Extract a top-level `name() { ... }` function body from a bash script (first
+ * match only). Used to unit-test helpers without sourcing the full orchestrator.
+ */
+function extractBashNamedFunction(script: string, functionName: string): string {
+  const re = new RegExp(`^${escapeRegExpLiteral(functionName)}\\(\\) \\{[\\s\\S]*?^\\}`, "m");
+  const match = script.match(re);
+  if (!match) {
+    throw new Error(`${functionName} function not found in scripts/develop.sh`);
+  }
   return match[0];
 }
+
+/** Combined stdout/stderr patterns for a loud `git apply` failure from the harness. */
+const GIT_APPLY_LOUD_FAILURE = /git apply failed|does not apply|patch failed/i;
 
 interface RunResult {
   status: number;
@@ -65,6 +78,9 @@ function initGitRepo(dir: string): void {
   execSync("git config user.email test@example.com", { cwd: dir });
   execSync("git config user.name test", { cwd: dir });
   execSync("git config commit.gpgsign false", { cwd: dir });
+  // On Windows, git's default core.autocrlf=true rewrites checked-out files
+  // to CRLF, breaking byte-for-byte assertions on file contents after `git apply`.
+  execSync("git config core.autocrlf false", { cwd: dir });
 }
 
 function commitFile(dir: string, relPath: string, content: string, message: string): void {
@@ -77,7 +93,10 @@ function commitFile(dir: string, relPath: string, content: string, message: stri
 
 describe("apply_protected_patch (scripts/develop.sh)", () => {
   let repoDir: string;
-  const fnCode = extractApplyProtectedPatch();
+  const fnCode = extractBashNamedFunction(
+    readFileSync(SCRIPT_PATH, "utf8"),
+    APPLY_PROTECTED_PATCH_FN,
+  );
 
   beforeEach(() => {
     repoDir = mkdtempSync(join(tmpdir(), "c2n-apply-protected-patch-"));
@@ -126,6 +145,8 @@ describe("apply_protected_patch (scripts/develop.sh)", () => {
     expect(readFileSync(join(repoDir, "target.md"), "utf8")).toBe("new line\n");
     expect(existsSync(join(repoDir, "output", "dev", "protected-paths.patch"))).toBe(false);
     expect(result.stdout).toMatch(/already applied/i);
+    expect(result.stdout).toContain("handoff artifact was:");
+    expect(result.stdout).toContain("protected-paths.patch");
   });
 
   it("(c) genuinely broken patch: fails loud and preserves the patch file", () => {
@@ -143,6 +164,6 @@ describe("apply_protected_patch (scripts/develop.sh)", () => {
     expect(result.status).not.toBe(0);
     expect(existsSync(join(repoDir, "output", "dev", "protected-paths.patch"))).toBe(true);
     const combined = result.stdout + result.stderr;
-    expect(combined).toMatch(/git apply failed|does not apply|patch failed/i);
+    expect(combined).toMatch(GIT_APPLY_LOUD_FAILURE);
   });
 });

--- a/tests/cli/applyProtectedPatch.test.ts
+++ b/tests/cli/applyProtectedPatch.test.ts
@@ -1,0 +1,148 @@
+import { execSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = join(__dirname, "..", "..");
+const SCRIPT_PATH = join(REPO_ROOT, "scripts", "develop.sh");
+
+// Extract the apply_protected_patch function from scripts/develop.sh so we
+// can exercise it without running the whole orchestration. Sourcing the full
+// script would trigger argv parsing, branch creation, and preflight checks.
+function extractApplyProtectedPatch(): string {
+  const content = readFileSync(SCRIPT_PATH, "utf8");
+  const match = content.match(/^apply_protected_patch\(\) \{[\s\S]*?^\}/m);
+  if (!match) throw new Error("apply_protected_patch function not found in scripts/develop.sh");
+  return match[0];
+}
+
+interface RunResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+function runHarness(repoDir: string, patchBody: string | null, fnCode: string): RunResult {
+  const outputDir = join(repoDir, "output", "dev");
+  mkdirSync(outputDir, { recursive: true });
+  const patchFile = join(outputDir, "protected-paths.patch");
+  if (patchBody !== null) {
+    writeFileSync(patchFile, patchBody);
+  }
+
+  const script = `
+set -uo pipefail
+cd "${repoDir}"
+OUTPUT_DIR="output/dev"
+FROM_STEP=1
+${fnCode}
+apply_protected_patch 2 "test"
+`;
+
+  try {
+    const stdout = execSync("bash", {
+      input: script,
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return { status: 0, stdout, stderr: "" };
+  } catch (err) {
+    const e = err as { status?: number; stdout?: Buffer | string; stderr?: Buffer | string };
+    return {
+      status: typeof e.status === "number" ? e.status : 1,
+      stdout: e.stdout ? e.stdout.toString() : "",
+      stderr: e.stderr ? e.stderr.toString() : "",
+    };
+  }
+}
+
+function initGitRepo(dir: string): void {
+  execSync("git init -q", { cwd: dir });
+  execSync("git config user.email test@example.com", { cwd: dir });
+  execSync("git config user.name test", { cwd: dir });
+  execSync("git config commit.gpgsign false", { cwd: dir });
+}
+
+function commitFile(dir: string, relPath: string, content: string, message: string): void {
+  const abs = join(dir, relPath);
+  mkdirSync(dirname(abs), { recursive: true });
+  writeFileSync(abs, content);
+  execSync(`git add -- "${relPath}"`, { cwd: dir });
+  execSync(`git commit -q -m "${message}"`, { cwd: dir });
+}
+
+describe("apply_protected_patch (scripts/develop.sh)", () => {
+  let repoDir: string;
+  const fnCode = extractApplyProtectedPatch();
+
+  beforeEach(() => {
+    repoDir = mkdtempSync(join(tmpdir(), "c2n-apply-protected-patch-"));
+    initGitRepo(repoDir);
+  });
+
+  afterEach(() => {
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it("(a) clean apply: applies the patch and removes the patch file", () => {
+    commitFile(repoDir, "target.md", "old line\n", "init");
+
+    const patch = `--- a/target.md
++++ b/target.md
+@@ -1 +1 @@
+-old line
++new line
+`;
+
+    const result = runHarness(repoDir, patch, fnCode);
+
+    expect(result.status).toBe(0);
+    expect(readFileSync(join(repoDir, "target.md"), "utf8")).toBe("new line\n");
+    expect(existsSync(join(repoDir, "output", "dev", "protected-paths.patch"))).toBe(false);
+    expect(result.stdout).toContain("applied successfully");
+  });
+
+  it("(b) already applied: reverse-check passes, logs 'already applied', removes the patch file, returns 0", () => {
+    // Commit the file already containing the post-patch content. The patch
+    // forward-applies cleanly to "old line" but the working tree already has
+    // "new line", so forward apply fails and reverse apply succeeds — meaning
+    // the patch is already in the tree (likely self-applied by an agent).
+    commitFile(repoDir, "target.md", "new line\n", "already-applied");
+
+    const patch = `--- a/target.md
++++ b/target.md
+@@ -1 +1 @@
+-old line
++new line
+`;
+
+    const result = runHarness(repoDir, patch, fnCode);
+
+    expect(result.status).toBe(0);
+    expect(readFileSync(join(repoDir, "target.md"), "utf8")).toBe("new line\n");
+    expect(existsSync(join(repoDir, "output", "dev", "protected-paths.patch"))).toBe(false);
+    expect(result.stdout).toMatch(/already applied/i);
+  });
+
+  it("(c) genuinely broken patch: fails loud and preserves the patch file", () => {
+    commitFile(repoDir, "target.md", "completely unrelated content\n", "init");
+
+    const patch = `--- a/target.md
++++ b/target.md
+@@ -1 +1 @@
+-old line
++new line
+`;
+
+    const result = runHarness(repoDir, patch, fnCode);
+
+    expect(result.status).not.toBe(0);
+    expect(existsSync(join(repoDir, "output", "dev", "protected-paths.patch"))).toBe(true);
+    const combined = result.stdout + result.stderr;
+    expect(combined).toMatch(/git apply failed|does not apply|patch failed/i);
+  });
+});


### PR DESCRIPTION
## Summary

Automated implementation for #191.

Closes #191

## Pipeline

Generated by `scripts/develop.sh 191` — Plan, Implement, Test, Review, Fix, Verify, PR.

## Artifacts

- Plan: `output/dev/plan.json`
- Review: `output/dev/review.json`

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes
- [ ] Manual review of changes against issue requirements