### PR TITLE
feat: cont: cont: feat(cli): add c2n init + profile-based credential storage (remaining) (remaining)

### DIFF
--- a/.claude/docs/ADR-00M-cli-surface-freeze.md
+++ b/.claude/docs/ADR-00M-cli-surface-freeze.md
@@ -34,7 +34,9 @@ Captured from `src/confluence_to_notion/cli.py` and
 > the first post-freeze additive subcommand, introduced by issue #188 (slice 1
 > of credential-storage work). `c2n auth` (with `confluence` and `notion`
 > subcommands) is the second post-freeze addition, introduced by issue #190
-> (slice 2). Adding new subcommands continues to require an ADR amendment.
+> (slice 2). `c2n use` and `c2n profiles list` are the third post-freeze
+> addition, introduced by issue #195 (slice 3). Adding new subcommands
+> continues to require an ADR amendment.
 
 ### `c2n init`
 
@@ -69,6 +71,22 @@ Captured from `src/confluence_to_notion/cli.py` and
 | `--profile` | TEXT | _none_ | — | No | Profile name to update. Resolution order: this flag, then `C2N_PROFILE`, then `currentProfile` from the config file, then `default`. |
 | `--notion-token` | TEXT | _none_ | `NOTION_TOKEN` | No | Notion integration token. Prompted in TTY mode if missing; required in non-TTY mode. |
 | `--notion-root-page-id` | TEXT | _none_ | `NOTION_ROOT_PAGE_ID` | No | Notion root page ID. Prompted in TTY mode if missing; required in non-TTY mode. |
+
+### `c2n use`
+
+> Switch the current profile to `<name>`. Mutates only `currentProfile` in the config file; the `profiles` map is left untouched. The named profile must already exist — this command refuses to create a new profile (use `c2n init` for that).
+
+| Flag | Type | Default | Env fallback | Required | Semantics |
+|---|---|---|---|---|---|
+| `NAME` (positional) | TEXT | _none_ | — | Yes | Name of an existing profile to mark as `currentProfile`. |
+
+### `c2n profiles list`
+
+> List profile names from the config file, marking the `currentProfile` with a leading `* `. Prints a friendly hint and exits 0 when no profiles are configured. Never prints credential values.
+
+| Flag | Type | Default | Env fallback | Required | Semantics |
+|---|---|---|---|---|---|
+| _none_ | — | — | — | — | No flags. Reads `currentProfile` and the `profiles` map from the config file. |
 
 ### `c2n fetch`
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9,6 +9,8 @@ import { registerFinalizeCommands } from "./finalize.js";
 import { registerInitCommand } from "./init.js";
 import { registerMigrateCommands } from "./migrate.js";
 import { registerNotionCommands } from "./notion.js";
