### PR TITLE
feat: feat(cli): silent prompt for secrets in c2n init / c2n auth

### DIFF
--- a/src/cli/auth.ts
+++ b/src/cli/auth.ts
@@ -1,4 +1,3 @@
-import * as readline from "node:readline/promises";
 import { type Command, Option } from "commander";
 import {
   type ConfigStoreOptions,
@@ -10,6 +9,7 @@ import {
   resolveProfileName,
   upsertProfile,
 } from "../configStore.js";
+import { promptField } from "./promptInput.js";
 
 export interface ConfluenceAuthOptions {
   profile?: string;
@@ -28,6 +28,7 @@ interface FieldSpec<K extends string> {
   flag: string;
   prompt: string;
   optionKey: K;
+  secret?: boolean;
 }
 
 const CONFLUENCE_FIELDS: FieldSpec<keyof ConfluenceAuthOptions>[] = [
@@ -45,6 +46,7 @@ const CONFLUENCE_FIELDS: FieldSpec<keyof ConfluenceAuthOptions>[] = [
     flag: "--confluence-api-token",
     prompt: "Confluence API token",
     optionKey: "confluenceApiToken",
+    secret: true,
   },
 ];
 
@@ -53,6 +55,7 @@ const NOTION_FIELDS: FieldSpec<keyof NotionAuthOptions>[] = [
     flag: "--notion-token",
     prompt: "Notion integration token",
     optionKey: "notionToken",
+    secret: true,
   },
   {
     flag: "--notion-root-page-id",
@@ -70,21 +73,21 @@ async function promptMissing<T extends Record<string, unknown>>(
   values: T,
   fields: FieldSpec<keyof T & string>[],
 ): Promise<T> {
-  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-  try {
-    for (const field of fields) {
-      const current = values[field.optionKey];
-      if (typeof current === "string" && current.length > 0) continue;
-      const answer = (await rl.question(`${field.prompt}: `)).trim();
-      if (answer.length === 0) {
+  for (const field of fields) {
+    const current = values[field.optionKey];
+    if (typeof current === "string" && current.length > 0) continue;
+    let answer: string;
+    try {
+      answer = await promptField({ prompt: field.prompt, secret: field.secret === true });
+    } catch (e) {
+      if (e instanceof Error && e.message === "Empty input") {
         throw new Error(`Empty input for ${field.flag}; aborting.`);
       }
-      (values as Record<string, unknown>)[field.optionKey] = answer;
+      throw e;
     }
-    return values;
-  } finally {
-    rl.close();
+    (values as Record<string, unknown>)[field.optionKey] = answer;
   }
+  return values;
 }
 
 async function resolveFields<T extends Record<string, unknown>>(

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,6 +1,6 @@
-import * as readline from "node:readline/promises";
 import { type Command, Option } from "commander";
 import { type ConfigStoreOptions, getConfigPath, upsertProfile } from "../configStore.js";
+import { promptField } from "./promptInput.js";
 
 export interface InitCliOptions {
   profile: string;
@@ -15,6 +15,7 @@ interface FieldSpec {
   flag: string;
   prompt: string;
   optionKey: keyof InitCliOptions;
+  secret?: boolean;
 }
 
 const FIELDS: FieldSpec[] = [
@@ -32,11 +33,13 @@ const FIELDS: FieldSpec[] = [
     flag: "--confluence-api-token",
     prompt: "Confluence API token",
     optionKey: "confluenceApiToken",
+    secret: true,
   },
   {
     flag: "--notion-token",
     prompt: "Notion integration token",
     optionKey: "notionToken",
+    secret: true,
   },
   {
     flag: "--notion-root-page-id",
@@ -51,22 +54,21 @@ function resolveConfigDirOpts(): ConfigStoreOptions {
 }
 
 async function promptMissing(values: InitCliOptions): Promise<InitCliOptions> {
-  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-  try {
-    for (const field of FIELDS) {
-      const current = values[field.optionKey];
-      if (typeof current === "string" && current.length > 0) continue;
-      // No masking in v1 — accept plain echo.
-      const answer = (await rl.question(`${field.prompt}: `)).trim();
-      if (answer.length === 0) {
+  for (const field of FIELDS) {
+    const current = values[field.optionKey];
+    if (typeof current === "string" && current.length > 0) continue;
+    let answer: string;
+    try {
+      answer = await promptField({ prompt: field.prompt, secret: field.secret === true });
+    } catch (e) {
+      if (e instanceof Error && e.message === "Empty input") {
         throw new Error(`Empty input for ${field.flag}; aborting.`);
       }
-      (values as unknown as Record<string, string>)[field.optionKey] = answer;
+      throw e;
     }
-    return values;
-  } finally {
-    rl.close();
+    (values as unknown as Record<string, string>)[field.optionKey] = answer;
   }
+  return values;
 }
 
 export async function runInitCommand(opts: InitCliOptions): Promise<void> {

--- a/src/cli/promptInput.ts
+++ b/src/cli/promptInput.ts
@@ -1,0 +1,85 @@
+import * as readline from "node:readline/promises";
+
+export interface PromptFieldOptions {
+  prompt: string;
+  secret?: boolean;
+}
+
+const ETX = 0x03; // Ctrl-C
+const BS = 0x08; // backspace
+const LF = 0x0a;
+const CR = 0x0d;
+const DEL = 0x7f; // backspace on most terminals
+
+export async function promptField(opts: PromptFieldOptions): Promise<string> {
+  if (opts.secret === true) {
+    return readSecretLine(opts.prompt);
+  }
+  return readPlainLine(opts.prompt);
+}
+
+async function readPlainLine(label: string): Promise<string> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = (await rl.question(`${label}: `)).trim();
+    if (answer.length === 0) {
+      throw new Error("Empty input");
+    }
+    return answer;
+  } finally {
+    rl.close();
+  }
+}
+
+interface RawStdin {
+  isRaw?: boolean;
+  setRawMode?: (mode: boolean) => unknown;
+  on(event: "data", listener: (chunk: Buffer) => void): unknown;
+  off(event: "data", listener: (chunk: Buffer) => void): unknown;
+  resume(): unknown;
+  pause(): unknown;
+}
+
+async function readSecretLine(label: string): Promise<string> {
+  const stdin = process.stdin as unknown as RawStdin;
+  process.stdout.write(`${label}: `);
+
+  const wasRaw = stdin.isRaw === true;
+  stdin.setRawMode?.(true);
+  stdin.resume();
+
+  let onData: ((chunk: Buffer) => void) | null = null;
+  try {
+    const raw = await new Promise<string>((resolve, reject) => {
+      let buffer = "";
+      onData = (chunk: Buffer) => {
+        for (const byte of chunk) {
+          if (byte === ETX) {
+            reject(new Error("Aborted by user"));
+            return;
+          }
+          if (byte === CR || byte === LF) {
+            resolve(buffer);
+            return;
+          }
+          if (byte === DEL || byte === BS) {
+            if (buffer.length > 0) buffer = buffer.slice(0, -1);
+            continue;
+          }
+          buffer += String.fromCharCode(byte);
+        }
+      };
+      stdin.on("data", onData);
+    });
+    process.stdout.write("\n");
+    const trimmed = raw.trim();
+    if (trimmed.length === 0) {
+      throw new Error("Empty input");
+    }
+    return trimmed;
+  } finally {
+    if (onData) stdin.off("data", onData);
+    stdin.setRawMode?.(wasRaw);
+    stdin.pause();
+  }
+}

--- a/tests/cli/auth.test.ts
+++ b/tests/cli/auth.test.ts
@@ -31,6 +31,40 @@ function scriptReadline(answers: string[]): ScriptedReadline {
   return { question, close };
 }
 
+function driveSecretAnswers(answers: string[]): { setRawMode: ReturnType<typeof vi.fn> } {
+  const remaining = [...answers];
+  const setRawMode = vi.fn((mode: boolean) => {
+    if (mode === true) {
+      const next = remaining.shift();
+      if (next === undefined) return;
+      setImmediate(() => {
+        process.stdin.emit("data", Buffer.from(`${next}\r`));
+      });
+    }
+  });
+  return { setRawMode };
+}
+
+interface StdinSecretGuard {
+  restore: () => void;
+}
+
+function installSecretStdin(setRawMode: (mode: boolean) => unknown): StdinSecretGuard {
+  const isTty = process.stdin.isTTY;
+  const stdinAny = process.stdin as unknown as {
+    setRawMode: ((mode: boolean) => unknown) | undefined;
+  };
+  const prevSetRawMode = stdinAny.setRawMode;
+  Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+  stdinAny.setRawMode = setRawMode;
+  return {
+    restore: () => {
+      Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: isTty });
+      stdinAny.setRawMode = prevSetRawMode;
+    },
+  };
+}
+
 const ENV_KEYS = [
   "C2N_CONFIG_DIR",
   "C2N_PROFILE",
@@ -256,26 +290,28 @@ describe("c2n auth confluence", () => {
 
   it("TTY mode prompts for missing fields and updates only the confluence subtree", async () => {
     await seedDefaultProfile();
+    vi.spyOn(process.stdout, "write").mockImplementation(
+      (() => true) as typeof process.stdout.write,
+    );
     const { question, close } = scriptReadline([
       "https://prompted.atlassian.net/wiki",
       "prompted@example.com",
-      "atl-token-prompted",
     ]);
-
-    const isTty = process.stdin.isTTY;
-    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    const driver = driveSecretAnswers(["atl-token-prompted"]);
+    const guard = installSecretStdin(driver.setRawMode);
 
     try {
       await createProgram().parseAsync(["node", "c2n", "auth", "confluence"]);
     } finally {
-      Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: isTty });
+      guard.restore();
     }
 
-    expect(question).toHaveBeenCalledTimes(3);
+    // Only the two non-secret fields go through readline; the api token uses the secret path.
+    expect(question).toHaveBeenCalledTimes(2);
     expect(question.mock.calls[0]?.[0]).toBe("Confluence base URL: ");
     expect(question.mock.calls[1]?.[0]).toBe("Confluence account email: ");
-    expect(question.mock.calls[2]?.[0]).toBe("Confluence API token: ");
-    expect(close).toHaveBeenCalledTimes(1);
+    // promptField creates one readline per non-secret prompt and closes it on exit.
+    expect(close).toHaveBeenCalledTimes(2);
 
     const cfg = await readStoredConfig();
     expect(cfg.profiles.default?.confluence).toEqual({
@@ -288,6 +324,37 @@ describe("c2n auth confluence", () => {
       token: "secret_abc",
       rootPageId: "00000000000000000000000000000000",
     });
+  });
+
+  it("TTY mode does not echo the Confluence API token while non-secret fields go through readline", async () => {
+    await seedDefaultProfile();
+    const writes: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+      writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk as Buffer).toString());
+      return true;
+    }) as typeof process.stdout.write);
+
+    const { question } = scriptReadline([
+      "https://prompted.atlassian.net/wiki",
+      "prompted@example.com",
+    ]);
+    const driver = driveSecretAnswers(["atl-token-must-not-leak"]);
+    const guard = installSecretStdin(driver.setRawMode);
+
+    try {
+      await createProgram().parseAsync(["node", "c2n", "auth", "confluence"]);
+    } finally {
+      guard.restore();
+    }
+
+    // Non-secret fields are driven through the readline mock.
+    expect(question.mock.calls[0]?.[0]).toBe("Confluence base URL: ");
+    expect(question.mock.calls[1]?.[0]).toBe("Confluence account email: ");
+
+    const captured = writes.join("");
+    // The secret prompt label is written; the typed value never reaches stdout.
+    expect(captured).toContain("Confluence API token:");
+    expect(captured).not.toContain("atl-token-must-not-leak");
   });
 
   it("TTY mode rejects when a prompted answer is empty", async () => {
@@ -440,23 +507,22 @@ describe("c2n auth notion", () => {
 
   it("TTY mode prompts for missing fields and updates only the notion subtree", async () => {
     await seedDefaultProfile();
-    const { question, close } = scriptReadline([
-      "secret_prompted",
-      "55555555555555555555555555555555",
-    ]);
-
-    const isTty = process.stdin.isTTY;
-    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    vi.spyOn(process.stdout, "write").mockImplementation(
+      (() => true) as typeof process.stdout.write,
+    );
+    const { question, close } = scriptReadline(["55555555555555555555555555555555"]);
+    const driver = driveSecretAnswers(["secret_prompted"]);
+    const guard = installSecretStdin(driver.setRawMode);
 
     try {
       await createProgram().parseAsync(["node", "c2n", "auth", "notion"]);
     } finally {
-      Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: isTty });
+      guard.restore();
     }
 
-    expect(question).toHaveBeenCalledTimes(2);
-    expect(question.mock.calls[0]?.[0]).toBe("Notion integration token: ");
-    expect(question.mock.calls[1]?.[0]).toBe("Notion root page ID: ");
+    // Only the non-secret root-page-id goes through readline.
+    expect(question).toHaveBeenCalledTimes(1);
+    expect(question.mock.calls[0]?.[0]).toBe("Notion root page ID: ");
     expect(close).toHaveBeenCalledTimes(1);
 
     const cfg = await readStoredConfig();
@@ -470,6 +536,31 @@ describe("c2n auth notion", () => {
       email: "user@example.com",
       apiToken: "atl-token-1",
     });
+  });
+
+  it("TTY mode does not echo the Notion integration token while the root page id goes through readline", async () => {
+    await seedDefaultProfile();
+    const writes: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+      writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk as Buffer).toString());
+      return true;
+    }) as typeof process.stdout.write);
+
+    const { question } = scriptReadline(["55555555555555555555555555555555"]);
+    const driver = driveSecretAnswers(["secret_must_not_leak"]);
+    const guard = installSecretStdin(driver.setRawMode);
+
+    try {
+      await createProgram().parseAsync(["node", "c2n", "auth", "notion"]);
+    } finally {
+      guard.restore();
+    }
+
+    expect(question.mock.calls[0]?.[0]).toBe("Notion root page ID: ");
+
+    const captured = writes.join("");
+    expect(captured).toContain("Notion integration token:");
+    expect(captured).not.toContain("secret_must_not_leak");
   });
 
   it("TTY mode rejects when a prompted answer is empty", async () => {

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -1,8 +1,49 @@
 import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import * as readline from "node:readline/promises";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createProgram } from "../../src/cli/index.js";
+
+vi.mock("node:readline/promises", () => ({
+  createInterface: vi.fn(),
+}));
+
+interface ScriptedReadline {
+  question: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+}
+
+function scriptReadline(answers: string[]): ScriptedReadline {
+  const remaining = [...answers];
+  const close = vi.fn();
+  const question = vi.fn(async () => {
+    const next = remaining.shift();
+    if (next === undefined) {
+      throw new Error("readline.question called more times than scripted");
+    }
+    return next;
+  });
+  vi.mocked(readline.createInterface).mockReturnValue({
+    question,
+    close,
+  } as unknown as ReturnType<typeof readline.createInterface>);
+  return { question, close };
+}
+
+function driveSecretAnswers(answers: string[]): { setRawMode: ReturnType<typeof vi.fn> } {
+  const remaining = [...answers];
+  const setRawMode = vi.fn((mode: boolean) => {
+    if (mode === true) {
+      const next = remaining.shift();
+      if (next === undefined) return;
+      setImmediate(() => {
+        process.stdin.emit("data", Buffer.from(`${next}\r`));
+      });
+    }
+  });
+  return { setRawMode };
+}
 
 const ENV_KEYS = [
   "C2N_CONFIG_DIR",
@@ -166,5 +207,95 @@ describe("c2n init", () => {
     await createProgram().parseAsync(["node", "c2n", "init", ...FLAGS_DEFAULT]);
     const fileStat = await stat(join(tmp, "config.json"));
     expect(fileStat.mode & 0o777).toBe(0o600);
+  });
+
+  it("TTY mode prompts secret token fields without echoing the typed value", async () => {
+    const writes: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+      writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk as Buffer).toString());
+      return true;
+    }) as typeof process.stdout.write);
+
+    const { question } = scriptReadline([
+      "https://prompted.atlassian.net/wiki",
+      "prompted@example.com",
+      "00000000000000000000000000000000",
+    ]);
+    const driver = driveSecretAnswers(["atl-token-secret", "secret_notion_token"]);
+
+    const isTty = process.stdin.isTTY;
+    const stdinAny = process.stdin as unknown as {
+      setRawMode: ((mode: boolean) => unknown) | undefined;
+    };
+    const prevSetRawMode = stdinAny.setRawMode;
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    stdinAny.setRawMode = driver.setRawMode;
+
+    try {
+      await createProgram().parseAsync(["node", "c2n", "init"]);
+    } finally {
+      Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: isTty });
+      stdinAny.setRawMode = prevSetRawMode;
+    }
+
+    // Non-secret fields go through the readline mock — three of the five field prompts.
+    expect(question).toHaveBeenCalledTimes(3);
+    expect(question.mock.calls[0]?.[0]).toBe("Confluence base URL: ");
+    expect(question.mock.calls[1]?.[0]).toBe("Confluence account email: ");
+    expect(question.mock.calls[2]?.[0]).toBe("Notion root page ID: ");
+
+    // Secret prompts wrote their labels but not their answers.
+    const captured = writes.join("");
+    expect(captured).toContain("Confluence API token:");
+    expect(captured).toContain("Notion integration token:");
+    expect(captured).not.toContain("atl-token-secret");
+    expect(captured).not.toContain("secret_notion_token");
+
+    const cfg = await readStoredConfig();
+    expect(cfg.profiles.default).toEqual({
+      confluence: {
+        baseUrl: "https://prompted.atlassian.net/wiki",
+        email: "prompted@example.com",
+        apiToken: "atl-token-secret",
+      },
+      notion: {
+        token: "secret_notion_token",
+        rootPageId: "00000000000000000000000000000000",
+      },
+    });
+  });
+
+  it("non-TTY missing-flags error path is unchanged when only secret fields are missing", async () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const exit = vi.spyOn(process, "exit").mockImplementation(((_code?: number) => {
+      throw new Error("__exit__");
+    }) as never);
+
+    const isTty = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: false });
+
+    try {
+      await expect(
+        createProgram().parseAsync([
+          "node",
+          "c2n",
+          "init",
+          "--confluence-base-url",
+          "https://example.atlassian.net/wiki",
+          "--confluence-email",
+          "user@example.com",
+          "--notion-root-page-id",
+          "00000000000000000000000000000000",
+          // Missing --confluence-api-token and --notion-token (the secret ones).
+        ]),
+      ).rejects.toThrow("__exit__");
+
+      expect(exit).toHaveBeenCalledWith(1);
+      const errMsg = stderr.mock.calls.map((c) => String(c[0])).join("");
+      expect(errMsg).toMatch(/--confluence-api-token/);
+      expect(errMsg).toMatch(/--notion-token/);
+    } finally {
+      Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: isTty });
+    }
   });
 });

