### PR TITLE
chore(ci): bump lint/typecheck jobs to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
@@ -30,7 +30,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm typecheck


### PR DESCRIPTION
## Summary

Aligns the two single-Node CI jobs (`lint`, `typecheck`) with the release workflow's Node 24 (#186). Test + build matrix stays at `[20, 22]` so consumer-facing runtime coverage is unchanged.

## Why

- Quiets the `actions/setup-node@v4` Node 20 deprecation warning that started showing up in CI logs.
- These jobs just run biome + tsc on the source — there's no value in pinning them to the oldest supported runtime.
- Test/build matrix is the right place for cross-version coverage; that decision stays separate.

## Test plan

- [x] Lint/typecheck both work locally on Node 24.
- [ ] CI green after push (lint/typecheck jobs run on the new image).