+import { registerProfilesCommands } from "./profiles.js";
+import { registerUseCommand } from "./use.js";
 import { registerValidateCommands } from "./validate.js";
 
 export function createProgram(): Command {
@@ -28,6 +30,8 @@ export function createProgram(): Command {
 
   registerInitCommand(program);
   registerAuthCommands(program);
+  registerUseCommand(program);
+  registerProfilesCommands(program);
   registerFetchCommands(program);
   registerNotionCommands(program);
   registerDiscoverShim(program);

--- a/src/cli/profiles.ts
+++ b/src/cli/profiles.ts
@@ -1,0 +1,36 @@
+import type { Command } from "commander";
+import { type ConfigStoreOptions, readConfig } from "../configStore.js";
+
+function resolveConfigDirOpts(): ConfigStoreOptions {
+  const dir = process.env.C2N_CONFIG_DIR?.trim();
+  return dir !== undefined && dir.length > 0 ? { configDir: dir } : {};
+}
+
+export async function runProfilesList(): Promise<void> {
+  const storeOpts = resolveConfigDirOpts();
+  const cfg = readConfig(storeOpts);
+  const names = Object.keys(cfg.profiles).sort();
+
+  if (names.length === 0) {
+    process.stdout.write("profiles: no profiles configured. Run `c2n init` to create one.\n");
+    return;
+  }
+
+  for (const name of names) {
+    const marker = name === cfg.currentProfile ? "* " : "  ";
+    process.stdout.write(`${marker}${name}\n`);
+  }
+}
+
+export function registerProfilesCommands(program: Command): void {
+  const profiles = program
+    .command("profiles")
+    .description("Manage credential profiles stored in the c2n config file.");
+
+  profiles
+    .command("list")
+    .description("List profile names; the current profile is marked with a leading '* '.")
+    .action(async () => {
+      await runProfilesList();
+    });
+}

--- a/src/cli/use.ts
+++ b/src/cli/use.ts
@@ -1,0 +1,36 @@
+import type { Command } from "commander";
+import {
+  type ConfigStoreOptions,
+  getConfigPath,
+  readConfig,
+  setCurrentProfile,
+} from "../configStore.js";
+
+function resolveConfigDirOpts(): ConfigStoreOptions {
+  const dir = process.env.C2N_CONFIG_DIR?.trim();
+  return dir !== undefined && dir.length > 0 ? { configDir: dir } : {};
+}
+
+export async function runUseCommand(name: string): Promise<void> {
+  const storeOpts = resolveConfigDirOpts();
+  const cfg = readConfig(storeOpts);
+  if (!cfg.profiles[name]) {
+    process.stderr.write(
+      `use: profile '${name}' does not exist; run \`c2n init --profile ${name}\` first.\n`,
+    );
+    process.exit(1);
+    throw new Error("process.exit did not terminate");
+  }
+  setCurrentProfile(name, storeOpts);
+  const { file } = getConfigPath(storeOpts);
+  process.stdout.write(`use: switched current profile to '${name}' in ${file}\n`);
+}
+
+export function registerUseCommand(program: Command): void {
+  program
+    .command("use <name>")
+    .description("Switch the current profile to <name> (must already exist).")
+    .action(async (name: string) => {
+      await runUseCommand(name);
+    });
+}

--- a/tests/cli/profiles.test.ts
+++ b/tests/cli/profiles.test.ts
@@ -1,0 +1,165 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createProgram } from "../../src/cli/index.js";
+
+const ENV_KEYS = [
+  "C2N_CONFIG_DIR",
+  "C2N_PROFILE",
+  "CONFLUENCE_BASE_URL",
+  "CONFLUENCE_EMAIL",
+  "CONFLUENCE_API_TOKEN",
+  "CONFLUENCE_TOKEN",
+  "NOTION_TOKEN",
+  "NOTION_API_TOKEN",
+  "NOTION_ROOT_PAGE_ID",
+] as const;
+
+const SECRET_TOKEN = "atl-token-must-not-leak";
+const NOTION_SECRET = "secret_must_not_leak";
+
+let tmp: string;
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(async () => {
+  tmp = await mkdtemp(join(tmpdir(), "c2n-profiles-"));
+  savedEnv = {};
+  for (const k of ENV_KEYS) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+  process.env.C2N_CONFIG_DIR = tmp;
+});
+
+afterEach(async () => {
+  for (const k of ENV_KEYS) {
+    const v = savedEnv[k];
+    if (v === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = v;
+    }
+  }
+  await rm(tmp, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+const FLAGS_INIT_DEFAULT = [
+  "--confluence-base-url",
+  "https://example.atlassian.net/wiki",
+  "--confluence-email",
+  "user@example.com",
+  "--confluence-api-token",
+  SECRET_TOKEN,
+  "--notion-token",
+  NOTION_SECRET,
+  "--notion-root-page-id",
+  "00000000000000000000000000000000",
+];
+
+const FLAGS_INIT_WORK = [
+  "--confluence-base-url",
+  "https://work.atlassian.net/wiki",
+  "--confluence-email",
+  "work@example.com",
+  "--confluence-api-token",
+  "atl-token-2",
+  "--notion-token",
+  "secret_work",
+  "--notion-root-page-id",
+  "11111111111111111111111111111111",
+];
+
+async function seedDefaultProfile(): Promise<void> {
+  await createProgram().parseAsync(["node", "c2n", "init", ...FLAGS_INIT_DEFAULT]);
+}
+
+async function seedWorkProfile(): Promise<void> {
+  await createProgram().parseAsync([
+    "node",
+    "c2n",
+    "init",
+    "--profile",
+    "work",
+    ...FLAGS_INIT_WORK,
+  ]);
+}
+
+function captureStdout(): { writes: string[]; restore: () => void } {
+  const writes: string[] = [];
+  const spy = vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+    writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk as Buffer).toString());
+    return true;
+  }) as typeof process.stdout.write);
+  return { writes, restore: () => spy.mockRestore() };
+}
+
+describe("c2n profiles list", () => {
+  it("prints each profile name, marking the currentProfile with '* '", async () => {
+    await seedDefaultProfile();
+    await seedWorkProfile();
+    // currentProfile is still 'default' (init does not flip it).
+
+    const captured = captureStdout();
+    try {
+      await createProgram().parseAsync(["node", "c2n", "profiles", "list"]);
+    } finally {
+      captured.restore();
+    }
+
+    const out = captured.writes.join("");
+    // Both profiles appear, default is marked with leading '* '.
+    expect(out).toMatch(/^\*\s+default$/m);
+    expect(out).toMatch(/^\s{2}work$|^work$/m);
+    // The non-current profile should not be marked.
+    expect(out).not.toMatch(/^\*\s+work$/m);
+  });
+
+  it("prints a friendly empty-state message when no profiles exist (exit 0)", async () => {
+    const captured = captureStdout();
+    try {
+      await createProgram().parseAsync(["node", "c2n", "profiles", "list"]);
+    } finally {
+      captured.restore();
+    }
+
+    const out = captured.writes.join("");
+    expect(out).toMatch(/no profiles configured/i);
+    expect(out).toMatch(/c2n init/);
+  });
+
+  it("honours C2N_CONFIG_DIR (reads from the test-scoped directory)", async () => {
+    await seedDefaultProfile();
+    // Sanity-check: the seeded profile must round-trip via the listing.
+    const captured = captureStdout();
+    try {
+      await createProgram().parseAsync(["node", "c2n", "profiles", "list"]);
+    } finally {
+      captured.restore();
+    }
+
+    const out = captured.writes.join("");
+    expect(out).toContain("default");
+  });
+
+  it("does not print any credential values", async () => {
+    await seedDefaultProfile();
+    await seedWorkProfile();
+
+    const captured = captureStdout();
+    try {
+      await createProgram().parseAsync(["node", "c2n", "profiles", "list"]);
+    } finally {
+      captured.restore();
+    }
+
+    const out = captured.writes.join("");
+    expect(out).not.toContain(SECRET_TOKEN);
+    expect(out).not.toContain(NOTION_SECRET);
+    expect(out).not.toContain("secret_work");
+    expect(out).not.toContain("atl-token-2");
+    expect(out).not.toContain("00000000000000000000000000000000");
+    expect(out).not.toContain("11111111111111111111111111111111");
+  });
+});

