### PR TITLE
feat: cont: feat(cli): add c2n init + profile-based credential storage (remaining)

### DIFF
--- a/.claude/docs/ADR-00M-cli-surface-freeze.md
+++ b/.claude/docs/ADR-00M-cli-surface-freeze.md
@@ -32,8 +32,9 @@ Captured from `src/confluence_to_notion/cli.py` and
 
 > **Post-freeze additions** appear at the top of this section. `c2n init` is
 > the first post-freeze additive subcommand, introduced by issue #188 (slice 1
-> of credential-storage work). Adding new subcommands continues to require an
-> ADR amendment.
+> of credential-storage work). `c2n auth` (with `confluence` and `notion`
+> subcommands) is the second post-freeze addition, introduced by issue #190
+> (slice 2). Adding new subcommands continues to require an ADR amendment.
 
 ### `c2n init`
 
@@ -45,6 +46,27 @@ Captured from `src/confluence_to_notion/cli.py` and
 | `--confluence-base-url` | TEXT | _none_ | `CONFLUENCE_BASE_URL` | No | Confluence base URL. Prompted in TTY mode if missing; required in non-TTY mode. |
 | `--confluence-email` | TEXT | _none_ | `CONFLUENCE_EMAIL` | No | Confluence account email. Prompted in TTY mode if missing; required in non-TTY mode. |
 | `--confluence-api-token` | TEXT | _none_ | `CONFLUENCE_API_TOKEN` | No | Confluence API token. Prompted in TTY mode if missing; required in non-TTY mode. |
+| `--notion-token` | TEXT | _none_ | `NOTION_TOKEN` | No | Notion integration token. Prompted in TTY mode if missing; required in non-TTY mode. |
+| `--notion-root-page-id` | TEXT | _none_ | `NOTION_ROOT_PAGE_ID` | No | Notion root page ID. Prompted in TTY mode if missing; required in non-TTY mode. |
+
+### `c2n auth confluence`
+
+> Update only the Confluence credentials of an existing profile. Interactive when stdin is a TTY (prompts for missing fields); otherwise non-interactive. The named profile must already exist — this command refuses to create a new profile (use `c2n init` for that).
+
+| Flag | Type | Default | Env fallback | Required | Semantics |
+|---|---|---|---|---|---|
+| `--profile` | TEXT | _none_ | — | No | Profile name to update. Resolution order: this flag, then `C2N_PROFILE`, then `currentProfile` from the config file, then `default`. |
+| `--confluence-base-url` | TEXT | _none_ | `CONFLUENCE_BASE_URL` | No | Confluence base URL. Prompted in TTY mode if missing; required in non-TTY mode. |
+| `--confluence-email` | TEXT | _none_ | `CONFLUENCE_EMAIL` | No | Confluence account email. Prompted in TTY mode if missing; required in non-TTY mode. |
+| `--confluence-api-token` | TEXT | _none_ | `CONFLUENCE_API_TOKEN` | No | Confluence API token. Prompted in TTY mode if missing; required in non-TTY mode. |
+
+### `c2n auth notion`
+
+> Update only the Notion credentials of an existing profile. Interactive when stdin is a TTY (prompts for missing fields); otherwise non-interactive. The named profile must already exist — this command refuses to create a new profile (use `c2n init` for that).
+
+| Flag | Type | Default | Env fallback | Required | Semantics |
+|---|---|---|---|---|---|
+| `--profile` | TEXT | _none_ | — | No | Profile name to update. Resolution order: this flag, then `C2N_PROFILE`, then `currentProfile` from the config file, then `default`. |
 | `--notion-token` | TEXT | _none_ | `NOTION_TOKEN` | No | Notion integration token. Prompted in TTY mode if missing; required in non-TTY mode. |
 | `--notion-root-page-id` | TEXT | _none_ | `NOTION_ROOT_PAGE_ID` | No | Notion root page ID. Prompted in TTY mode if missing; required in non-TTY mode. |
 

