### PR TITLE
feat(cli): wire --profile flag into fetch/notion-ping/convert/migrate (#203)

### DIFF
--- a/.claude/docs/ADR-00M-cli-surface-freeze.md
+++ b/.claude/docs/ADR-00M-cli-surface-freeze.md
@@ -35,8 +35,12 @@ Captured from `src/confluence_to_notion/cli.py` and
 > of credential-storage work). `c2n auth` (with `confluence` and `notion`
 > subcommands) is the second post-freeze addition, introduced by issue #190
 > (slice 2). `c2n use` and `c2n profiles list` are the third post-freeze
-> addition, introduced by issue #195 (slice 3). Adding new subcommands
-> continues to require an ADR amendment.
+> addition, introduced by issue #195 (slice 3). Issue #203 (slice 4) extends
+> every existing data-prep subcommand (`fetch`, `fetch-tree`, `notion-ping`,
+> `convert`, `migrate`, `migrate-tree`, `migrate-tree-pages`) with a
+> `--profile <name>` flag that reads stored credentials through
+> `getConfluenceCreds(profile?)` / `getNotionCreds(profile?)`. Adding new
+> subcommands continues to require an ADR amendment.
 
 ### `c2n init`
 
@@ -99,6 +103,7 @@ Captured from `src/confluence_to_notion/cli.py` and
 | `--limit` | INTEGER | `25` | — | No | Max pages when using `--space`. |
 | `--out-dir` | PATH | `samples` | — | No | Output directory for XHTML. |
 | `--url` | TEXT | _none_ | — | No | Confluence source URL; when set, writes artifacts to `output/runs/<slug>/` and overrides `--out-dir`. |
+| `--profile` | TEXT | _none_ | — | No | Profile name to read credentials from. Resolution order: this flag, then `C2N_PROFILE`, then `currentProfile` from the config file, then `default`. |
 
 ### `c2n fetch-tree`
 
@@ -109,12 +114,17 @@ Captured from `src/confluence_to_notion/cli.py` and
 | `--root-id` | TEXT | _none_ | — | Yes | Confluence root page ID. |
 | `--output` | PATH | `output/page-tree.json` | — | No | Output JSON path; ignored when `--url` is set. |
 | `--url` | TEXT | _none_ | — | No | When set, writes `page-tree.json` under `output/runs/<slug>/`. |
+| `--profile` | TEXT | _none_ | — | No | Profile name to read credentials from. Resolution order: this flag, then `C2N_PROFILE`, then `currentProfile` from the config file, then `default`. |
 
 ### `c2n notion-ping`
 
 > Validate Notion API token by fetching bot user info.
 
-No flags. Requires `NOTION_API_TOKEN` and `NOTION_ROOT_PAGE_ID`.
+| Flag | Type | Default | Env fallback | Required | Semantics |
+|---|---|---|---|---|---|
+| `--profile` | TEXT | _none_ | — | No | Profile name to read credentials from. Resolution order: this flag, then `C2N_PROFILE`, then `currentProfile` from the config file, then `default`. |
+
+Requires `NOTION_API_TOKEN` and `NOTION_ROOT_PAGE_ID`.
 
 ### `c2n discover`
 
@@ -161,6 +171,7 @@ No flags.
 | `--rules` | PATH | `output/rules.json` | — | No | Path to rules.json. |
 | `--input` | PATH | `samples` | — | No | Directory of XHTML files. |
 | `--url` | TEXT | _none_ | — | **Yes** | Confluence source URL; converted JSON lands under `output/runs/<slug>/converted/`. |
+| `--profile` | TEXT | _none_ | — | No | Profile name to read credentials from. Resolution order: this flag, then `C2N_PROFILE`, then `currentProfile` from the config file, then `default`. |
 
 ### `c2n migrate`
 
@@ -175,6 +186,7 @@ No flags.
 | `--name` | TEXT | _none_ | — | No | Override the run slug under `output/runs/`. |
 | `--rediscover` | FLAG | `false` | — | No | Force re-running `scripts/discover.sh` even when `output/rules.json` exists. |
 | `--dry-run` | FLAG | `false` | — | No | Fetch + convert only; skip every Notion write. |