--- a/tests/cli/surface.test.ts
+++ b/tests/cli/surface.test.ts
@@ -129,6 +129,8 @@ const EXPECTED_LEAVES = [
   "init",
   "auth confluence",
   "auth notion",
+  "use",
+  "profiles list",
   "fetch",
   "fetch-tree",
   "notion-ping",

--- a/tests/cli/use.test.ts
+++ b/tests/cli/use.test.ts
@@ -1,0 +1,171 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createProgram } from "../../src/cli/index.js";
+
+const ENV_KEYS = [
+  "C2N_CONFIG_DIR",
+  "C2N_PROFILE",
+  "CONFLUENCE_BASE_URL",
+  "CONFLUENCE_EMAIL",
+  "CONFLUENCE_API_TOKEN",
+  "CONFLUENCE_TOKEN",
+  "NOTION_TOKEN",
+  "NOTION_API_TOKEN",
+  "NOTION_ROOT_PAGE_ID",
+] as const;
+
+let tmp: string;
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(async () => {
+  tmp = await mkdtemp(join(tmpdir(), "c2n-use-"));
+  savedEnv = {};
+  for (const k of ENV_KEYS) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+  process.env.C2N_CONFIG_DIR = tmp;
+});
+
+afterEach(async () => {
+  for (const k of ENV_KEYS) {
+    const v = savedEnv[k];
+    if (v === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = v;
+    }
+  }
+  await rm(tmp, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+const FLAGS_INIT_DEFAULT = [
+  "--confluence-base-url",
+  "https://example.atlassian.net/wiki",
+  "--confluence-email",
+  "user@example.com",
+  "--confluence-api-token",
+  "atl-token-1",
+  "--notion-token",
+  "secret_abc",
+  "--notion-root-page-id",
+  "00000000000000000000000000000000",
+];
+
+const FLAGS_INIT_WORK = [
+  "--confluence-base-url",
+  "https://work.atlassian.net/wiki",
+  "--confluence-email",
+  "work@example.com",
+  "--confluence-api-token",
+  "atl-token-2",
+  "--notion-token",
+  "secret_work",
+  "--notion-root-page-id",
+  "11111111111111111111111111111111",
+];
+
+interface StoredProfile {
+  confluence: { baseUrl: string; email: string; apiToken: string };
+  notion: { token: string; rootPageId: string };
+}
+
+interface StoredConfig {
+  currentProfile: string;
+  profiles: Record<string, StoredProfile>;
+}
+
+async function readStoredConfig(): Promise<StoredConfig> {
+  const raw = await readFile(join(tmp, "config.json"), "utf8");
+  return JSON.parse(raw) as StoredConfig;
+}
+
+async function seedDefaultProfile(): Promise<void> {
+  await createProgram().parseAsync(["node", "c2n", "init", ...FLAGS_INIT_DEFAULT]);
+}
+
+async function seedWorkProfile(): Promise<void> {
+  await createProgram().parseAsync([
+    "node",
+    "c2n",
+    "init",
+    "--profile",
+    "work",
+    ...FLAGS_INIT_WORK,
+  ]);
+}
+
+describe("c2n use <name>", () => {
+  it("sets currentProfile when the named profile exists, persisting to the config file", async () => {
+    await seedDefaultProfile();
+    await seedWorkProfile();
+
+    // `c2n init --profile work` does not flip currentProfile; it stays at default.
+    const before = await readStoredConfig();
+    expect(before.currentProfile).toBe("default");
+
+    await createProgram().parseAsync(["node", "c2n", "use", "work"]);
+
+    const after = await readStoredConfig();
+    expect(after.currentProfile).toBe("work");
+  });
+
+  it("preserves the profiles map untouched (only currentProfile changes)", async () => {
+    await seedDefaultProfile();
+    await seedWorkProfile();
+
+    const before = await readStoredConfig();
+
+    await createProgram().parseAsync(["node", "c2n", "use", "work"]);
+
+    const after = await readStoredConfig();
+    expect(after.profiles).toEqual(before.profiles);
+  });
+
+  it("errors with non-zero exit and a clear stderr message when the profile does not exist", async () => {
+    await seedDefaultProfile();
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const exit = vi.spyOn(process, "exit").mockImplementation(((_code?: number) => {
+      throw new Error("__exit__");
+    }) as never);
+
+    await expect(createProgram().parseAsync(["node", "c2n", "use", "missing"])).rejects.toThrow(
+      "__exit__",
+    );
+
+    expect(exit).toHaveBeenCalledWith(1);
+    const errMsg = stderr.mock.calls.map((c) => String(c[0])).join("");
+    expect(errMsg).toMatch(/profile 'missing' does not exist/);
+    expect(errMsg).toMatch(/c2n init/);
+
+    // currentProfile must remain unchanged.
+    const cfg = await readStoredConfig();
+    expect(cfg.currentProfile).toBe("default");
+  });
+
+  it("errors when no <name> argument is given", async () => {
+    await seedDefaultProfile();
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const exit = vi.spyOn(process, "exit").mockImplementation(((_code?: number) => {
+      throw new Error("__exit__");
+    }) as never);
+    // Commander writes its own usage error, which calls process.exit; intercept it.
+    const program = createProgram();
+    program.exitOverride();
+
+    await expect(program.parseAsync(["node", "c2n", "use"])).rejects.toThrow();
+
+    // Either commander's exit-override threw (no process.exit call needed) or we
+    // recorded a non-zero exit. Both are acceptable; assert one happened.
+    const wroteToStderr = stderr.mock.calls.length > 0;
+    const calledExit = exit.mock.calls.length > 0;
+    expect(wroteToStderr || calledExit).toBe(true);
+
+    // currentProfile must remain unchanged.
+    const cfg = await readStoredConfig();
+    expect(cfg.currentProfile).toBe("default");
+  });
+});


### PR DESCRIPTION
## Summary

Automated implementation for #195.

Closes #195

## Pipeline

Generated by `scripts/develop.sh 195` — Plan, Implement, Test, Review, Fix, Verify, PR.

## Artifacts

- Plan: `output/dev/plan.json`
- Review: `output/dev/review.json`

## Notes for reviewers

- `tests/cli/surface.test.ts` was edited beyond the planned `affected_files`. The implementer flagged this as drift in `output/dev/implement-log.json`: the file's `EXPECTED_LEAVES` set is the surface-conformance contract, so adding the new `c2n use` and `c2n profiles` subcommands required updating it in lockstep. The alternative was a deliberately broken pipeline. Treat the change as scope-bound, not creep.
- Remaining work from #195 (--profile flag wiring across existing subcommands, MCP credential routing, README rewrite, 0.2.0 CHANGELOG via changesets) was auto-split into #203.

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (481 passed, 1 skipped)
- [x] Reviewer agent approved (no errors, 4 suggestion-level notes — all flagged intentional)