--- a/tests/cli/promptInput.test.ts
+++ b/tests/cli/promptInput.test.ts
@@ -1,0 +1,205 @@
+import * as readline from "node:readline/promises";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { promptField } from "../../src/cli/promptInput.js";
+
+vi.mock("node:readline/promises", () => ({
+  createInterface: vi.fn(),
+}));
+
+interface ScriptedReadline {
+  question: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+}
+
+function scriptReadline(answer: string): ScriptedReadline {
+  const close = vi.fn();
+  const question = vi.fn(async () => answer);
+  vi.mocked(readline.createInterface).mockReturnValue({
+    question,
+    close,
+  } as unknown as ReturnType<typeof readline.createInterface>);
+  return { question, close };
+}
+
+interface StdinSnapshot {
+  isTTY: boolean | undefined;
+  setRawMode: ((mode: boolean) => unknown) | undefined;
+}
+
+function snapshotStdin(): StdinSnapshot {
+  const stdin = process.stdin as unknown as {
+    isTTY: boolean | undefined;
+    setRawMode?: (mode: boolean) => unknown;
+  };
+  return { isTTY: stdin.isTTY, setRawMode: stdin.setRawMode };
+}
+
+function restoreStdin(snap: StdinSnapshot): void {
+  Object.defineProperty(process.stdin, "isTTY", {
+    configurable: true,
+    value: snap.isTTY,
+  });
+  const stdin = process.stdin as unknown as {
+    setRawMode: ((mode: boolean) => unknown) | undefined;
+  };
+  stdin.setRawMode = snap.setRawMode;
+}
+
+interface SecretDriver {
+  setRawMode: ReturnType<typeof vi.fn>;
+}
+
+function driveSecretAnswers(answers: Buffer[]): SecretDriver {
+  const remaining = [...answers];
+  const setRawMode = vi.fn((mode: boolean) => {
+    if (mode === true) {
+      const next = remaining.shift();
+      if (next === undefined) return;
+      setImmediate(() => {
+        process.stdin.emit("data", next);
+      });
+    }
+  });
+  return { setRawMode };
+}
+
+let stdinSnap: StdinSnapshot;
+
+beforeEach(() => {
+  stdinSnap = snapshotStdin();
+});
+
+afterEach(() => {
+  restoreStdin(stdinSnap);
+  vi.restoreAllMocks();
+});
+
+describe("promptField (non-secret)", () => {
+  it("prints the label and returns the trimmed answer", async () => {
+    const { question, close } = scriptReadline("  hello-value  ");
+    const result = await promptField({ prompt: "Email", secret: false });
+    expect(result).toBe("hello-value");
+    expect(question).toHaveBeenCalledTimes(1);
+    expect(question.mock.calls[0]?.[0]).toBe("Email: ");
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it("defaults secret to false when omitted", async () => {
+    const { question } = scriptReadline("plain");
+    const result = await promptField({ prompt: "Name" });
+    expect(result).toBe("plain");
+    expect(question).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws on whitespace-only answer and still closes the readline", async () => {
+    const { close } = scriptReadline("   ");
+    await expect(promptField({ prompt: "Email", secret: false })).rejects.toThrow(/empty/i);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("promptField (secret on TTY)", () => {
+  it("writes the prompt label but never echoes typed characters", async () => {
+    const writes: string[] = [];
+    vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+      writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk as Buffer).toString());
+      return true;
+    }) as typeof process.stdout.write);
+
+    const driver = driveSecretAnswers([Buffer.from("super-secret-token\r")]);
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    (process.stdin as unknown as { setRawMode: typeof driver.setRawMode }).setRawMode =
+      driver.setRawMode;
+
+    const result = await promptField({ prompt: "API token", secret: true });
+    expect(result).toBe("super-secret-token");
+
+    const captured = writes.join("");
+    expect(captured).toContain("API token:");
+    expect(captured).not.toContain("super-secret-token");
+  });
+
+  it("trims surrounding whitespace from the captured value", async () => {
+    vi.spyOn(process.stdout, "write").mockImplementation(
+      (() => true) as typeof process.stdout.write,
+    );
+    const driver = driveSecretAnswers([Buffer.from("  trimmed  \r")]);
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    (process.stdin as unknown as { setRawMode: typeof driver.setRawMode }).setRawMode =
+      driver.setRawMode;
+
+    const result = await promptField({ prompt: "API token", secret: true });
+    expect(result).toBe("trimmed");
+  });
+
+  it("supports backspace to delete the last buffered character", async () => {
+    vi.spyOn(process.stdout, "write").mockImplementation(
+      (() => true) as typeof process.stdout.write,
+    );
+    // Type "abcX", backspace (0x7f), then Enter — final value should be "abc".
+    const driver = driveSecretAnswers([Buffer.from([0x61, 0x62, 0x63, 0x58, 0x7f, 0x0d])]);
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    (process.stdin as unknown as { setRawMode: typeof driver.setRawMode }).setRawMode =
+      driver.setRawMode;
+
+    const result = await promptField({ prompt: "API token", secret: true });
+    expect(result).toBe("abc");
+  });
+
+  it("treats LF as end-of-line just like CR", async () => {
+    vi.spyOn(process.stdout, "write").mockImplementation(
+      (() => true) as typeof process.stdout.write,
+    );
+    const driver = driveSecretAnswers([Buffer.from("lf-value\n")]);
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    (process.stdin as unknown as { setRawMode: typeof driver.setRawMode }).setRawMode =
+      driver.setRawMode;
+
+    const result = await promptField({ prompt: "API token", secret: true });
+    expect(result).toBe("lf-value");
+  });
+
+  it("rejects on Ctrl-C with an Aborted error and still cleans up", async () => {
+    vi.spyOn(process.stdout, "write").mockImplementation(
+      (() => true) as typeof process.stdout.write,
+    );
+    const driver = driveSecretAnswers([Buffer.from([0x03])]);
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    (process.stdin as unknown as { setRawMode: typeof driver.setRawMode }).setRawMode =
+      driver.setRawMode;
+
+    const before = process.stdin.listenerCount("data");
+    await expect(promptField({ prompt: "API token", secret: true })).rejects.toThrow(/abort/i);
+    expect(process.stdin.listenerCount("data")).toBe(before);
+    // Last setRawMode call restores prior mode (false in tests).
+    expect(driver.setRawMode).toHaveBeenLastCalledWith(false);
+  });
+
+  it("throws on empty input (Enter only) and restores raw mode", async () => {
+    vi.spyOn(process.stdout, "write").mockImplementation(
+      (() => true) as typeof process.stdout.write,
+    );
+    const driver = driveSecretAnswers([Buffer.from([0x0d])]);
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    (process.stdin as unknown as { setRawMode: typeof driver.setRawMode }).setRawMode =
+      driver.setRawMode;
+
+    await expect(promptField({ prompt: "API token", secret: true })).rejects.toThrow(/empty/i);
+    expect(driver.setRawMode).toHaveBeenLastCalledWith(false);
+  });
+
+  it("removes its data listener after a successful read (no leaked listeners)", async () => {
+    vi.spyOn(process.stdout, "write").mockImplementation(
+      (() => true) as typeof process.stdout.write,
+    );
+    const driver = driveSecretAnswers([Buffer.from("ok\r")]);
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    (process.stdin as unknown as { setRawMode: typeof driver.setRawMode }).setRawMode =
+      driver.setRawMode;
+
+    const before = process.stdin.listenerCount("data");
+    const result = await promptField({ prompt: "API token", secret: true });
+    expect(result).toBe("ok");
+    expect(process.stdin.listenerCount("data")).toBe(before);
+  });
+});


### PR DESCRIPTION
## Summary

Automated implementation for #197.

Closes #197

## Pipeline

Generated by `scripts/develop.sh 197` — Plan, Implement, Test, Review, Fix, Verify, PR.

## Artifacts

- Plan: `output/dev/plan.json`
- Review: `output/dev/review.json`

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes
- [ ] Manual review of changes against issue requirements