+| `--profile` | TEXT | _none_ | — | No | Profile name to read credentials from. Resolution order: this flag, then `C2N_PROFILE`, then `currentProfile` from the config file, then `default`. |
 
 **Legacy form** (no positional URL):
 
@@ -184,6 +196,7 @@ No flags.
 | `--input` | PATH | `samples` | — | No | Directory of XHTML files. |
 | `--target` | TEXT | _none_ | `NOTION_ROOT_PAGE_ID` | No | Notion parent page ID. |
 | `--url` | TEXT | _none_ | — | **Yes** (in legacy form) | Confluence source URL; required when the positional URL is omitted. |
+| `--profile` | TEXT | _none_ | — | No | Profile name to read credentials from. Resolution order: this flag, then `C2N_PROFILE`, then `currentProfile` from the config file, then `default`. |
 
 ### `c2n migrate-tree`
 
@@ -194,6 +207,7 @@ No flags.
 | `--tree` | PATH | `output/page-tree.json` | — | No | Path to page-tree.json produced by `fetch-tree`. |
 | `--target` | TEXT | _none_ | `NOTION_ROOT_PAGE_ID` | No | Notion parent page ID. |
 | `--url` | TEXT | _none_ | — | **Yes** | Confluence source URL; `resolution.json` lands under `output/runs/<slug>/`. |
+| `--profile` | TEXT | _none_ | — | No | Profile name to read credentials from. Resolution order: this flag, then `C2N_PROFILE`, then `currentProfile` from the config file, then `default`. |
 
 ### `c2n migrate-tree-pages`
 
@@ -205,6 +219,7 @@ No flags.
 | `--target` | TEXT | _none_ | `NOTION_ROOT_PAGE_ID` | No | Notion parent page ID. |
 | `--rules` | PATH | `output/rules.json` | — | No | Path to rules.json. |
 | `--url` | TEXT | _none_ | — | **Yes** | Confluence source URL; every artifact (source / status / report / resolution / rules / converted) lands under `output/runs/<slug>/`. |
+| `--profile` | TEXT | _none_ | — | No | Profile name to read credentials from. Resolution order: this flag, then `C2N_PROFILE`, then `currentProfile` from the config file, then `default`. |
 
 ## Exit codes
 

