### PR TITLE
feat: refactor(cli): drop or scope dead try/catch in auth.ts action handlers

### DIFF
--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -189,14 +189,7 @@ export function registerAuthCommands(program: Command): void {
       ),
     )
     .action(async function (this: Command) {
-      const o = this.opts<ConfluenceAuthOptions>();
-      try {
-        await runConfluenceAuth(o);
-      } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        process.stderr.write(`auth confluence: ${msg}\n`);
-        process.exit(1);
-      }
+      await runConfluenceAuth(this.opts<ConfluenceAuthOptions>());
     });
 
   auth
@@ -213,13 +206,6 @@ export function registerAuthCommands(program: Command): void {
       new Option("--notion-root-page-id <id>", "Notion root page ID").env("NOTION_ROOT_PAGE_ID"),
     )
     .action(async function (this: Command) {
-      const o = this.opts<NotionAuthOptions>();
-      try {
-        await runNotionAuth(o);
-      } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        process.stderr.write(`auth notion: ${msg}\n`);
-        process.exit(1);
-      }
+      await runNotionAuth(this.opts<NotionAuthOptions>());
     });
 }

--- a/tests/cli/auth.test.ts
+++ b/tests/cli/auth.test.ts
@@ -184,6 +184,7 @@ describe("c2n auth confluence", () => {
     const errMsg = stderr.mock.calls.map((c) => String(c[0])).join("");
     expect(errMsg).toMatch(/profile 'missing' does not exist/);
     expect(errMsg).toMatch(/c2n init/);
+    expect(errMsg).not.toMatch(/auth confluence: __exit__/);
 
     // Config must not have been created with a half-populated profile.
     await expect(readFile(join(tmp, "config.json"), "utf8")).rejects.toThrow();
@@ -216,6 +217,7 @@ describe("c2n auth confluence", () => {
       const errMsg = stderr.mock.calls.map((c) => String(c[0])).join("");
       expect(errMsg).toMatch(/--confluence-email/);
       expect(errMsg).toMatch(/--confluence-api-token/);
+      expect(errMsg).not.toMatch(/auth confluence: __exit__/);
     } finally {
       Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: isTty });
     }
@@ -304,6 +306,7 @@ describe("c2n auth notion", () => {
     const errMsg = stderr.mock.calls.map((c) => String(c[0])).join("");
     expect(errMsg).toMatch(/profile 'missing' does not exist/);
     expect(errMsg).toMatch(/c2n init/);
+    expect(errMsg).not.toMatch(/auth notion: __exit__/);
   });
 
   it("non-TTY without all required flags exits 1 listing the missing flags", async () => {
@@ -332,6 +335,7 @@ describe("c2n auth notion", () => {
       expect(exit).toHaveBeenCalledWith(1);
       const errMsg = stderr.mock.calls.map((c) => String(c[0])).join("");
       expect(errMsg).toMatch(/--notion-root-page-id/);
+      expect(errMsg).not.toMatch(/auth notion: __exit__/);
     } finally {
       Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: isTty });
     }


### PR DESCRIPTION
## Summary

Automated implementation for #196.

Closes #196

## Pipeline

Generated by `scripts/develop.sh 196` — Plan, Implement, Test, Review, Fix, Verify, PR.

## Artifacts

- Plan: `output/dev/plan.json`
- Review: `output/dev/review.json`

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes
- [ ] Manual review of changes against issue requirements