--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -1,0 +1,225 @@
+import * as readline from "node:readline/promises";
+import { type Command, Option } from "commander";
+import {
+  type ConfigStoreOptions,
+  type ConfluenceCreds,
+  type NotionCreds,
+  type Profile,
+  getConfigPath,
+  readConfig,
+  resolveProfileName,
+  upsertProfile,
+} from "../configStore.js";
+
+export interface ConfluenceAuthOptions {
+  profile?: string;
+  confluenceBaseUrl?: string;
+  confluenceEmail?: string;
+  confluenceApiToken?: string;
+}
+
+export interface NotionAuthOptions {
+  profile?: string;
+  notionToken?: string;
+  notionRootPageId?: string;
+}
+
+interface FieldSpec<K extends string> {
+  flag: string;
+  prompt: string;
+  optionKey: K;
+}
+
+const CONFLUENCE_FIELDS: FieldSpec<keyof ConfluenceAuthOptions>[] = [
+  {
+    flag: "--confluence-base-url",
+    prompt: "Confluence base URL",
+    optionKey: "confluenceBaseUrl",
+  },
+  {
+    flag: "--confluence-email",
+    prompt: "Confluence account email",
+    optionKey: "confluenceEmail",
+  },
+  {
+    flag: "--confluence-api-token",
+    prompt: "Confluence API token",
+    optionKey: "confluenceApiToken",
+  },
+];
+
+const NOTION_FIELDS: FieldSpec<keyof NotionAuthOptions>[] = [
+  {
+    flag: "--notion-token",
+    prompt: "Notion integration token",
+    optionKey: "notionToken",
+  },
+  {
+    flag: "--notion-root-page-id",
+    prompt: "Notion root page ID",
+    optionKey: "notionRootPageId",
+  },
+];
+
+function resolveConfigDirOpts(): ConfigStoreOptions {
+  const dir = process.env.C2N_CONFIG_DIR?.trim();
+  return dir !== undefined && dir.length > 0 ? { configDir: dir } : {};
+}
+
+async function promptMissing<T extends Record<string, unknown>>(
+  values: T,
+  fields: FieldSpec<keyof T & string>[],
+): Promise<T> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    for (const field of fields) {
+      const current = values[field.optionKey];
+      if (typeof current === "string" && current.length > 0) continue;
+      const answer = (await rl.question(`${field.prompt}: `)).trim();
+      if (answer.length === 0) {
+        throw new Error(`Empty input for ${field.flag}; aborting.`);
+      }
+      (values as Record<string, unknown>)[field.optionKey] = answer;
+    }
+    return values;
+  } finally {
+    rl.close();
+  }
+}
+
+async function resolveFields<T extends Record<string, unknown>>(
+  opts: T,
+  fields: FieldSpec<keyof T & string>[],
+  subcommandLabel: string,
+): Promise<T> {
+  const missing = fields.filter((f) => {
+    const v = opts[f.optionKey];
+    return typeof v !== "string" || v.length === 0;
+  });
+
+  if (missing.length === 0) return opts;
+  if (process.stdin.isTTY) return promptMissing({ ...opts }, fields);
+
+  const flagList = missing.map((f) => f.flag).join(", ");
+  process.stderr.write(
+    `auth ${subcommandLabel}: missing required value(s): ${flagList}. Pass them as flags, set the matching env vars, or run interactively in a TTY.\n`,
+  );
+  process.exit(1);
+  // Unreachable in production; keeps type narrowing happy when process.exit is mocked.
+  throw new Error("process.exit did not terminate");
+}
+
+function requireExistingProfile(
+  name: string,
+  storeOpts: ConfigStoreOptions,
+  subcommandLabel: string,
+): Profile {
+  const cfg = readConfig(storeOpts);
+  const existing = cfg.profiles[name];
+  if (!existing) {
+    process.stderr.write(
+      `auth ${subcommandLabel}: profile '${name}' does not exist; run \`c2n init --profile ${name}\` first.\n`,
+    );
+    process.exit(1);
+    throw new Error("process.exit did not terminate");
+  }
+  return existing;
+}
+
+export async function runConfluenceAuth(opts: ConfluenceAuthOptions): Promise<void> {
+  const storeOpts = resolveConfigDirOpts();
+  const name = resolveProfileName(opts.profile, storeOpts);
+  const existing = requireExistingProfile(name, storeOpts, "confluence");
+
+  const resolved = await resolveFields({ ...opts }, CONFLUENCE_FIELDS, "confluence");
+
+  const confluence: ConfluenceCreds = {
+    baseUrl: resolved.confluenceBaseUrl ?? "",
+    email: resolved.confluenceEmail ?? "",
+    apiToken: resolved.confluenceApiToken ?? "",
+  };
+
+  const next: Profile = { ...existing, confluence };
+  upsertProfile(name, next, storeOpts);
+  const { file } = getConfigPath(storeOpts);
+  process.stdout.write(`auth: updated confluence for profile '${name}' at ${file}\n`);
+}
+
+export async function runNotionAuth(opts: NotionAuthOptions): Promise<void> {
+  const storeOpts = resolveConfigDirOpts();
+  const name = resolveProfileName(opts.profile, storeOpts);
+  const existing = requireExistingProfile(name, storeOpts, "notion");
+
+  const resolved = await resolveFields({ ...opts }, NOTION_FIELDS, "notion");
+
+  const notion: NotionCreds = {
+    token: resolved.notionToken ?? "",
+    rootPageId: resolved.notionRootPageId ?? "",
+  };
+
+  const next: Profile = { ...existing, notion };
+  upsertProfile(name, next, storeOpts);
+  const { file } = getConfigPath(storeOpts);
+  process.stdout.write(`auth: updated notion for profile '${name}' at ${file}\n`);
+}
+
+export function registerAuthCommands(program: Command): void {
+  const auth = program
+    .command("auth")
+    .description("Update credentials for an existing c2n profile (Confluence or Notion).");
+
+  auth
+    .command("confluence")
+    .description("Update only the Confluence credentials of an existing profile.")
+    .addOption(
+      new Option(
+        "--profile <name>",
+        "profile name to update (defaults to C2N_PROFILE or currentProfile)",
+      ),
+    )
+    .addOption(
+      new Option("--confluence-base-url <url>", "Confluence base URL").env("CONFLUENCE_BASE_URL"),
+    )
+    .addOption(
+      new Option("--confluence-email <email>", "Confluence account email").env("CONFLUENCE_EMAIL"),
+    )
+    .addOption(
+      new Option("--confluence-api-token <token>", "Confluence API token").env(
+        "CONFLUENCE_API_TOKEN",
+      ),
+    )
+    .action(async function (this: Command) {
+      const o = this.opts<ConfluenceAuthOptions>();
+      try {
+        await runConfluenceAuth(o);
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        process.stderr.write(`auth confluence: ${msg}\n`);
+        process.exit(1);
+      }
+    });
+
+  auth
+    .command("notion")
+    .description("Update only the Notion credentials of an existing profile.")
+    .addOption(
+      new Option(
+        "--profile <name>",
+        "profile name to update (defaults to C2N_PROFILE or currentProfile)",
+      ),
+    )
+    .addOption(new Option("--notion-token <token>", "Notion integration token").env("NOTION_TOKEN"))
+    .addOption(
+      new Option("--notion-root-page-id <id>", "Notion root page ID").env("NOTION_ROOT_PAGE_ID"),
+    )
+    .action(async function (this: Command) {
+      const o = this.opts<NotionAuthOptions>();
+      try {
+        await runNotionAuth(o);
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        process.stderr.write(`auth notion: ${msg}\n`);
+        process.exit(1);
+      }
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import pkg from "../../package.json" with { type: "json" };
+import { registerAuthCommands } from "./auth.js";
 import { registerConvertCommands } from "./convert.js";
 import { registerDiscoverShim } from "./discover.js";
 import { registerEvalHarness } from "./evalHarness.js";
@@ -26,6 +27,7 @@ export function createProgram(): Command {
     .option("--no-color", "disable ANSI color output");
 
   registerInitCommand(program);
+  registerAuthCommands(program);
   registerFetchCommands(program);
   registerNotionCommands(program);
   registerDiscoverShim(program);

--- a/tests/cli/auth.test.ts
+++ b/tests/cli/auth.test.ts
@@ -1,0 +1,342 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createProgram } from "../../src/cli/index.js";
+
+const ENV_KEYS = [
+  "C2N_CONFIG_DIR",
+  "C2N_PROFILE",
+  "CONFLUENCE_BASE_URL",
+  "CONFLUENCE_EMAIL",
+  "CONFLUENCE_API_TOKEN",
+  "CONFLUENCE_TOKEN",
+  "NOTION_TOKEN",
+  "NOTION_API_TOKEN",
+  "NOTION_ROOT_PAGE_ID",
+] as const;
+
+let tmp: string;
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(async () => {
+  tmp = await mkdtemp(join(tmpdir(), "c2n-auth-"));
+  savedEnv = {};
+  for (const k of ENV_KEYS) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+  process.env.C2N_CONFIG_DIR = tmp;
+});
+
+afterEach(async () => {
+  for (const k of ENV_KEYS) {
+    const v = savedEnv[k];
+    if (v === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = v;
+    }
+  }
+  await rm(tmp, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+const FLAGS_INIT_DEFAULT = [
+  "--confluence-base-url",
+  "https://example.atlassian.net/wiki",
+  "--confluence-email",
+  "user@example.com",
+  "--confluence-api-token",
+  "atl-token-1",
+  "--notion-token",
+  "secret_abc",
+  "--notion-root-page-id",
+  "00000000000000000000000000000000",
+];
+
+const FLAGS_INIT_WORK = [
+  "--confluence-base-url",
+  "https://work.atlassian.net/wiki",
+  "--confluence-email",
+  "work@example.com",
+  "--confluence-api-token",
+  "atl-token-2",
+  "--notion-token",
+  "secret_work",
+  "--notion-root-page-id",
+  "11111111111111111111111111111111",
+];
+
+interface StoredProfile {
+  confluence: { baseUrl: string; email: string; apiToken: string };
+  notion: { token: string; rootPageId: string };
+}
+
+interface StoredConfig {
+  currentProfile: string;
+  profiles: Record<string, StoredProfile>;
+}
+
+async function readStoredConfig(): Promise<StoredConfig> {
+  const raw = await readFile(join(tmp, "config.json"), "utf8");
+  return JSON.parse(raw) as StoredConfig;
+}
+
+async function seedDefaultProfile(): Promise<void> {
+  await createProgram().parseAsync(["node", "c2n", "init", ...FLAGS_INIT_DEFAULT]);
+}
+
+async function seedWorkProfile(): Promise<void> {
+  await createProgram().parseAsync([
+    "node",
+    "c2n",
+    "init",
+    "--profile",
+    "work",
+    ...FLAGS_INIT_WORK,
+  ]);
+}
+
+describe("c2n auth confluence", () => {
+  it("with all three Confluence flags updates only the confluence subtree", async () => {
+    await seedDefaultProfile();
+
+    await createProgram().parseAsync([
+      "node",
+      "c2n",
+      "auth",
+      "confluence",
+      "--confluence-base-url",
+      "https://updated.atlassian.net/wiki",
+      "--confluence-email",
+      "new@example.com",
+      "--confluence-api-token",
+      "atl-token-new",
+    ]);
+
+    const cfg = await readStoredConfig();
+    expect(cfg.profiles.default?.confluence).toEqual({
+      baseUrl: "https://updated.atlassian.net/wiki",
+      email: "new@example.com",
+      apiToken: "atl-token-new",
+    });
+    expect(cfg.profiles.default?.notion).toEqual({
+      token: "secret_abc",
+      rootPageId: "00000000000000000000000000000000",
+    });
+  });
+
+  it("--profile work updates only the work profile", async () => {
+    await seedDefaultProfile();
+    await seedWorkProfile();
+
+    await createProgram().parseAsync([
+      "node",
+      "c2n",
+      "auth",
+      "confluence",
+      "--profile",
+      "work",
+      "--confluence-base-url",
+      "https://work-updated.atlassian.net/wiki",
+      "--confluence-email",
+      "work-new@example.com",
+      "--confluence-api-token",
+      "atl-token-work-new",
+    ]);
+
+    const cfg = await readStoredConfig();
+    expect(cfg.profiles.default?.confluence.email).toBe("user@example.com");
+    expect(cfg.profiles.work?.confluence).toEqual({
+      baseUrl: "https://work-updated.atlassian.net/wiki",
+      email: "work-new@example.com",
+      apiToken: "atl-token-work-new",
+    });
+    // Notion subtree on the work profile is untouched.
+    expect(cfg.profiles.work?.notion.token).toBe("secret_work");
+  });
+
+  it("refuses when the named profile does not exist", async () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const exit = vi.spyOn(process, "exit").mockImplementation(((_code?: number) => {
+      throw new Error("__exit__");
+    }) as never);
+
+    await expect(
+      createProgram().parseAsync([
+        "node",
+        "c2n",
+        "auth",
+        "confluence",
+        "--profile",
+        "missing",
+        "--confluence-base-url",
+        "https://example.atlassian.net/wiki",
+        "--confluence-email",
+        "user@example.com",
+        "--confluence-api-token",
+        "atl-token-1",
+      ]),
+    ).rejects.toThrow("__exit__");
+
+    expect(exit).toHaveBeenCalledWith(1);
+    const errMsg = stderr.mock.calls.map((c) => String(c[0])).join("");
+    expect(errMsg).toMatch(/profile 'missing' does not exist/);
+    expect(errMsg).toMatch(/c2n init/);
+
+    // Config must not have been created with a half-populated profile.
+    await expect(readFile(join(tmp, "config.json"), "utf8")).rejects.toThrow();
+  });
+
+  it("non-TTY without all required flags exits 1 listing the missing flags", async () => {
+    await seedDefaultProfile();
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const exit = vi.spyOn(process, "exit").mockImplementation(((_code?: number) => {
+      throw new Error("__exit__");
+    }) as never);
+
+    const isTty = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: false });
+
+    try {
+      await expect(
+        createProgram().parseAsync([
+          "node",
+          "c2n",
+          "auth",
+          "confluence",
+          // Missing --confluence-email and --confluence-api-token
+          "--confluence-base-url",
+          "https://example.atlassian.net/wiki",
+        ]),
+      ).rejects.toThrow("__exit__");
+
+      expect(exit).toHaveBeenCalledWith(1);
+      const errMsg = stderr.mock.calls.map((c) => String(c[0])).join("");
+      expect(errMsg).toMatch(/--confluence-email/);
+      expect(errMsg).toMatch(/--confluence-api-token/);
+    } finally {
+      Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: isTty });
+    }
+
+    // Confluence subtree on default must remain unchanged.
+    const cfg = await readStoredConfig();
+    expect(cfg.profiles.default?.confluence.email).toBe("user@example.com");
+  });
+});
+
+describe("c2n auth notion", () => {
+  it("with both Notion flags updates only the notion subtree", async () => {
+    await seedDefaultProfile();
+
+    await createProgram().parseAsync([
+      "node",
+      "c2n",
+      "auth",
+      "notion",
+      "--notion-token",
+      "secret_new",
+      "--notion-root-page-id",
+      "22222222222222222222222222222222",
+    ]);
+
+    const cfg = await readStoredConfig();
+    expect(cfg.profiles.default?.notion).toEqual({
+      token: "secret_new",
+      rootPageId: "22222222222222222222222222222222",
+    });
+    expect(cfg.profiles.default?.confluence).toEqual({
+      baseUrl: "https://example.atlassian.net/wiki",
+      email: "user@example.com",
+      apiToken: "atl-token-1",
+    });
+  });
+
+  it("--profile work updates only the work profile", async () => {
+    await seedDefaultProfile();
+    await seedWorkProfile();
+
+    await createProgram().parseAsync([
+      "node",
+      "c2n",
+      "auth",
+      "notion",
+      "--profile",
+      "work",
+      "--notion-token",
+      "secret_work_new",
+      "--notion-root-page-id",
+      "33333333333333333333333333333333",
+    ]);
+
+    const cfg = await readStoredConfig();
+    expect(cfg.profiles.default?.notion.token).toBe("secret_abc");
+    expect(cfg.profiles.work?.notion).toEqual({
+      token: "secret_work_new",
+      rootPageId: "33333333333333333333333333333333",
+    });
+    expect(cfg.profiles.work?.confluence.email).toBe("work@example.com");
+  });
+
+  it("refuses when the named profile does not exist", async () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const exit = vi.spyOn(process, "exit").mockImplementation(((_code?: number) => {
+      throw new Error("__exit__");
+    }) as never);
+
+    await expect(
+      createProgram().parseAsync([
+        "node",
+        "c2n",
+        "auth",
+        "notion",
+        "--profile",
+        "missing",
+        "--notion-token",
+        "secret_x",
+        "--notion-root-page-id",
+        "44444444444444444444444444444444",
+      ]),
+    ).rejects.toThrow("__exit__");
+
+    expect(exit).toHaveBeenCalledWith(1);
+    const errMsg = stderr.mock.calls.map((c) => String(c[0])).join("");
+    expect(errMsg).toMatch(/profile 'missing' does not exist/);
+    expect(errMsg).toMatch(/c2n init/);
+  });
+
+  it("non-TTY without all required flags exits 1 listing the missing flags", async () => {
+    await seedDefaultProfile();
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const exit = vi.spyOn(process, "exit").mockImplementation(((_code?: number) => {
+      throw new Error("__exit__");
+    }) as never);
+
+    const isTty = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: false });
+
+    try {
+      await expect(
+        createProgram().parseAsync([
+          "node",
+          "c2n",
+          "auth",
+          "notion",
+          // Missing --notion-root-page-id
+          "--notion-token",
+          "secret_x",
+        ]),
+      ).rejects.toThrow("__exit__");
+
+      expect(exit).toHaveBeenCalledWith(1);
+      const errMsg = stderr.mock.calls.map((c) => String(c[0])).join("");
+      expect(errMsg).toMatch(/--notion-root-page-id/);
+    } finally {
+      Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: isTty });
+    }
+
+    const cfg = await readStoredConfig();
+    expect(cfg.profiles.default?.notion.token).toBe("secret_abc");
+  });
+});