--- a/src/cli/convert.ts
+++ b/src/cli/convert.ts
@@ -9,6 +9,7 @@ export interface ConvertCliOptions {
   rules: string;
   input: string;
   url: string;
+  profile?: string;
 }
 
 function outputRootDir(): string {
@@ -68,6 +69,7 @@ export function registerConvertCommands(program: Command): void {
       "--url <url>",
       "Confluence source URL; converted JSON lands under output/runs/<slug>/converted/",
     )
+    .option("--profile <name>", "credential profile name (overrides C2N_PROFILE / currentProfile)")
     .action(async function (this: Command) {
       const o = this.opts<ConvertCliOptions>();
       try {

--- a/src/cli/fetch.ts
+++ b/src/cli/fetch.ts
@@ -1,9 +1,14 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import type { Command } from "commander";
+import { type ConfigStoreOptions, getConfluenceCreds } from "../configStore.js";
 import { type FetchLike, createConfluenceClient } from "../confluence/client.js";
 import { type RunContext, finalizeRun, startRun, updateStep } from "../runs/index.js";
-import { readConfluenceAuth, readConfluenceBaseUrl } from "./confluenceEnv.js";
+
+function resolveConfigDirOpts(): ConfigStoreOptions {
+  const dir = process.env.C2N_CONFIG_DIR?.trim();
+  return dir !== undefined && dir.length > 0 ? { configDir: dir } : {};
+}
 
 export interface FetchCliOptions {
   space?: string;
@@ -11,6 +16,7 @@ export interface FetchCliOptions {
   limit: string;
   outDir: string;
   url?: string;
+  profile?: string;
 }
 
 function outputRootDir(): string {
@@ -18,15 +24,15 @@ function outputRootDir(): string {
 }
 
 /** When `C2N_USE_GLOBAL_FETCH=1`, use `globalThis.fetch` so MSW can intercept in tests. */
-function createCliConfluenceClient(): ReturnType<typeof createConfluenceClient> {
-  const { email, token } = readConfluenceAuth();
-  const baseUrl = readConfluenceBaseUrl();
+function createCliConfluenceClient(profile?: string): ReturnType<typeof createConfluenceClient> {
+  const { baseUrl, email, apiToken } = getConfluenceCreds(profile, resolveConfigDirOpts());
+  const trimmedBaseUrl = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
   const useGlobal = process.env.C2N_USE_GLOBAL_FETCH === "1";
   const g = globalThis as { fetch?: FetchLike };
   return createConfluenceClient({
     email,
-    token,
-    baseUrl,
+    token: apiToken,
+    baseUrl: trimmedBaseUrl,
     ...(useGlobal && typeof g.fetch === "function" ? { fetchImpl: g.fetch } : {}),
   });
 }
@@ -89,7 +95,7 @@ export async function runFetchCommand(opts: FetchCliOptions): Promise<void> {
     process.exit(1);
   }
 
-  const client = createCliConfluenceClient();
+  const client = createCliConfluenceClient(opts.profile);
 
   let runContext: RunContext | null = null;
   if (opts.url !== undefined && opts.url.length > 0) {
@@ -124,10 +130,11 @@ export interface FetchTreeCliOptions {
   rootId: string;
   output: string;
   url?: string;
+  profile?: string;
 }
 
 export async function runFetchTreeCommand(opts: FetchTreeCliOptions): Promise<void> {
-  const client = createCliConfluenceClient();
+  const client = createCliConfluenceClient(opts.profile);
   const tree = await client.getPageTree(opts.rootId, { maxDepth: 25 });
   const json = `${JSON.stringify(tree, null, 2)}\n`;
 
@@ -168,6 +175,7 @@ export function registerFetchCommands(program: Command): void {
     .option("--limit <n>", "max pages when using --space", "25")
     .option("--out-dir <path>", "output directory for XHTML", "samples")
     .option("--url <url>", "Confluence source URL; writes artifacts under output/runs/<slug>/")
+    .option("--profile <name>", "credential profile name (overrides C2N_PROFILE / currentProfile)")
     .action(async function (this: Command) {
       const o = this.opts<FetchCliOptions>();
       try {
@@ -184,6 +192,7 @@ export function registerFetchCommands(program: Command): void {
     .requiredOption("--root-id <id>", "Confluence root page ID")
     .option("--output <path>", "output JSON path", "output/page-tree.json")
     .option("--url <url>", "Confluence source URL (overrides --output placement)")
+    .option("--profile <name>", "credential profile name (overrides C2N_PROFILE / currentProfile)")
     .action(async function (this: Command) {
       const o = this.opts<FetchTreeCliOptions>();
       try {

--- a/src/cli/migrate.ts
+++ b/src/cli/migrate.ts
@@ -19,6 +19,7 @@ export function registerMigrateCommands(program: Command): void {
       new Option("--target <id>", "Notion parent page ID (legacy form)").env("NOTION_ROOT_PAGE_ID"),
     )
     .option("--url <url>", "Confluence source URL (required when the positional URL is omitted)")
+    .option("--profile <name>", "credential profile name (overrides C2N_PROFILE / currentProfile)")
     .action(notImplemented("migrate"));
 
   program
@@ -30,6 +31,7 @@ export function registerMigrateCommands(program: Command): void {
       "--url <url>",
       "Confluence source URL; resolution.json lands under output/runs/<slug>/",
     )
+    .option("--profile <name>", "credential profile name (overrides C2N_PROFILE / currentProfile)")
     .action(notImplemented("migrate-tree"));
 
   program
@@ -42,5 +44,6 @@ export function registerMigrateCommands(program: Command): void {
       "--url <url>",
       "Confluence source URL; every artifact lands under output/runs/<slug>/",
     )
+    .option("--profile <name>", "credential profile name (overrides C2N_PROFILE / currentProfile)")
     .action(notImplemented("migrate-tree-pages"));
 }

--- a/src/cli/notion.ts
+++ b/src/cli/notion.ts
@@ -1,36 +1,32 @@
 import { Client } from "@notionhq/client";
 import type { Command } from "commander";
+import { ConfigStoreError, type ConfigStoreOptions, getNotionCreds } from "../configStore.js";
 
-function readNotionToken(): string | undefined {
-  const a = process.env.NOTION_TOKEN;
-  const b = process.env.NOTION_API_TOKEN;
-  if (typeof a === "string" && a.length > 0) return a;
-  if (typeof b === "string" && b.length > 0) return b;
-  return undefined;
+interface NotionPingOptions {
+  profile?: string;
 }
 
-function readNotionRootPageId(): string | undefined {
-  const v = process.env.NOTION_ROOT_PAGE_ID;
-  return typeof v === "string" && v.length > 0 ? v : undefined;
+function resolveConfigDirOpts(): ConfigStoreOptions {
+  const dir = process.env.C2N_CONFIG_DIR?.trim();
+  return dir !== undefined && dir.length > 0 ? { configDir: dir } : {};
 }
 
 export function registerNotionCommands(program: Command): void {
   program
     .command("notion-ping")
     .description("Validate the Notion API token by fetching bot user info.")
-    .action(async () => {
-      const token = readNotionToken();
-      if (token === undefined) {
-        process.stderr.write(
-          "Missing NOTION_TOKEN (legacy NOTION_API_TOKEN also accepted). See CONTRIBUTING.md and ADR-00M.\n",
-        );
-        process.exit(1);
-      }
-      if (readNotionRootPageId() === undefined) {
-        process.stderr.write(
-          "Missing NOTION_ROOT_PAGE_ID (required by the frozen CLI contract).\n",
-        );
-        process.exit(1);
+    .option("--profile <name>", "credential profile name (overrides C2N_PROFILE / currentProfile)")
+    .action(async function (this: Command) {
+      const opts = this.opts<NotionPingOptions>();
+      let token: string;
+      try {
+        ({ token } = getNotionCreds(opts.profile, resolveConfigDirOpts()));
+      } catch (e) {
+        if (e instanceof ConfigStoreError) {
+          process.stderr.write(`${e.message}\n`);
+          process.exit(1);
+        }
+        throw e;
       }
       try {
         const client = new Client({ auth: token });

--- a/tests/cli/fetch.test.ts
+++ b/tests/cli/fetch.test.ts
@@ -1,0 +1,259 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/confluence/client.js", () => ({
+  createConfluenceClient: vi.fn(),
+}));
+
+import { createProgram } from "../../src/cli/index.js";
+import { createConfluenceClient } from "../../src/confluence/client.js";
+
+const createConfluenceClientMock = vi.mocked(createConfluenceClient);
+
+const ENV_KEYS = [
+  "C2N_CONFIG_DIR",
+  "C2N_PROFILE",
+  "CONFLUENCE_BASE_URL",
+  "CONFLUENCE_EMAIL",
+  "CONFLUENCE_API_TOKEN",
+  "CONFLUENCE_TOKEN",
+] as const;
+
+interface StoredProfile {
+  confluence: { baseUrl: string; email: string; apiToken: string };
+  notion: { token: string; rootPageId: string };
+}
+
+let tmp: string;
+let cwdSaved: string;
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(async () => {
+  tmp = await mkdtemp(join(tmpdir(), "c2n-fetch-"));
+  await mkdir(join(tmp, "samples"), { recursive: true });
+  savedEnv = {};
+  for (const k of ENV_KEYS) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+  process.env.C2N_CONFIG_DIR = tmp;
+  cwdSaved = process.cwd();
+  process.chdir(tmp);
+  createConfluenceClientMock.mockReset();
+});
+
+afterEach(async () => {
+  process.chdir(cwdSaved);
+  for (const k of ENV_KEYS) {
+    const v = savedEnv[k];
+    if (v === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = v;
+    }
+  }
+  await rm(tmp, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+async function seedConfig(
+  profiles: Record<string, StoredProfile>,
+  currentProfile = "default",
+): Promise<void> {
+  const cfg = { currentProfile, profiles };
+  await writeFile(join(tmp, "config.json"), JSON.stringify(cfg), "utf8");
+}
+
+function fakeClient(): unknown {
+  return {
+    getPage: async (id: string) => ({
+      id,
+      title: "fake",
+      version: { number: 1, when: "2024-01-01T00:00:00.000Z", by: { displayName: "u" } },
+      space: { key: "TEST" },
+      body: { storage: { value: "<p>hi</p>", representation: "storage" } },
+    }),
+    listSpacePages: async () => ({ results: [], start: 0, limit: 25, size: 0 }),
+    getPageTree: async (rootId: string) => ({ id: rootId, title: "root", children: [] }),
+    getAttachment: async () => new Uint8Array(),
+  };
+}
+
+const DEFAULT_PROFILE: StoredProfile = {
+  confluence: {
+    baseUrl: "https://default.example/wiki",
+    email: "default@example.com",
+    apiToken: "tok-default",
+  },
+  notion: { token: "secret_default", rootPageId: "0".repeat(32) },
+};
+
+const FOO_PROFILE: StoredProfile = {
+  confluence: {
+    baseUrl: "https://foo.example/wiki",
+    email: "foo@example.com",
+    apiToken: "tok-foo",
+  },
+  notion: { token: "secret_foo", rootPageId: "1".repeat(32) },
+};
+
+describe("c2n fetch --profile", () => {
+  it("--profile foo causes credential reads to use the foo profile entry", async () => {
+    await seedConfig({ default: DEFAULT_PROFILE, foo: FOO_PROFILE });
+    createConfluenceClientMock.mockReturnValue(fakeClient() as never);
+
+    await createProgram().parseAsync([
+      "node",
+      "c2n",
+      "fetch",
+      "--profile",
+      "foo",
+      "--pages",
+      "p1",
+      "--out-dir",
+      "samples",
+    ]);
+
+    expect(createConfluenceClientMock).toHaveBeenCalledTimes(1);
+    expect(createConfluenceClientMock.mock.calls[0]?.[0]).toMatchObject({
+      baseUrl: "https://foo.example/wiki",
+      email: "foo@example.com",
+      token: "tok-foo",
+    });
+  });
+
+  it("without --profile resolves through C2N_PROFILE > currentProfile > default", async () => {
+    const bar: StoredProfile = {
+      confluence: {
+        baseUrl: "https://bar.example/wiki",
+        email: "bar@example.com",
+        apiToken: "tok-bar",
+      },
+      notion: { token: "secret_bar", rootPageId: "2".repeat(32) },
+    };
+    const baz: StoredProfile = {
+      confluence: {
+        baseUrl: "https://baz.example/wiki",
+        email: "baz@example.com",
+        apiToken: "tok-baz",
+      },
+      notion: { token: "secret_baz", rootPageId: "3".repeat(32) },
+    };
+    await seedConfig({ default: DEFAULT_PROFILE, bar, baz }, "bar");
+    process.env.C2N_PROFILE = "baz";
+    createConfluenceClientMock.mockReturnValue(fakeClient() as never);
+
+    await createProgram().parseAsync([
+      "node",
+      "c2n",
+      "fetch",
+      "--pages",
+      "p1",
+      "--out-dir",
+      "samples",
+    ]);
+
+    // C2N_PROFILE wins over currentProfile.
+    expect(createConfluenceClientMock.mock.calls[0]?.[0]).toMatchObject({
+      baseUrl: "https://baz.example/wiki",
+      email: "baz@example.com",
+      token: "tok-baz",
+    });
+    createConfluenceClientMock.mockReset();
+    createConfluenceClientMock.mockReturnValue(fakeClient() as never);
+
+    const profileKey = "C2N_PROFILE" as const;
+    delete process.env[profileKey];
+    await createProgram().parseAsync([
+      "node",
+      "c2n",
+      "fetch",
+      "--pages",
+      "p1",
+      "--out-dir",
+      "samples",
+    ]);
+
+    // With C2N_PROFILE unset, currentProfile (bar) is used.
+    expect(createConfluenceClientMock.mock.calls[0]?.[0]).toMatchObject({
+      baseUrl: "https://bar.example/wiki",
+      email: "bar@example.com",
+      token: "tok-bar",
+    });
+  });
+
+  it("env vars override stored profile values", async () => {
+    await seedConfig({ default: DEFAULT_PROFILE });
+    process.env.CONFLUENCE_BASE_URL = "https://env.example/wiki/";
+    process.env.CONFLUENCE_EMAIL = "env@example.com";
+    process.env.CONFLUENCE_API_TOKEN = "tok-env";
+    createConfluenceClientMock.mockReturnValue(fakeClient() as never);
+
+    await createProgram().parseAsync([
+      "node",
+      "c2n",
+      "fetch",
+      "--pages",
+      "p1",
+      "--out-dir",
+      "samples",
+    ]);
+
+    expect(createConfluenceClientMock.mock.calls[0]?.[0]).toMatchObject({
+      baseUrl: "https://env.example/wiki",
+      email: "env@example.com",
+      token: "tok-env",
+    });
+  });
+});
+
+describe("c2n fetch-tree --profile", () => {
+  it("--profile foo causes credential reads to use the foo profile entry", async () => {
+    await seedConfig({ default: DEFAULT_PROFILE, foo: FOO_PROFILE });
+    createConfluenceClientMock.mockReturnValue(fakeClient() as never);
+
+    await createProgram().parseAsync([
+      "node",
+      "c2n",
+      "fetch-tree",
+      "--root-id",
+      "root1",
+      "--profile",
+      "foo",
+      "--output",
+      "tree.json",
+    ]);
+
+    expect(createConfluenceClientMock.mock.calls[0]?.[0]).toMatchObject({
+      baseUrl: "https://foo.example/wiki",
+      email: "foo@example.com",
+      token: "tok-foo",
+    });
+  });
+
+  it("env vars override stored profile values", async () => {
+    await seedConfig({ default: DEFAULT_PROFILE });
+    process.env.CONFLUENCE_BASE_URL = "https://env.example/wiki";
+    process.env.CONFLUENCE_EMAIL = "env@example.com";
+    process.env.CONFLUENCE_API_TOKEN = "tok-env";
+    createConfluenceClientMock.mockReturnValue(fakeClient() as never);
+
+    await createProgram().parseAsync([
+      "node",
+      "c2n",
+      "fetch-tree",
+      "--root-id",
+      "root1",
+      "--output",
+      "tree.json",
+    ]);
+
+    expect(createConfluenceClientMock.mock.calls[0]?.[0]).toMatchObject({
+      baseUrl: "https://env.example/wiki",
+      email: "env@example.com",
+      token: "tok-env",
+    });
+  });
+});

--- a/tests/cli/notion.test.ts
+++ b/tests/cli/notion.test.ts
@@ -1,0 +1,137 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const usersMeMock = vi.fn();
+
+vi.mock("@notionhq/client", () => ({
+  Client: vi.fn(),
+}));
+
+import { Client } from "@notionhq/client";
+import { createProgram } from "../../src/cli/index.js";
+
+const ClientMock = vi.mocked(Client);
+
+const ENV_KEYS = [
+  "C2N_CONFIG_DIR",
+  "C2N_PROFILE",
+  "NOTION_TOKEN",
+  "NOTION_API_TOKEN",
+  "NOTION_ROOT_PAGE_ID",
+] as const;
+
+interface StoredProfile {
+  confluence: { baseUrl: string; email: string; apiToken: string };
+  notion: { token: string; rootPageId: string };
+}
+
+let tmp: string;
+let cwdSaved: string;
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(async () => {
+  tmp = await mkdtemp(join(tmpdir(), "c2n-notion-"));
+  await mkdir(tmp, { recursive: true });
+  savedEnv = {};
+  for (const k of ENV_KEYS) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+  process.env.C2N_CONFIG_DIR = tmp;
+  cwdSaved = process.cwd();
+  process.chdir(tmp);
+  ClientMock.mockReset();
+  ClientMock.mockImplementation(() => ({ users: { me: usersMeMock } }) as unknown as Client);
+  usersMeMock.mockReset();
+  usersMeMock.mockResolvedValue({ id: "bot" } as never);
+});
+
+afterEach(async () => {
+  process.chdir(cwdSaved);
+  for (const k of ENV_KEYS) {
+    const v = savedEnv[k];
+    if (v === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = v;
+    }
+  }
+  await rm(tmp, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+async function seedConfig(
+  profiles: Record<string, StoredProfile>,
+  currentProfile = "default",
+): Promise<void> {
+  const cfg = { currentProfile, profiles };
+  await writeFile(join(tmp, "config.json"), JSON.stringify(cfg), "utf8");
+}
+
+const DEFAULT_PROFILE: StoredProfile = {
+  confluence: {
+    baseUrl: "https://default.example/wiki",
+    email: "default@example.com",
+    apiToken: "tok-default",
+  },
+  notion: { token: "secret_default", rootPageId: "0".repeat(32) },
+};
+
+const FOO_PROFILE: StoredProfile = {
+  confluence: {
+    baseUrl: "https://foo.example/wiki",
+    email: "foo@example.com",
+    apiToken: "tok-foo",
+  },
+  notion: { token: "secret_foo", rootPageId: "1".repeat(32) },
+};
+
+describe("c2n notion-ping --profile", () => {
+  it("--profile foo reads creds from the foo profile entry", async () => {
+    await seedConfig({ default: DEFAULT_PROFILE, foo: FOO_PROFILE });
+
+    await createProgram().parseAsync(["node", "c2n", "notion-ping", "--profile", "foo"]);
+
+    expect(ClientMock).toHaveBeenCalledTimes(1);
+    expect(ClientMock.mock.calls[0]?.[0]).toMatchObject({ auth: "secret_foo" });
+    expect(usersMeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("env vars override stored profile values", async () => {
+    await seedConfig({ default: DEFAULT_PROFILE });
+    process.env.NOTION_TOKEN = "secret_env";
+    process.env.NOTION_ROOT_PAGE_ID = "9".repeat(32);
+
+    await createProgram().parseAsync(["node", "c2n", "notion-ping"]);
+
+    expect(ClientMock.mock.calls[0]?.[0]).toMatchObject({ auth: "secret_env" });
+  });
+
+  it("legacy NOTION_API_TOKEN is also accepted", async () => {
+    await seedConfig({ default: DEFAULT_PROFILE });
+    process.env.NOTION_API_TOKEN = "secret_legacy";
+
+    await createProgram().parseAsync(["node", "c2n", "notion-ping"]);
+
+    expect(ClientMock.mock.calls[0]?.[0]).toMatchObject({ auth: "secret_legacy" });
+  });
+
+  it("missing creds exits non-zero with a stderr message", async () => {
+    // No config seeded, no env vars set.
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const exit = vi.spyOn(process, "exit").mockImplementation(((_code?: number) => {
+      throw new Error("__exit__");
+    }) as never);
+
+    await expect(createProgram().parseAsync(["node", "c2n", "notion-ping"])).rejects.toThrow(
+      "__exit__",
+    );
+
+    expect(exit).toHaveBeenCalledWith(1);
+    const errMsg = stderr.mock.calls.map((c) => String(c[0])).join("");
+    expect(errMsg).toMatch(/NOTION_TOKEN/);
+    expect(errMsg).toMatch(/NOTION_ROOT_PAGE_ID/);
+  });
+});


### PR DESCRIPTION
## Summary

Slice 4 of the credential-store rollout (#190 → #195 → #203). Wires the `--profile <name>` flag into the existing data-flow subcommands so they can pick up Confluence/Notion credentials from `~/.config/c2n/config.json` instead of (or as a fallback after) env vars.

Closes #203

## Scope (this PR)

- `c2n fetch` and `c2n fetch-tree`: read `--profile` and route Confluence creds via the store; env vars remain a valid fallback.
- `c2n notion-ping`: same routing for the Notion token.
- `c2n convert`: profile flag accepted (no creds needed at convert time, but the flag is now registered for surface-conformance).
- `c2n migrate` family: profile flag accepted; full credential plumbing through migrate is deferred to the MCP-routing slice (#206) where the same store is shared with `c2n-mcp`.
- `ADR-00M` updated: the per-command tables now document `--profile` for each affected subcommand.

## Deferred to #206

- `src/mcp/server.ts` / `c2n-mcp` stdio entry: route credential reads through the same store so the `env:` block in `claude_desktop_config.json` becomes optional.
- README Configuration section: rewrite with `c2n init` / `c2n auth` / `c2n use` as the happy path, demote env vars to a CI / advanced subsection.
- 0.2.0 CHANGELOG entry via changesets.

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (490 passed, 1 skipped)
- [x] Reviewer agent approved (no error- or warning-severity issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)