--- a/tests/cli/surface.test.ts
+++ b/tests/cli/surface.test.ts
@@ -90,7 +90,8 @@ function parseAdr(): Map<string, SubcommandSpec> {
     if (current) specs.set(current.name, current);
   };
 
-  const subHeaderRe = /^###\s+`c2n\s+([a-z-]+)`/;
+  // Allow multi-word command chains like "auth confluence" / "auth notion".
+  const subHeaderRe = /^###\s+`c2n\s+([a-z][a-z0-9-]*(?:\s+[a-z][a-z0-9-]*)*)`/;
   const tableRowRe = /^\|(.+)\|\s*$/;
   const separatorRe = /^\|[\s:|-]+\|\s*$/;
 
@@ -123,8 +124,11 @@ function parseAdr(): Map<string, SubcommandSpec> {
   return specs;
 }
 
-const EXPECTED_SUBCOMMANDS = [
+// Frozen set of leaf command chains as documented in ADR-00M.
+const EXPECTED_LEAVES = [
   "init",
+  "auth confluence",
+  "auth notion",
   "fetch",
   "fetch-tree",
   "notion-ping",
@@ -138,7 +142,16 @@ const EXPECTED_SUBCOMMANDS = [
   "migrate-tree-pages",
 ] as const;
 
-function getSubcommands(program: Command): Map<string, Command> {
+function expectedTopLevel(): string[] {
+  const set = new Set<string>();
+  for (const chain of EXPECTED_LEAVES) {
+    const head = chain.split(/\s+/)[0];
+    if (head) set.add(head);
+  }
+  return [...set].sort();
+}
+
+function getTopLevel(program: Command): Map<string, Command> {
   const map = new Map<string, Command>();
   for (const cmd of program.commands) {
     map.set(cmd.name(), cmd);
@@ -146,31 +159,40 @@ function getSubcommands(program: Command): Map<string, Command> {
   return map;
 }
 
+function walkChain(program: Command, chain: string): Command | undefined {
+  const parts = chain.split(/\s+/);
+  let cur: Command | undefined = program;
+  for (const part of parts) {
+    if (!cur) return undefined;
+    cur = cur.commands.find((c) => c.name() === part);
+  }
+  return cur;
+}
+
 describe("CLI surface: ADR-00M compliance", () => {
   const adrSpecs = parseAdr();
   const program = createProgram();
-  const actual = getSubcommands(program);
+  const topLevel = getTopLevel(program);
 
-  it("ADR-00M lists every expected subcommand", () => {
+  it("ADR-00M lists every expected leaf subcommand", () => {
     const parsed = [...adrSpecs.keys()].sort();
-    const expected = [...EXPECTED_SUBCOMMANDS].sort();
+    const expected = [...EXPECTED_LEAVES].sort();
     expect(parsed).toEqual(expected);
   });
 
-  it("registers exactly the frozen subcommand set (no drift)", () => {
-    const actualNames = [...actual.keys()].sort();
-    const expectedNames = [...EXPECTED_SUBCOMMANDS].sort();
-    expect(actualNames).toEqual(expectedNames);
+  it("registers exactly the frozen top-level subcommand set (no drift)", () => {
+    const actualNames = [...topLevel.keys()].sort();
+    expect(actualNames).toEqual(expectedTopLevel());
   });
 
-  for (const subName of EXPECTED_SUBCOMMANDS) {
-    describe(`c2n ${subName}`, () => {
-      const spec = adrSpecs.get(subName);
-      const cmd = actual.get(subName);
+  for (const chain of EXPECTED_LEAVES) {
+    describe(`c2n ${chain}`, () => {
+      const spec = adrSpecs.get(chain);
+      const cmd = walkChain(program, chain);
 
       it("is registered", () => {
-        expect(cmd, `subcommand ${subName} missing`).toBeDefined();
-        expect(spec, `ADR spec for ${subName} missing`).toBeDefined();
+        expect(cmd, `subcommand ${chain} missing`).toBeDefined();
+        expect(spec, `ADR spec for ${chain} missing`).toBeDefined();
       });
 
       it("exposes exactly the ADR flag set", () => {
@@ -194,7 +216,7 @@ describe("CLI surface: ADR-00M compliance", () => {
         if (!cmd || !spec) return;
         for (const flag of spec.flags) {
           const opt = cmd.options.find((o) => o.long === flag.name);
-          expect(opt, `option ${flag.name} missing on ${subName}`).toBeDefined();
+          expect(opt, `option ${flag.name} missing on ${chain}`).toBeDefined();
           if (!opt) continue;
 
           if (flag.default === undefined) {
@@ -202,18 +224,18 @@ describe("CLI surface: ADR-00M compliance", () => {
             // user-supplied default) when no default is set. Accept either.
             expect(
               opt.defaultValue === undefined || opt.defaultValue === false,
-              `${subName} ${flag.name} expected no default, got ${String(opt.defaultValue)}`,
+              `${chain} ${flag.name} expected no default, got ${String(opt.defaultValue)}`,
             ).toBe(true);
           } else {
-            expect(String(opt.defaultValue), `${subName} ${flag.name} default mismatch`).toBe(
+            expect(String(opt.defaultValue), `${chain} ${flag.name} default mismatch`).toBe(
               flag.default,
             );
           }
 
-          expect(opt.mandatory, `${subName} ${flag.name} mandatory mismatch`).toBe(flag.required);
+          expect(opt.mandatory, `${chain} ${flag.name} mandatory mismatch`).toBe(flag.required);
 
           if (flag.envFallback) {
-            expect(opt.envVar, `${subName} ${flag.name} env fallback mismatch`).toBe(
+            expect(opt.envVar, `${chain} ${flag.name} env fallback mismatch`).toBe(
               flag.envFallback,
             );
           }
@@ -226,9 +248,9 @@ describe("CLI surface: ADR-00M compliance", () => {
           const arg = cmd.registeredArguments.find(
             (a) => a.name().toUpperCase() === pos.name.toUpperCase(),
           );
-          expect(arg, `positional ${pos.name} missing on ${subName}`).toBeDefined();
+          expect(arg, `positional ${pos.name} missing on ${chain}`).toBeDefined();
           if (!arg) continue;
-          expect(arg.required, `${subName} ${pos.name} required mismatch`).toBe(pos.required);
+          expect(arg.required, `${chain} ${pos.name} required mismatch`).toBe(pos.required);
           if (pos.default === undefined) {
             expect(arg.defaultValue).toBeUndefined();
           } else {


### PR DESCRIPTION
## Summary

Slice 2 of the credential-storage track for #190: adds `c2n auth confluence` / `c2n auth notion` partial-update commands on top of the `c2n init` foundation from #189.

- `runConfluenceAuth` / `runNotionAuth` resolve the profile via `resolveProfileName` (flag → `C2N_PROFILE` → `currentProfile` → `default`), refuse to create new profiles (`c2n init` is the only creator), and deep-merge only the relevant credential subtree.
- Non-TTY without all required flags exits 1 listing every missing flag at once.
- ADR-00M extended with two new subsections (`c2n auth confluence`, `c2n auth notion`).
- `tests/cli/surface.test.ts` was extended (not relaxed) to handle multi-word command chains in ADR (`auth confluence`/`auth notion`) — `EXPECTED_LEAVES` + `walkChain` now strengthens freeze coverage instead of hardcoding flat names.

Closes #190

## Pipeline

Generated by `scripts/develop.sh 190` — Plan, Implement, Test, Review, Fix, Verify, PR.

## Artifacts

- Plan: `output/dev/plan.json`
- Review: `output/dev/review.json` (approved, 0 errors / 0 warnings / 3 suggestions)

## Follow-ups (filed as separate issues)

- #196 — drop or scope the dead try/catch in `auth.ts` action handlers
- #197 — silent prompt for secret fields in `c2n init` / `c2n auth`
- #198 — cover the TTY prompt branch in `auth.ts` with a mocked `readline`

Remaining slices for #190's parent (`c2n use`, `c2n profiles`, `--profile` wiring on existing subcommands, MCP integration, README / CHANGELOG) are tracked in #195.

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (445 passed / 1 skipped)
- [x] Manual review of changes against issue requirements